### PR TITLE
Setup basic unit test workflow

### DIFF
--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -15,7 +15,11 @@ jobs:
 
       - name: Install packages with homebrew
         run: |
-          brew install gcc
+          #brew install gcc     # Not needed on GitHub server, already installed
+          brew install open-mpi
+          brew install petsc
+          brew install netcdf
+          brew install netcdf-fortran
 
     #  - name: Install nix
     #    uses: cachix/install-nix-action@v22

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -16,9 +16,9 @@ jobs:
     #    run: |
     #      nix --version
 
-      - name: Build UFEMISM with nix
-        run: |
-          nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
+    #  - name: Build UFEMISM with nix
+    #    run: |
+    #      nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
 
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -35,9 +35,9 @@ jobs:
           key: UFEMISM_nix_packages
 
       - name: Build UFEMISM with nix
+        if: steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true'
         run: |
           nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
-        if: steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true'
 
   compile_UFEMISM:
     needs: setup_packages

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -5,14 +5,9 @@ run-name: ${{ github.actor }} - UFEMISM Test Suite (full)
 on: workflow_dispatch
 
 jobs:
-  setup_packages:
+  compile_UFEMISM:
     runs-on: macos-latest
     steps:
-
-      - name: Check the Cellar before installing everything
-        run: |
-          echo ls -a /opt/homebrew/Cellar
-          ls -a /opt/homebrew/Cellar
           
       - name: Install packages with Homebrew   # Packages end up in /opt/homebrew/Cellar
         run: |
@@ -23,31 +18,31 @@ jobs:
           brew install netcdf
           brew install netcdf-fortran
 
-      - name: Check the Cellar after installing everything
-        run: |
-          echo ls -a /opt/homebrew/Cellar
-          ls -a /opt/homebrew/Cellar
-            
-   #   - name: Cache packages
-   #     uses: actions/cache/save@v3
-   #     id: UFEMISM_brew_packages
-   #     with:
-   #       path: /opt/homebrew/Cellar
-   #       key: UFEMISM_brew_packages
-          
-    #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
-    #    name: Cache miss! Download and build UFEMISM nix packages
-    #    run: |
-    #      nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
-          
-    #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit == 'true' }}
-    #    name: Cache hit! Load UFEMISM nix packages from cache.
-    #    run: |
-    #      echo ls -a /nix/store
-    #      ls -a /nix/store
+      - name: Set up Fortran compiler          # See: https://github.com/marketplace/actions/setup-fortran
+        uses: fortran-lang/setup-fortran@v1
+        id: setup-fortran
+        with:
+          compiler: gcc
+          version: 13
 
-  compile_UFEMISM:
-    needs: setup_packages
+      - name: Verify compiler setup
+        run: gfortran --version
+
+      - name: Checkout UFEMISM repository
+        uses: actions/checkout@v4
+
+      - name: Compile UFEMISM
+        run: ./compile_all_mac.csh
+            
+      - name: Cache UFEMISM program
+        uses: actions/cache/save@v3
+        id: UFEMISM_program_cache_save
+        with:
+          path: UFEMISM_program
+          key: UFEMISM_program
+
+  run_unit_tests:
+    needs: compile_UFEMISM
     runs-on: macos-latest
     steps:
 
@@ -55,39 +50,12 @@ jobs:
         run: |
           echo Hello world!
 
-      - name: Check the Cellar
-        run: |
-          echo ls -a /opt/homebrew/Cellar
-          ls -a /opt/homebrew/Cellar
-
-    #  - name: Set up Fortran compiler          # See: https://github.com/marketplace/actions/setup-fortran
-    #    uses: fortran-lang/setup-fortran@v1
-    #    id: setup-fortran
-    #    with:
-    #      compiler: gcc
-    #      version: 13
-
-    #  - name: Verify compiler setup
-    #    run: gfortran --version
-
-    #  - name: Checkout UFEMISM repository
-    #    uses: actions/checkout@v4
-
-    #  - name: Compile UFEMISM
-    #    run: ./compile_all_mac.csh
-
-  #    - uses: actions/cache/restore@v3
-  #      id: restore_cache
-  #      with:
-  #        path: /nix/store
-  #        key: UFEMISM_nix_packages
-
-  #    - uses: actions/cache@v2
-  #      id: cache_UFEMISM_nix_packages
-  #      with:
-  #        path: /nix/store
-  #        key: UFEMISM_nix_packages
-  #      #  continue-on-error: true
+      - name: Restore UFEMISM program from cache
+        uses: actions/cache/restore@v3
+        id: UFEMISM_program_cache_restore
+        with:
+          path: UFEMISM_program
+          key: UFEMISM_program
 
     #  - name: Install MATLAB
     #    uses: matlab-actions/setup-matlab@v2.2.0

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -35,21 +35,33 @@ jobs:
           ls -a ${{github.workspace}}
           ls -a ~
 
-      - uses: actions/cache/save@v3
-        id: cache
+    #  - uses: actions/cache/save@v3
+    #    id: cache
+    #    with:
+    #      path: ${{github.workspace}}/src
+    #      key: UFEMISM_build
+
+      - uses: actions/cache@v2
+        id: cache-tijn  # give it a name for checking the cache hit-or-not
         with:
-          path: ${{github.workspace}}/src
-          key: UFEMISM_build
+          path: ${{github.workspace}}/src  # what we cache: the folder
+          key: Tijns_cache_test
 
   run-unit-tests:
     needs: setup
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/cache/restore@v3
-        id: restore-cache
+   #   - uses: actions/cache/restore@v3
+   #     id: restore-cache
+   #     with:
+   #       key: UFEMISM_build
+
+      - uses: actions/cache@v2
+        id: cache-tijn  # give it a name for checking the cache hit-or-not
         with:
-          key: UFEMISM_build
+          path: ${{github.workspace}}/src  # what we cache: the folder
+          key: Tijns_cache_test
 
       - name: Check if we have it
         run: |

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -11,14 +11,17 @@ jobs:
 
       - name: Install nix
         uses: cachix/install-nix-action@v22
+
+      - uses: actions/cache@v2
+        id: cache_UFEMISM_program
+        with:
+          path: result
+          key: UFEMISM_program
           
-      - name: Build UFEMISM with nix
+      - if: ${{ steps.cache_UFEMISM_program.outputs.cache-hit != 'true' }}
+        name: Build UFEMISM with nix
         run: |
           nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
-
-    #  - name: Get nix version
-    #    run: |
-    #      nix --version
 
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4
@@ -31,12 +34,6 @@ jobs:
           ls -a result
           echo ls -a result/bin
           ls -a result/bin
-
-    #  - uses: actions/cache@v2
-    #    id: cache_UFEMISM_nix_packages
-    #    with:
-    #      path: /nix/store
-    #      key: UFEMISM_nix_packages
           
     #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
     #    name: Cache miss! Download and build UFEMISM nix packages

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Add gfortran to PATH
         run: |
-          echo -e "\nexport PATH="/opt/homebrew/Cellar/gcc/14.1.0_2:$PATH"" >> ~/.bash_profile
+          echo -e '\nexport PATH="/opt/homebrew/Cellar/gcc/14.1.0_2:$PATH"' >> ~/.bash_profile
 
       - name: Testerdetest2
         run: |

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -40,7 +40,7 @@ jobs:
           echo cat ~/.bash_profile
           cat ~/.bash_profile
 
-      - name: Add gfortran to PATH
+      - name: Add gfortran to path
         run: |
           echo -e '\nexport PATH="/opt/homebrew/Cellar/gcc/14.1.0_2:$PATH"' >> ~/.bash_profile
 
@@ -48,6 +48,9 @@ jobs:
         run: |
           echo cat ~/.bash_profile
           cat ~/.bash_profile
+
+      - name: Reload bash profile to apply path changes
+        run: source ~/.bash_profile
 
    #   - name: Compile UFEMISM
    #     run: |

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -32,6 +32,8 @@ jobs:
           ls -a /opt/homebrew/Cellar/gcc
           echo ls -a /opt/homebrew/Cellar/gcc/14.1.0_2
           ls -a /opt/homebrew/Cellar/gcc/14.1.0_2
+          echo ls -a ~
+          ls -a ~
 
       - name: Testerdetest2
         run: |

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -18,9 +18,9 @@ jobs:
     #      path: ${{ github.workspace }}/result
     #      key: UFEMISM_program
           
-      - name: Build UFEMISM with nix
-        run: |
-          nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
+    #  - name: Build UFEMISM with nix
+    #    run: |
+    #      nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
 
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4
@@ -62,6 +62,7 @@ jobs:
       - uses: actions/cache/restore@v3
         id: restore_cache
         with:
+          path: /nix/store
           key: UFEMISM_nix_packages
 
   #    - uses: actions/cache@v2

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -22,6 +22,13 @@ jobs:
           brew install netcdf
           brew install netcdf-fortran
 
+      - name: testerdetest
+        run: |
+          echo ls -a
+          ls -a
+          echo ls -a ~
+          ls -a ~
+
     #  - name: Install nix
     #    uses: cachix/install-nix-action@v22
 

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -25,10 +25,18 @@ jobs:
         run: |
           echo ls -a /opt/homebrew/Cellar
           ls -a /opt/homebrew/Cellar
+          echo ls -a /opt/homebrew/Cellar/gcc
+          ls -a /opt/homebrew/Cellar/gcc
+          echo cat ~/.bash_profile
+          cat ~/.bash_profile
 
-      - name: Compile UFEMISM
-        run: |
-          ls -a ~
+   #   - name: Add gfortran to PATH
+   #     run: |
+   #       echo "export PATH="your-dir:$PATH"" >> ~/.inputrc
+
+   #   - name: Compile UFEMISM
+   #     run: |
+   #       ls -a ~
     #      gfortran --version
     #      ./compile_all_mac.csh
             

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -74,6 +74,22 @@ jobs:
           name: results_unit_tests
           path: results_unit_tests
 
+  analyse_unit_test_results:
+    needs: run_unit_tests
+    runs-on: macos-latest
+    steps:
+
+      - name: Checkout UFEMISM repository
+        uses: actions/checkout@v4
+
+      - name: Download unit test results as artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: results_unit_tests
+
+      - name: Test
+        run: ls -a
+
     #  - name: Install MATLAB
     #    uses: matlab-actions/setup-matlab@v2.2.0
 

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -89,7 +89,11 @@ jobs:
           path: results_unit_tests
 
       - name: Test
-        run: ls -a
+        run: |
+          echo ls -a
+          ls -a
+          echo ls -a results_unit_tests
+          ls -a results_unit_tests
 
     #  - name: Install MATLAB
     #    uses: matlab-actions/setup-matlab@v2.2.0

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -32,6 +32,8 @@ jobs:
           ls -a
           echo ls -a result
           ls -a result
+          echo ls -a result/result
+          ls -a result/result
           echo ls -a result/bin
           ls -a result/bin
           echo ls -a result/bin

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -5,44 +5,44 @@ run-name: ${{ github.actor }} - UFEMISM Test Suite (full)
 on: workflow_dispatch
 
 jobs:
-#  compile_UFEMISM:
-#    runs-on: macos-latest
-#    steps:
+  compile_UFEMISM:
+    runs-on: macos-latest
+    steps:
           
-#      - name: Install packages with Homebrew   # Packages end up in /opt/homebrew/Cellar
-#        run: |
-#          #brew install gcc                    # Not needed on GitHub server, already installed
-#          brew install open-mpi
-#          brew install petsc
-#          brew unlink hdf5-mpi                 # To fix the following conflict: "hdf5-mpi: because hdf5-mpi is a variant of hdf5, one can only use one or the other"
-#          brew install netcdf
-#          brew install netcdf-fortran
+      - name: Install packages with Homebrew   # Packages end up in /opt/homebrew/Cellar
+        run: |
+          #brew install gcc                    # Not needed on GitHub server, already installed
+          brew install open-mpi
+          brew install petsc
+          brew unlink hdf5-mpi                 # To fix the following conflict: "hdf5-mpi: because hdf5-mpi is a variant of hdf5, one can only use one or the other"
+          brew install netcdf
+          brew install netcdf-fortran
 
-#      - name: Set up Fortran compiler          # See: https://github.com/marketplace/actions/setup-fortran
-#        uses: fortran-lang/setup-fortran@v1
-#        id: setup-fortran
-#        with:
-#          compiler: gcc
-#          version: 13
+      - name: Set up Fortran compiler          # See: https://github.com/marketplace/actions/setup-fortran
+        uses: fortran-lang/setup-fortran@v1
+        id: setup-fortran
+        with:
+          compiler: gcc
+          version: 13
 
-#      - name: Verify compiler setup
-#        run: gfortran --version
+      - name: Verify compiler setup
+        run: gfortran --version
 
-#      - name: Checkout UFEMISM repository
-#        uses: actions/checkout@v4
+      - name: Checkout UFEMISM repository
+        uses: actions/checkout@v4
 
-#      - name: Compile UFEMISM
-#        run: ./compile_all_mac.csh
+      - name: Compile UFEMISM
+        run: ./compile_all_mac.csh
             
-#      - name: Cache UFEMISM program
-#        uses: actions/cache/save@v3
-#        id: UFEMISM_program_cache_save
-#        with:
-#          path: UFEMISM_program
-#          key: UFEMISM_program
+      - name: Cache UFEMISM program
+        uses: actions/cache/save@v3
+        id: UFEMISM_program_cache_save
+        with:
+          path: UFEMISM_program
+          key: UFEMISM_program
 
   run_unit_tests:
-#    needs: compile_UFEMISM
+    needs: compile_UFEMISM
     runs-on: macos-latest
     steps:
           
@@ -88,17 +88,10 @@ jobs:
           name: results_unit_tests
           path: results_unit_tests
 
-      - name: Test
-        run: |
-          echo ls -a
-          ls -a
-          echo ls -a results_unit_tests
-          ls -a results_unit_tests
+      - name: Install MATLAB
+        uses: matlab-actions/setup-matlab@v2.2.0
 
-    #  - name: Install MATLAB
-    #    uses: matlab-actions/setup-matlab@v2.2.0
-
-    #  - name: Another MATLAB test
-    #    uses: matlab-actions/run-command@v2
-    #    with:
-    #      command: disp('Hello world!')
+      - name: Short MATLAB test
+        uses: matlab-actions/run-command@v2
+        with:
+          command: disp('Hello world!')

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -11,6 +11,10 @@ jobs:
 
       - name: Install nix
         uses: cachix/install-nix-action@v22
+          
+      - name: Build UFEMISM with nix
+        run: |
+          nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
 
     #  - name: Get nix version
     #    run: |
@@ -19,31 +23,31 @@ jobs:
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4
 
-    #  - name: testerdetest
+      - name: testerdetest
+        run: |
+          echo ls -a
+          ls -a
+          echo ls -a result
+          ls -a result
+          echo ls -a result/bin
+          ls -a result/bin
+
+    #  - uses: actions/cache@v2
+    #    id: cache_UFEMISM_nix_packages
+    #    with:
+    #      path: /nix/store
+    #      key: UFEMISM_nix_packages
+          
+    #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
+    #    name: Cache miss! Download and build UFEMISM nix packages
     #    run: |
-    #      echo ls -a ~
-    #      ls -a ~
-    #      echo ls -a /nix
-    #      ls -a /nix
+    #      nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
+          
+    #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit == 'true' }}
+    #    name: Cache hit! Load UFEMISM nix packages from cache.
+    #    run: |
     #      echo ls -a /nix/store
     #      ls -a /nix/store
-
-      - uses: actions/cache@v2
-        id: cache_UFEMISM_nix_packages
-        with:
-          path: /nix/store
-          key: UFEMISM_nix_packages
-          
-      - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
-        name: Cache miss! Download and build UFEMISM nix packages
-        run: |
-          nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
-          
-      - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit == 'true' }}
-        name: Cache hit! Load UFEMISM nix packages from cache.
-        run: |
-          echo ls -a /nix/store
-          ls -a /nix/store
 
 #  compile_UFEMISM:
 #    needs: setup_packages

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -28,11 +28,9 @@ jobs:
 
       - name: Compile UFEMISM
         run: |
-          echo apropos fort
-          apropos fort
-          echo beep
-          gfortran --version
-          ./compile_all_mac.csh
+          ls -a ~
+    #      gfortran --version
+    #      ./compile_all_mac.csh
             
     #  - uses: actions/cache/save@v3
     #    id: cache

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -21,8 +21,15 @@ jobs:
       - name: Checkout UFEMISM repository
         uses: actions/checkout@v4
 
+      - name: Check the Cellar
+        run: |
+          echo ls -a /opt/homebrew/Cellar
+          ls -a /opt/homebrew/Cellar
+
       - name: Compile UFEMISM
         run: |
+          echo apropos fort
+          apropos fort
           gfortran --version
           ./compile_all_mac.csh
             

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -25,8 +25,9 @@ jobs:
 
       - name: testerdetest
         run: |
-          echo ~/src
+          echo ~
           ls -a ~
+          ls -a /nix
 
 #      - uses: actions/cache@v2
 #        id: cache-tijn  # give it a name for checking the cache hit-or-not

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -25,6 +25,9 @@ jobs:
           compiler: gcc
           version: 13
 
+      - name: Verify compiler setup
+        run: gfortran --version
+
       - name: Checkout UFEMISM repository
         uses: actions/checkout@v4
 
@@ -60,9 +63,7 @@ jobs:
 #        run: source ~/.bash_profile
 
       - name: Compile UFEMISM
-        run: |
-          gfortran --version
-    #      ./compile_all_mac.csh
+        run: ./compile_all_mac.csh
             
     #  - uses: actions/cache/save@v3
     #    id: cache

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -25,8 +25,16 @@ jobs:
         run: |
           echo ls -a /opt/homebrew/Cellar
           ls -a /opt/homebrew/Cellar
+
+      - name: Testerdetest
+        run: |
           echo ls -a /opt/homebrew/Cellar/gcc
           ls -a /opt/homebrew/Cellar/gcc
+          echo ls -a /opt/homebrew/Cellar/gcc/14.1.0_2
+          ls -a /opt/homebrew/Cellar/gcc/14.1.0_2
+
+      - name: Testerdetest2
+        run: |
           echo cat ~/.bash_profile
           cat ~/.bash_profile
 

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           echo ${{github.workspace}}/src
           echo ~/src
-          ls -a ${{github.workspace}}/src
-          ls -a ~/src
+          ls -a ${{github.workspace}}
+          ls -a ~
 
       - uses: actions/cache/save@v3
         id: cache

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -19,32 +19,32 @@ jobs:
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4
 
-    #  - name: testerdetest
+      - name: testerdetest
+        run: |
+          echo ls -a ~
+          ls -a ~
+          echo ls -a /nix
+          ls -a /nix
+          echo ls -a /nix/store
+          ls -a /nix/store
+
+    #  - uses: actions/cache@v2
+    #    id: cache_UFEMISM_nix_packages
+    #    with:
+    #      path: /nix/store
+    #      key: UFEMISM_nix_packages
+          
+    #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit == 'true' }}
+    #    name: Cache hit!
     #    run: |
-    #      echo ls -a ~
-    #      ls -a ~
-    #      echo ls -a /nix
-    #      ls -a /nix
     #      echo ls -a /nix/store
     #      ls -a /nix/store
-
-      - uses: actions/cache@v2
-        id: cache_UFEMISM_nix_packages
-        with:
-          path: /nix/store
-          key: UFEMISM_nix_packages
           
-      - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit == 'true' }}
-        name: Cache hit!
-        run: |
-          echo ls -a /nix/store
-          ls -a /nix/store
-          
-      - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
-        name: Cache miss!
-        run: |
-          echo ls -a /nix/store
-          ls -a /nix/store
+    #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
+    #    name: Cache miss!
+    #    run: |
+    #      echo ls -a /nix/store
+    #      ls -a /nix/store
 
    #   - name: Build UFEMISM with nix
    #     if: steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true'

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -8,6 +8,11 @@ jobs:
   setup_packages:
     runs-on: macos-latest
     steps:
+
+      - name: Check the Cellar before installing everything
+        run: |
+          echo ls -a /opt/homebrew/Cellar
+          ls -a /opt/homebrew/Cellar
           
       - name: Install packages with Homebrew   # Packages end up in /opt/homebrew/Cellar
         run: |
@@ -17,13 +22,18 @@ jobs:
           brew unlink hdf5-mpi                 # To fix the following conflict: "hdf5-mpi: because hdf5-mpi is a variant of hdf5, one can only use one or the other"
           brew install netcdf
           brew install netcdf-fortran
+
+      - name: Check the Cellar after installing everything
+        run: |
+          echo ls -a /opt/homebrew/Cellar
+          ls -a /opt/homebrew/Cellar
             
-      - name: Cache packages
-        uses: actions/cache/save@v3
-        id: UFEMISM_brew_packages
-        with:
-          path: /opt/homebrew/Cellar
-          key: UFEMISM_brew_packages
+   #   - name: Cache packages
+   #     uses: actions/cache/save@v3
+   #     id: UFEMISM_brew_packages
+   #     with:
+   #       path: /opt/homebrew/Cellar
+   #       key: UFEMISM_brew_packages
           
     #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
     #    name: Cache miss! Download and build UFEMISM nix packages

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -59,12 +59,17 @@ jobs:
  #     - name: Install nix
  #       uses: cachix/install-nix-action@v22
 
-      - uses: actions/cache@v2
-        id: cache_UFEMISM_nix_packages
+      - uses: actions/cache/restore@v3
+        id: restore_cache
         with:
-          path: /nix/store
           key: UFEMISM_nix_packages
-        #  continue-on-error: true
+
+  #    - uses: actions/cache@v2
+  #      id: cache_UFEMISM_nix_packages
+  #      with:
+  #        path: /nix/store
+  #        key: UFEMISM_nix_packages
+  #      #  continue-on-error: true
 
       - name: check if cache loaded succesfully
         run: |

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -29,7 +29,7 @@ jobs:
           ls -a
 
       - name: testerdetest
-        run: ${{github.workspace}}/src
+        run: echo ${{github.workspace}}/src
 
       - uses: actions/cache/save@v3
         id: cache

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -6,7 +6,7 @@ on: workflow_dispatch
 
 jobs:
   setup_packages:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
 
       - name: Step 0
@@ -61,7 +61,7 @@ jobs:
 
   compile_UFEMISM:
     needs: setup_packages
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
 
       - name: Step 0

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -9,67 +9,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    #  - name: Install nix
-    #    uses: cachix/install-nix-action@v22
+      - name: Install nix
+        uses: cachix/install-nix-action@v22
 
     #  - name: Get nix version
     #    run: |
     #      nix --version
 
-    #  - name: Build UFEMISM with nix
-    #    run: |
-    #      nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
-
-      - name: Checkout UFEMISM repository
-        uses: actions/checkout@v4
-
-      - name: Check what we checked out
+      - name: Build UFEMISM with nix
         run: |
-          pwd
-          ls -a
-
-      - name: testerdetest
-        run: |
-          echo ${{github.workspace}}/src
-          echo ~/src
-          ls -a ${{github.workspace}}
-          ls -a ~
-
-    #  - uses: actions/cache/save@v3
-    #    id: cache
-    #    with:
-    #      path: ${{github.workspace}}/src
-    #      key: UFEMISM_build
-
-      - uses: actions/cache@v2
-        id: cache-tijn  # give it a name for checking the cache hit-or-not
-        with:
-          path: ${{github.workspace}}/src  # what we cache: the folder
-          key: Tijns_cache_test
-
-  run-unit-tests:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-
-   #   - uses: actions/cache/restore@v3
-   #     id: restore-cache
-   #     with:
-   #       key: UFEMISM_build
-
-      - uses: actions/cache@v2
-        id: cache-tijn  # give it a name for checking the cache hit-or-not
-        with:
-          path: ${{github.workspace}}/src  # what we cache: the folder
-          key: Tijns_cache_test
-
-      - name: Check if we have it
-        run: |
-          ls -a
-          ls src
+          nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
 
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4
+
+      - name: testerdetest
+        run: |
+          echo ~/src
+          ls -a ~
+
+#      - uses: actions/cache@v2
+#        id: cache-tijn  # give it a name for checking the cache hit-or-not
+#        with:
+#          path: ${{github.workspace}}/src  # what we cache: the folder
+#          key: Tijns_cache_test
+
+#  run-unit-tests:
+#    needs: setup
+#    runs-on: ubuntu-latest
+#    steps:
+#
+#      - uses: actions/cache@v2
+#        id: cache-tijn  # give it a name for checking the cache hit-or-not
+#        with:
+#          path: ${{github.workspace}}/src  # what we cache: the folder
+#          key: Tijns_cache_test
+#
+#      - name: Check if we have it
+#        run: |
+#          ls -a
 
     #  - name: Install MATLAB
     #    uses: matlab-actions/setup-matlab@v2.2.0

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -9,67 +9,21 @@ jobs:
     runs-on: macos-latest
     steps:
           
-      - name: Install packages with Homebrew
+      - name: Install packages with Homebrew   # Packages end up in /opt/homebrew/Cellar
         run: |
-          #brew install gcc        # Not needed on GitHub server, already installed
+          #brew install gcc                    # Not needed on GitHub server, already installed
           brew install open-mpi
           brew install petsc
-          brew unlink hdf5-mpi     # To fix the following conflict: "hdf5-mpi: because hdf5-mpi is a variant of hdf5, one can only use one or the other"
+          brew unlink hdf5-mpi                 # To fix the following conflict: "hdf5-mpi: because hdf5-mpi is a variant of hdf5, one can only use one or the other"
           brew install netcdf
           brew install netcdf-fortran
-
-      - name: Set up Fortran compiler          # See: https://github.com/marketplace/actions/setup-fortran
-        uses: fortran-lang/setup-fortran@v1
-        id: setup-fortran
-        with:
-          compiler: gcc
-          version: 13
-
-      - name: Verify compiler setup
-        run: gfortran --version
-
-      - name: Checkout UFEMISM repository
-        uses: actions/checkout@v4
-
-#      - name: Check the Cellar
-#        run: |
-#          echo ls -a /opt/homebrew/Cellar
-#          ls -a /opt/homebrew/Cellar
-
-#      - name: Testerdetest
-#        run: |
-#          echo ls -a /opt/homebrew/Cellar/gcc
-#          ls -a /opt/homebrew/Cellar/gcc
-#          echo ls -a /opt/homebrew/Cellar/gcc/14.1.0_2
-#          ls -a /opt/homebrew/Cellar/gcc/14.1.0_2
-#          echo ls -a ~
-#          ls -a ~
-
-#      - name: Testerdetest2
-#        run: |
-#          echo cat ~/.bash_profile
-#          cat ~/.bash_profile
-#
-#      - name: Add gfortran to path
-#        run: |
-#          echo -e '\nexport PATH="/opt/homebrew/Cellar/gcc/14.1.0_2:$PATH"' >> ~/.bash_profile
-#
-#      - name: Testerdetest2
-#        run: |
-#          echo cat ~/.bash_profile
-#          cat ~/.bash_profile
-#
-#      - name: Reload bash profile to apply path changes
-#        run: source ~/.bash_profile
-
-      - name: Compile UFEMISM
-        run: ./compile_all_mac.csh
             
-    #  - uses: actions/cache/save@v3
-    #    id: cache
-    #    with:
-    #      path: /nix/store
-    #      key: UFEMISM_nix_packages
+      - name: Cache packages
+        uses: actions/cache/save@v3
+        id: UFEMISM_brew_packages
+        with:
+          path: /opt/homebrew/Cellar
+          key: UFEMISM_brew_packages
           
     #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
     #    name: Cache miss! Download and build UFEMISM nix packages
@@ -96,8 +50,21 @@ jobs:
           echo ls -a /opt/homebrew/Cellar
           ls -a /opt/homebrew/Cellar
 
- #     - name: Install nix
- #       uses: cachix/install-nix-action@v22
+    #  - name: Set up Fortran compiler          # See: https://github.com/marketplace/actions/setup-fortran
+    #    uses: fortran-lang/setup-fortran@v1
+    #    id: setup-fortran
+    #    with:
+    #      compiler: gcc
+    #      version: 13
+
+    #  - name: Verify compiler setup
+    #    run: gfortran --version
+
+    #  - name: Checkout UFEMISM repository
+    #    uses: actions/checkout@v4
+
+    #  - name: Compile UFEMISM
+    #    run: ./compile_all_mac.csh
 
   #    - uses: actions/cache/restore@v3
   #      id: restore_cache
@@ -111,11 +78,6 @@ jobs:
   #        path: /nix/store
   #        key: UFEMISM_nix_packages
   #      #  continue-on-error: true
-
-   #   - name: check if cache loaded succesfully
-   #     run: |
-   #       echo ls -a /nix/store
-   #       ls -a /nix/store
 
     #  - name: Install MATLAB
     #    uses: matlab-actions/setup-matlab@v2.2.0

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -18,6 +18,7 @@ jobs:
           #brew install gcc     # Not needed on GitHub server, already installed
           brew install open-mpi
           brew install petsc
+          brew unlink hdf5-mpi     # To fix the following conflict: "hdf5-mpi: because hdf5-mpi is a variant of hdf5, one can only use one or the other"
           brew install netcdf
           brew install netcdf-fortran
 

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -18,17 +18,12 @@ jobs:
           brew install netcdf
           brew install netcdf-fortran
 
-      - name: Set up Fortran compiler
+      - name: Set up Fortran compiler          # See: https://github.com/marketplace/actions/setup-fortran
         uses: fortran-lang/setup-fortran@v1
         id: setup-fortran
         with:
           compiler: gcc
           version: 13
-
-      - name: Set Fortran compiler environment variables
-        run: |
-          ${{ env.FC }} ... # environment vars FC, CC, and CXX are set
-          ${{ steps.setup-fortran.outputs.fc }} ... # outputs work too
 
       - name: Checkout UFEMISM repository
         uses: actions/checkout@v4

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -45,6 +45,15 @@ jobs:
 #    needs: compile_UFEMISM
     runs-on: macos-latest
     steps:
+          
+      - name: Install packages with Homebrew   # Packages end up in /opt/homebrew/Cellar
+        run: |
+          #brew install gcc                    # Not needed on GitHub server, already installed
+          brew install open-mpi
+          brew install petsc
+          brew unlink hdf5-mpi                 # To fix the following conflict: "hdf5-mpi: because hdf5-mpi is a variant of hdf5, one can only use one or the other"
+          brew install netcdf
+          brew install netcdf-fortran
 
       - name: Checkout UFEMISM repository
         uses: actions/checkout@v4

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -11,7 +11,7 @@ jobs:
           
       - name: Install packages with Homebrew
         run: |
-          brew reinstall gcc        # Not needed on GitHub server, already installed
+          #brew install gcc        # Not needed on GitHub server, already installed
           brew install open-mpi
           brew install petsc
           brew unlink hdf5-mpi     # To fix the following conflict: "hdf5-mpi: because hdf5-mpi is a variant of hdf5, one can only use one or the other"
@@ -21,28 +21,33 @@ jobs:
       - name: Checkout UFEMISM repository
         uses: actions/checkout@v4
 
-      - name: Check the Cellar
-        run: |
-          echo ls -a /opt/homebrew/Cellar
-          ls -a /opt/homebrew/Cellar
+#      - name: Check the Cellar
+#        run: |
+#          echo ls -a /opt/homebrew/Cellar
+#          ls -a /opt/homebrew/Cellar
 
-      - name: Testerdetest
-        run: |
-          echo ls -a /opt/homebrew/Cellar/gcc
-          ls -a /opt/homebrew/Cellar/gcc
-          echo ls -a /opt/homebrew/Cellar/gcc/14.1.0_2
-          ls -a /opt/homebrew/Cellar/gcc/14.1.0_2
-          echo ls -a ~
-          ls -a ~
+#      - name: Testerdetest
+#        run: |
+#          echo ls -a /opt/homebrew/Cellar/gcc
+#          ls -a /opt/homebrew/Cellar/gcc
+#          echo ls -a /opt/homebrew/Cellar/gcc/14.1.0_2
+#          ls -a /opt/homebrew/Cellar/gcc/14.1.0_2
+#          echo ls -a ~
+#          ls -a ~
 
       - name: Testerdetest2
         run: |
           echo cat ~/.bash_profile
           cat ~/.bash_profile
 
-   #   - name: Add gfortran to PATH
-   #     run: |
-   #       echo "export PATH="your-dir:$PATH"" >> ~/.inputrc
+      - name: Add gfortran to PATH
+        run: |
+          echo "export PATH="/opt/homebrew/Cellar/gcc/14.1.0_2:$PATH"" >> ~/.bash_profile
+
+      - name: Testerdetest2
+        run: |
+          echo cat ~/.bash_profile
+          cat ~/.bash_profile
 
    #   - name: Compile UFEMISM
    #     run: |

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           echo ${{github.workspace}}/src
           echo ~/src
+          ls -a ${{github.workspace}}/src
+          ls -a ~/src
 
       - uses: actions/cache/save@v3
         id: cache

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -33,34 +33,42 @@ jobs:
         with:
           path: /nix/store
           key: UFEMISM_nix_packages
-
-      - name: testerdetest
+          
+      - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit == 'true' }}
+        name: Cache hit!
         run: |
-          echo steps.cache_UFEMISM_nix_packages.outputs.cache-hit
+          echo ls -a /nix/store
+          ls -a /nix/store
+          
+      - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
+        name: Cache miss!
+        run: |
+          echo ls -a /nix/store
+          ls -a /nix/store
 
    #   - name: Build UFEMISM with nix
    #     if: steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true'
    #     run: |
    #       nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
 
-  compile_UFEMISM:
-    needs: setup_packages
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Install nix
-        uses: cachix/install-nix-action@v22
-
-      - uses: actions/cache@v2
-        id: cache_UFEMISM_nix_packages
-        with:
-          path: /nix/store
-          key: UFEMISM_nix_packages
-
-      - name: check if cache loaded succesfully
-        run: |
-          echo ls -a /nix/store
-          ls -a /nix/store
+#  compile_UFEMISM:
+#    needs: setup_packages
+#    runs-on: ubuntu-latest
+#    steps:
+#
+#      - name: Install nix
+#        uses: cachix/install-nix-action@v22
+#
+#      - uses: actions/cache@v2
+#        id: cache_UFEMISM_nix_packages
+#        with:
+#          path: /nix/store
+#          key: UFEMISM_nix_packages
+#
+#      - name: check if cache loaded succesfully
+#        run: |
+#          echo ls -a /nix/store
+#          ls -a /nix/store
 
     #  - name: Install MATLAB
     #    uses: matlab-actions/setup-matlab@v2.2.0

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Compile UFEMISM
         run: |
+          which gfortran
+          gfortran --version
           ./compile_all_mac.csh
             
     #  - uses: actions/cache/save@v3

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -28,6 +28,9 @@ jobs:
           pwd
           ls -a
 
+      - name: testerdetest
+        run: ${{github.workspace}}/src
+
       - uses: actions/cache/save@v3
         id: cache
         with:

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -18,6 +18,18 @@ jobs:
           brew install netcdf
           brew install netcdf-fortran
 
+      - name: Set up Fortran compiler
+        uses: fortran-lang/setup-fortran@v1
+        id: setup-fortran
+        with:
+          compiler: gcc
+          version: 13
+
+      - name: Set Fortran compiler environment variables
+        run: |
+          ${{ env.FC }} ... # environment vars FC, CC, and CXX are set
+          ${{ steps.setup-fortran.outputs.fc }} ... # outputs work too
+
       - name: Checkout UFEMISM repository
         uses: actions/checkout@v4
 
@@ -35,22 +47,22 @@ jobs:
 #          echo ls -a ~
 #          ls -a ~
 
-      - name: Testerdetest2
-        run: |
-          echo cat ~/.bash_profile
-          cat ~/.bash_profile
-
-      - name: Add gfortran to path
-        run: |
-          echo -e '\nexport PATH="/opt/homebrew/Cellar/gcc/14.1.0_2:$PATH"' >> ~/.bash_profile
-
-      - name: Testerdetest2
-        run: |
-          echo cat ~/.bash_profile
-          cat ~/.bash_profile
-
-      - name: Reload bash profile to apply path changes
-        run: source ~/.bash_profile
+#      - name: Testerdetest2
+#        run: |
+#          echo cat ~/.bash_profile
+#          cat ~/.bash_profile
+#
+#      - name: Add gfortran to path
+#        run: |
+#          echo -e '\nexport PATH="/opt/homebrew/Cellar/gcc/14.1.0_2:$PATH"' >> ~/.bash_profile
+#
+#      - name: Testerdetest2
+#        run: |
+#          echo cat ~/.bash_profile
+#          cat ~/.bash_profile
+#
+#      - name: Reload bash profile to apply path changes
+#        run: source ~/.bash_profile
 
       - name: Compile UFEMISM
         run: |

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -52,10 +52,9 @@ jobs:
       - name: Reload bash profile to apply path changes
         run: source ~/.bash_profile
 
-   #   - name: Compile UFEMISM
-   #     run: |
-   #       ls -a ~
-    #      gfortran --version
+      - name: Compile UFEMISM
+        run: |
+          gfortran --version
     #      ./compile_all_mac.csh
             
     #  - uses: actions/cache/save@v3

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -86,6 +86,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: results_unit_tests
+          path: results_unit_tests
 
       - name: Test
         run: ls -a

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -9,8 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Install nix
-        uses: cachix/install-nix-action@v22
+      - name: Step 0
+        run: |
+          echo Hello world!
+
+    #  - name: Install nix
+    #    uses: cachix/install-nix-action@v22
 
     #  - uses: actions/cache@v2
     #    id: cache_UFEMISM_program
@@ -25,20 +29,20 @@ jobs:
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4
 
-      - name: testerdetest
-        run: |
-          echo ls -a
-          ls -a
-          echo ls -a /nix
-          ls -a /nix
-          echo ls -a /nix/store
-          ls -a /nix/store
+    #  - name: testerdetest
+    #    run: |
+    #      echo ls -a
+    #      ls -a
+    #      echo ls -a /nix
+    #      ls -a /nix
+    #      echo ls -a /nix/store
+    #      ls -a /nix/store
             
-      - uses: actions/cache/save@v3
-        id: cache
-        with:
-          path: /nix/store
-          key: UFEMISM_nix_packages
+    #  - uses: actions/cache/save@v3
+    #    id: cache
+    #    with:
+    #      path: /nix/store
+    #      key: UFEMISM_nix_packages
           
     #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
     #    name: Cache miss! Download and build UFEMISM nix packages
@@ -56,21 +60,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Step 0
+        run: |
+          echo Hello world!
+
  #     - name: Install nix
  #       uses: cachix/install-nix-action@v22
 
-      - name: idee
-        run: |
-          echo mkdir nix
-          mkdir /nix
-          echo mkdir nix/store
-          mkdir /nix/store
-
-      - uses: actions/cache/restore@v3
-        id: restore_cache
-        with:
-          path: /nix/store
-          key: UFEMISM_nix_packages
+  #    - uses: actions/cache/restore@v3
+  #      id: restore_cache
+  #      with:
+  #        path: /nix/store
+  #        key: UFEMISM_nix_packages
 
   #    - uses: actions/cache@v2
   #      id: cache_UFEMISM_nix_packages
@@ -79,10 +80,10 @@ jobs:
   #        key: UFEMISM_nix_packages
   #      #  continue-on-error: true
 
-      - name: check if cache loaded succesfully
-        run: |
-          echo ls -a /nix/store
-          ls -a /nix/store
+   #   - name: check if cache loaded succesfully
+   #     run: |
+   #       echo ls -a /nix/store
+   #       ls -a /nix/store
 
     #  - name: Install MATLAB
     #    uses: matlab-actions/setup-matlab@v2.2.0

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -5,7 +5,7 @@ run-name: ${{ github.actor }} - UFEMISM Test Suite (full)
 on: workflow_dispatch
 
 jobs:
-  setup:
+  setup_packages:
     runs-on: ubuntu-latest
     steps:
 
@@ -23,35 +23,36 @@ jobs:
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4
 
-      - name: testerdetest
+    #  - name: testerdetest
+    #    run: |
+    #      echo ls -a ~
+    #      ls -a ~
+    #      echo ls -a /nix
+    #      ls -a /nix
+    #      echo ls -a /nix/store
+    #      ls -a /nix/store
+
+      - uses: actions/cache@v2
+        id: cache_UFEMISM_nix_packages
+        with:
+          path: /nix/store
+          key: UFEMISM_nix_packages
+
+  compile_UFEMISM:
+    needs: setup_packages
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/cache@v2
+        id: cache_UFEMISM_nix_packages
+        with:
+          path: /nix/store
+          key: UFEMISM_nix_packages
+
+      - name: check if cache loaded succesfully
         run: |
-          echo ls -a ~
-          ls -a ~
-          echo ls -a /nix
-          ls -a /nix
           echo ls -a /nix/store
           ls -a /nix/store
-
-#      - uses: actions/cache@v2
-#        id: cache-tijn  # give it a name for checking the cache hit-or-not
-#        with:
-#          path: ${{github.workspace}}/src  # what we cache: the folder
-#          key: Tijns_cache_test
-
-#  run-unit-tests:
-#    needs: setup
-#    runs-on: ubuntu-latest
-#    steps:
-#
-#      - uses: actions/cache@v2
-#        id: cache-tijn  # give it a name for checking the cache hit-or-not
-#        with:
-#          path: ${{github.workspace}}/src  # what we cache: the folder
-#          key: Tijns_cache_test
-#
-#      - name: Check if we have it
-#        run: |
-#          ls -a
 
     #  - name: Install MATLAB
     #    uses: matlab-actions/setup-matlab@v2.2.0

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -66,7 +66,7 @@ jobs:
           key: UFEMISM_program
 
       - name: Run unit tests
-        run: mpiexec  -n 2  UFEMISM_program  config-files/config_test_01.cfg
+        run: mpiexec  -n 2  UFEMISM_program  config-files/unit_tests.cfg
 
     #  - name: Install MATLAB
     #    uses: matlab-actions/setup-matlab@v2.2.0

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -23,10 +23,7 @@ jobs:
 
       - name: Compile UFEMISM
         run: |
-          echo ls -a
-          ls -a
-          echo ls -a templates
-          ls -a templates
+          ./compile_all_mac.csh
             
     #  - uses: actions/cache/save@v3
     #    id: cache

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -8,54 +8,25 @@ jobs:
   setup_packages:
     runs-on: macos-latest
     steps:
-
-      - name: Step 0
-        run: |
-          echo Hello world!
-
-      - name: Check the Cellar
-        run: |
-          echo ls -a /opt/homebrew/Cellar
-          ls -a /opt/homebrew/Cellar
           
-      - name: Install packages with homebrew
+      - name: Install packages with Homebrew
         run: |
-          #brew install gcc     # Not needed on GitHub server, already installed
+          #brew install gcc        # Not needed on GitHub server, already installed
           brew install open-mpi
           brew install petsc
           brew unlink hdf5-mpi     # To fix the following conflict: "hdf5-mpi: because hdf5-mpi is a variant of hdf5, one can only use one or the other"
           brew install netcdf
           brew install netcdf-fortran
 
-      - name: Check the Cellar again
+      - name: Checkout UFEMISM repository
+        uses: actions/checkout@v4
+
+      - name: Compile UFEMISM
         run: |
-          echo ls -a /opt/homebrew/Cellar
-          ls -a /opt/homebrew/Cellar
-
-    #  - name: Install nix
-    #    uses: cachix/install-nix-action@v22
-
-    #  - uses: actions/cache@v2
-    #    id: cache_UFEMISM_program
-    #    with:
-    #      path: ${{ github.workspace }}/result
-    #      key: UFEMISM_program
-          
-    #  - name: Build UFEMISM with nix
-    #    run: |
-    #      nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
-
-    #  - name: Checkout UFEMISM repository
-    #    uses: actions/checkout@v4
-
-    #  - name: testerdetest
-    #    run: |
-    #      echo ls -a
-    #      ls -a
-    #      echo ls -a /nix
-    #      ls -a /nix
-    #      echo ls -a /nix/store
-    #      ls -a /nix/store
+          echo ls -a
+          ls -a
+          echo ls -a templates
+          ls -a templates
             
     #  - uses: actions/cache/save@v3
     #    id: cache

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -13,6 +13,11 @@ jobs:
         run: |
           echo Hello world!
 
+      - name: Check the Cellar
+        run: |
+          echo ls -a /opt/homebrew/Cellar
+          ls -a /opt/homebrew/Cellar
+          
       - name: Install packages with homebrew
         run: |
           #brew install gcc     # Not needed on GitHub server, already installed
@@ -22,12 +27,10 @@ jobs:
           brew install netcdf
           brew install netcdf-fortran
 
-      - name: testerdetest
+      - name: Check the Cellar again
         run: |
-          echo ls -a
-          ls -a
-          echo ls -a ~
-          ls -a ~
+          echo ls -a /opt/homebrew/Cellar
+          ls -a /opt/homebrew/Cellar
 
     #  - name: Install nix
     #    uses: cachix/install-nix-action@v22
@@ -79,6 +82,11 @@ jobs:
       - name: Step 0
         run: |
           echo Hello world!
+
+      - name: Check the Cellar
+        run: |
+          echo ls -a /opt/homebrew/Cellar
+          ls -a /opt/homebrew/Cellar
 
  #     - name: Install nix
  #       uses: cachix/install-nix-action@v22

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -29,7 +29,9 @@ jobs:
           ls -a
 
       - name: testerdetest
-        run: echo ${{github.workspace}}/src
+        run: |
+          echo ${{github.workspace}}/src
+          echo ~/src
 
       - uses: actions/cache/save@v3
         id: cache

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -18,10 +18,9 @@ jobs:
     #      path: ${{ github.workspace }}/result
     #      key: UFEMISM_program
           
-    #  - if: ${{ steps.cache_UFEMISM_program.outputs.cache-hit != 'true' }}
-    #    name: Build UFEMISM with nix
-    #    run: |
-    #      nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
+      - name: Build UFEMISM with nix
+        run: |
+          nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
 
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4
@@ -52,24 +51,25 @@ jobs:
     #      echo ls -a /nix/store
     #      ls -a /nix/store
 
-#  compile_UFEMISM:
-#    needs: setup_packages
-#    runs-on: ubuntu-latest
-#    steps:
-#
-#      - name: Install nix
-#        uses: cachix/install-nix-action@v22
-#
-#      - uses: actions/cache@v2
-#        id: cache_UFEMISM_nix_packages
-#        with:
-#          path: /nix/store
-#          key: UFEMISM_nix_packages
-#
-#      - name: check if cache loaded succesfully
-#        run: |
-#          echo ls -a /nix/store
-#          ls -a /nix/store
+  compile_UFEMISM:
+    needs: setup_packages
+    runs-on: ubuntu-latest
+    steps:
+
+ #     - name: Install nix
+ #       uses: cachix/install-nix-action@v22
+
+      - uses: actions/cache@v2
+        id: cache_UFEMISM_nix_packages
+        with:
+          path: /nix/store
+          key: UFEMISM_nix_packages
+        #  continue-on-error: true
+
+      - name: check if cache loaded succesfully
+        run: |
+          echo ls -a /nix/store
+          ls -a /nix/store
 
     #  - name: Install MATLAB
     #    uses: matlab-actions/setup-matlab@v2.2.0

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -34,10 +34,14 @@ jobs:
           path: /nix/store
           key: UFEMISM_nix_packages
 
-      - name: Build UFEMISM with nix
-        if: steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true'
+      - name: testerdetest
         run: |
-          nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
+          echo steps.cache_UFEMISM_nix_packages.outputs.cache-hit
+
+   #   - name: Build UFEMISM with nix
+   #     if: steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true'
+   #     run: |
+   #       nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
 
   compile_UFEMISM:
     needs: setup_packages

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -19,37 +19,31 @@ jobs:
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4
 
-      - name: testerdetest
+    #  - name: testerdetest
+    #    run: |
+    #      echo ls -a ~
+    #      ls -a ~
+    #      echo ls -a /nix
+    #      ls -a /nix
+    #      echo ls -a /nix/store
+    #      ls -a /nix/store
+
+      - uses: actions/cache@v2
+        id: cache_UFEMISM_nix_packages
+        with:
+          path: /nix/store
+          key: UFEMISM_nix_packages
+          
+      - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
+        name: Cache miss! Download and build UFEMISM nix packages
         run: |
-          echo ls -a ~
-          ls -a ~
-          echo ls -a /nix
-          ls -a /nix
+          nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
+          
+      - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit == 'true' }}
+        name: Cache hit! Load UFEMISM nix packages from cache.
+        run: |
           echo ls -a /nix/store
           ls -a /nix/store
-
-    #  - uses: actions/cache@v2
-    #    id: cache_UFEMISM_nix_packages
-    #    with:
-    #      path: /nix/store
-    #      key: UFEMISM_nix_packages
-          
-    #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit == 'true' }}
-    #    name: Cache hit!
-    #    run: |
-    #      echo ls -a /nix/store
-    #      ls -a /nix/store
-          
-    #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
-    #    name: Cache miss!
-    #    run: |
-    #      echo ls -a /nix/store
-    #      ls -a /nix/store
-
-   #   - name: Build UFEMISM with nix
-   #     if: steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true'
-   #     run: |
-   #       nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
 
 #  compile_UFEMISM:
 #    needs: setup_packages

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -16,10 +16,6 @@ jobs:
     #    run: |
     #      nix --version
 
-      - name: Build UFEMISM with nix
-        run: |
-          nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
-
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4
 
@@ -38,10 +34,18 @@ jobs:
           path: /nix/store
           key: UFEMISM_nix_packages
 
+      - name: Build UFEMISM with nix
+        run: |
+          nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
+        if: steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true'
+
   compile_UFEMISM:
     needs: setup_packages
     runs-on: ubuntu-latest
     steps:
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v22
 
       - uses: actions/cache@v2
         id: cache_UFEMISM_nix_packages

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -59,6 +59,13 @@ jobs:
  #     - name: Install nix
  #       uses: cachix/install-nix-action@v22
 
+      - name: idee
+        run: |
+          echo mkdir nix
+          mkdir /nix
+          echo mkdir nix/store
+          mkdir /nix/store
+
       - uses: actions/cache/restore@v3
         id: restore_cache
         with:

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -23,7 +23,6 @@ jobs:
 
       - name: Compile UFEMISM
         run: |
-          which gfortran
           gfortran --version
           ./compile_all_mac.csh
             

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -13,6 +13,10 @@ jobs:
         run: |
           echo Hello world!
 
+      - name: Install packages with homebrew
+        run: |
+          brew install gcc
+
     #  - name: Install nix
     #    uses: cachix/install-nix-action@v22
 

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -68,6 +68,12 @@ jobs:
       - name: Run unit tests
         run: mpiexec  -n 2  UFEMISM_program  config-files/unit_tests.cfg
 
+      - name: Upload output as artifacts
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: results_unit_tests
+          path: results_unit_tests
+
     #  - name: Install MATLAB
     #    uses: matlab-actions/setup-matlab@v2.2.0
 

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -11,7 +11,7 @@ jobs:
           
       - name: Install packages with Homebrew
         run: |
-          #brew install gcc        # Not needed on GitHub server, already installed
+          brew reinstall gcc        # Not needed on GitHub server, already installed
           brew install open-mpi
           brew install petsc
           brew unlink hdf5-mpi     # To fix the following conflict: "hdf5-mpi: because hdf5-mpi is a variant of hdf5, one can only use one or the other"

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           echo apropos fort
           apropos fort
+          echo beep
           gfortran --version
           ./compile_all_mac.csh
             

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -5,50 +5,49 @@ run-name: ${{ github.actor }} - UFEMISM Test Suite (full)
 on: workflow_dispatch
 
 jobs:
-  compile_UFEMISM:
+#  compile_UFEMISM:
+#    runs-on: macos-latest
+#    steps:
+          
+#      - name: Install packages with Homebrew   # Packages end up in /opt/homebrew/Cellar
+#        run: |
+#          #brew install gcc                    # Not needed on GitHub server, already installed
+#          brew install open-mpi
+#          brew install petsc
+#          brew unlink hdf5-mpi                 # To fix the following conflict: "hdf5-mpi: because hdf5-mpi is a variant of hdf5, one can only use one or the other"
+#          brew install netcdf
+#          brew install netcdf-fortran
+
+#      - name: Set up Fortran compiler          # See: https://github.com/marketplace/actions/setup-fortran
+#        uses: fortran-lang/setup-fortran@v1
+#        id: setup-fortran
+#        with:
+#          compiler: gcc
+#          version: 13
+
+#      - name: Verify compiler setup
+#        run: gfortran --version
+
+#      - name: Checkout UFEMISM repository
+#        uses: actions/checkout@v4
+
+#      - name: Compile UFEMISM
+#        run: ./compile_all_mac.csh
+            
+#      - name: Cache UFEMISM program
+#        uses: actions/cache/save@v3
+#        id: UFEMISM_program_cache_save
+#        with:
+#          path: UFEMISM_program
+#          key: UFEMISM_program
+
+  run_unit_tests:
+#    needs: compile_UFEMISM
     runs-on: macos-latest
     steps:
-          
-      - name: Install packages with Homebrew   # Packages end up in /opt/homebrew/Cellar
-        run: |
-          #brew install gcc                    # Not needed on GitHub server, already installed
-          brew install open-mpi
-          brew install petsc
-          brew unlink hdf5-mpi                 # To fix the following conflict: "hdf5-mpi: because hdf5-mpi is a variant of hdf5, one can only use one or the other"
-          brew install netcdf
-          brew install netcdf-fortran
-
-      - name: Set up Fortran compiler          # See: https://github.com/marketplace/actions/setup-fortran
-        uses: fortran-lang/setup-fortran@v1
-        id: setup-fortran
-        with:
-          compiler: gcc
-          version: 13
-
-      - name: Verify compiler setup
-        run: gfortran --version
 
       - name: Checkout UFEMISM repository
         uses: actions/checkout@v4
-
-      - name: Compile UFEMISM
-        run: ./compile_all_mac.csh
-            
-      - name: Cache UFEMISM program
-        uses: actions/cache/save@v3
-        id: UFEMISM_program_cache_save
-        with:
-          path: UFEMISM_program
-          key: UFEMISM_program
-
-  run_unit_tests:
-    needs: compile_UFEMISM
-    runs-on: macos-latest
-    steps:
-
-      - name: Step 0
-        run: |
-          echo Hello world!
 
       - name: Restore UFEMISM program from cache
         uses: actions/cache/restore@v3
@@ -56,6 +55,9 @@ jobs:
         with:
           path: UFEMISM_program
           key: UFEMISM_program
+
+      - name: Run unit tests
+        run: mpiexec  -n 2  UFEMISM_program  config-files/config_test_01.cfg
 
     #  - name: Install MATLAB
     #    uses: matlab-actions/setup-matlab@v2.2.0

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -34,6 +34,12 @@ jobs:
           ls -a /nix
           echo ls -a /nix/store
           ls -a /nix/store
+            
+      - uses: actions/cache/save@v3
+        id: cache
+        with:
+          path: /nix/store
+          key: UFEMISM_nix_packages
           
     #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
     #    name: Cache miss! Download and build UFEMISM nix packages

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Add gfortran to PATH
         run: |
-          echo "export PATH="/opt/homebrew/Cellar/gcc/14.1.0_2:$PATH"" >> ~/.bash_profile
+          echo -e "\nexport PATH="/opt/homebrew/Cellar/gcc/14.1.0_2:$PATH"" >> ~/.bash_profile
 
       - name: Testerdetest2
         run: |

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -16,18 +16,21 @@ jobs:
     #    run: |
     #      nix --version
 
-    #  - name: Build UFEMISM with nix
-    #    run: |
-    #      nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
+      - name: Build UFEMISM with nix
+        run: |
+          nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
 
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4
 
       - name: testerdetest
         run: |
-          echo ~
+          echo ls -a ~
           ls -a ~
+          echo ls -a /nix
           ls -a /nix
+          echo ls -a /nix/store
+          ls -a /nix/store
 
 #      - uses: actions/cache@v2
 #        id: cache-tijn  # give it a name for checking the cache hit-or-not

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -12,16 +12,16 @@ jobs:
       - name: Install nix
         uses: cachix/install-nix-action@v22
 
-      - uses: actions/cache@v2
-        id: cache_UFEMISM_program
-        with:
-          path: ${{ github.workspace }}/result
-          key: UFEMISM_program
+    #  - uses: actions/cache@v2
+    #    id: cache_UFEMISM_program
+    #    with:
+    #      path: ${{ github.workspace }}/result
+    #      key: UFEMISM_program
           
-      - if: ${{ steps.cache_UFEMISM_program.outputs.cache-hit != 'true' }}
-        name: Build UFEMISM with nix
-        run: |
-          nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
+    #  - if: ${{ steps.cache_UFEMISM_program.outputs.cache-hit != 'true' }}
+    #    name: Build UFEMISM with nix
+    #    run: |
+    #      nix build github:IMAU-paleo/UFEMISM2.0/${{github.sha}}?dir=tools/flake
 
     #  - name: Checkout UFEMISM repository
     #    uses: actions/checkout@v4
@@ -30,16 +30,10 @@ jobs:
         run: |
           echo ls -a
           ls -a
-          echo ls -a result
-          ls -a result
-          echo ls -a result/result
-          ls -a result/result
-          echo ls -a result/bin
-          ls -a result/bin
-          echo ls -a result/bin
-          ls -a result/bin
-          echo ls -a ${{ github.workspace }}
-          ls -a ${{ github.workspace }}
+          echo ls -a /nix
+          ls -a /nix
+          echo ls -a /nix/store
+          ls -a /nix/store
           
     #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
     #    name: Cache miss! Download and build UFEMISM nix packages

--- a/.github/workflows/UFE_test_suite_full.yml
+++ b/.github/workflows/UFE_test_suite_full.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache_UFEMISM_program
         with:
-          path: result
+          path: ${{ github.workspace }}/result
           key: UFEMISM_program
           
       - if: ${{ steps.cache_UFEMISM_program.outputs.cache-hit != 'true' }}
@@ -34,6 +34,10 @@ jobs:
           ls -a result
           echo ls -a result/bin
           ls -a result/bin
+          echo ls -a result/bin
+          ls -a result/bin
+          echo ls -a ${{ github.workspace }}
+          ls -a ${{ github.workspace }}
           
     #  - if: ${{ steps.cache_UFEMISM_nix_packages.outputs.cache-hit != 'true' }}
     #    name: Cache miss! Download and build UFEMISM nix packages


### PR DESCRIPTION
Set up a basic GitHub Workflow that installs the required packages with Homebrew (on macos), compiles UFEMISM, stores the compiled program in cache (so it can be easily reused for all the automated tests), runs the unit tests (in a separate job, where the compiled program is restored from cache), uploads the unit test results as an artifact, and sets up a new job where the unit test results are downloaded again, and Matlab is installed so the results can eventually be analysed.