### PR TITLE
Rearrange CSR matrix code

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -64,6 +64,7 @@ UFEMISM_source = \
   basic/reallocate_mod.f90 \
   basic/control_resources_and_error_messaging.f90 \
   basic/model_configuration.f90 \
+  basic/CSR_sparse_matrix_type.f90 \
   validation/unit_tests_output.f90 \
   validation/assertions_unit_tests.f90 \
   basic/mpi_distributed_memory.f90 \

--- a/src/basic/CSR_sparse_matrix_type.f90
+++ b/src/basic/CSR_sparse_matrix_type.f90
@@ -1,0 +1,30 @@
+module CSR_sparse_matrix_type
+
+  ! The Compressed Sparse Row matrix type
+
+  use precisions, only: dp
+
+  implicit none
+
+  private
+
+  public :: type_sparse_matrix_CSR_dp
+
+  ! The basic CSR matrix type
+  type type_sparse_matrix_CSR_dp
+    ! Compressed Sparse Row (CSR) format matrix
+
+    integer                             :: m,n         ! A = [m-by-n]
+    integer                             :: m_loc,n_loc ! number of rows and columns owned by each process
+    integer                             :: i1,i2,j1,j2 ! rows and columns owned by each process
+    integer                             :: nnz_max     ! Maximum number of non-zero entries in A
+    integer                             :: nnz         ! Actual  number of non-zero entries in A
+    integer,  dimension(:), allocatable :: ptr         ! Row start indices
+    integer,  dimension(:), allocatable :: ind         ! Column indices
+    real(dp), dimension(:), allocatable :: val         ! Values
+
+  end type type_sparse_matrix_CSR_dp
+
+contains
+
+end module CSR_sparse_matrix_type

--- a/src/basic/CSR_sparse_matrix_utilities.f90
+++ b/src/basic/CSR_sparse_matrix_utilities.f90
@@ -1,58 +1,36 @@
-MODULE CSR_sparse_matrix_utilities
+module CSR_sparse_matrix_utilities
 
   ! Subroutines to work with Compressed Sparse Row formatted matrices
 
-! ===== Preamble =====
-! ====================
+  use CSR_sparse_matrix_type                                 , only: type_sparse_matrix_CSR_dp
+  use mpi
+  use precisions                                             , only: dp
+  use mpi_basic                                              , only: par, cerr, ierr, recv_status, sync
+  use control_resources_and_error_messaging                  , only: warning, crash, happy, init_routine, finalise_routine, colour_string
+  use parameters
+  use reallocate_mod                                         , only: reallocate
+  use mpi_distributed_memory                                 , only: partition_list
 
-  USE mpi
-  USE precisions                                             , ONLY: dp
-  USE mpi_basic                                              , ONLY: par, cerr, ierr, recv_status, sync
-  USE control_resources_and_error_messaging                  , ONLY: warning, crash, happy, init_routine, finalise_routine, colour_string
-  USE parameters
-  USE reallocate_mod                                         , ONLY: reallocate
-  USE mpi_distributed_memory                                 , ONLY: partition_list
+  implicit none
 
-  IMPLICIT NONE
-
-  ! The basic CSR matrix type
-  TYPE type_sparse_matrix_CSR_dp
-    ! Compressed Sparse Row (CSR) format matrix
-
-    INTEGER                                 :: m,n                           ! A = [m-by-n]
-    INTEGER                                 :: m_loc,n_loc                   ! number of rows and columns owned by each process
-    INTEGER                                 :: i1,i2,j1,j2                   ! rows and columns owned by each process
-    INTEGER                                 :: nnz_max                       ! Maximum number of non-zero entries in A
-    INTEGER                                 :: nnz                           ! Actual  number of non-zero entries in A
-    INTEGER,  DIMENSION(:    ), ALLOCATABLE :: ptr                           ! Row start indices
-    INTEGER,  DIMENSION(:    ), ALLOCATABLE :: ind                           ! Column indices
-    REAL(dp), DIMENSION(:    ), ALLOCATABLE :: val                           ! Values
-
-  END TYPE type_sparse_matrix_CSR_dp
-
-CONTAINS
-
-! ===== Subroutinea ======
-! ========================
+contains
 
   ! ===== CSR matrices in distributed memory =====
   ! ==============================================
 
-  SUBROUTINE allocate_matrix_CSR_dist( A, m_glob, n_glob, m_loc, n_loc, nnz_max_proc)
+  subroutine allocate_matrix_CSR_dist( A, m_glob, n_glob, m_loc, n_loc, nnz_max_proc)
     ! Allocate memory for a CSR-format sparse m-by-n matrix A
 
-    IMPLICIT NONE
-
     ! In- and output variables:
-    TYPE(type_sparse_matrix_CSR_dp),     INTENT(INOUT) :: A
-    INTEGER,                             INTENT(IN)    :: m_glob, n_glob, m_loc, n_loc, nnz_max_proc
+    type(type_sparse_matrix_CSR_dp),     intent(inout) :: A
+    integer,                             intent(in)    :: m_glob, n_glob, m_loc, n_loc, nnz_max_proc
 
     ! Local variables:
-    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'allocate_matrix_CSR_dist'
-    INTEGER,  DIMENSION(par%n)                         :: m_loc_all, n_loc_all
+    character(len=256), parameter                      :: routine_name = 'allocate_matrix_CSR_dist'
+    integer,  dimension(par%n)                         :: m_loc_all, n_loc_all
 
-    ! Add routine to path
-    CALL init_routine( routine_name)
+    ! Add routine to call stack
+    call init_routine( routine_name)
 
     ! Matrix dimensions
     A%m       = m_glob
@@ -63,41 +41,39 @@ CONTAINS
     A%nnz     = 0
 
     ! Partition rows and columns over the processes
-    CALL MPI_ALLGATHER( m_loc, 1, MPI_INTEGER, m_loc_all, 1, MPI_INTEGER, MPI_COMM_WORLD, ierr)
-    CALL MPI_ALLGATHER( n_loc, 1, MPI_INTEGER, n_loc_all, 1, MPI_INTEGER, MPI_COMM_WORLD, ierr)
+    call MPI_ALLGATHER( m_loc, 1, MPI_integer, m_loc_all, 1, MPI_integer, MPI_COMM_WORLD, ierr)
+    call MPI_ALLGATHER( n_loc, 1, MPI_integer, n_loc_all, 1, MPI_integer, MPI_COMM_WORLD, ierr)
 
     ! Safety
-    IF (SUM( m_loc_all) /= m_glob) CALL crash('sum of numbers of local rows doesnt match number of global rows!')
-    IF (SUM( n_loc_all) /= n_glob) CALL crash('sum of numbers of local columns doesnt match number of global columns!')
+    if (sum( m_loc_all) /= m_glob) call crash('sum of numbers of local rows doesnt match number of global rows!')
+    if (sum( n_loc_all) /= n_glob) call crash('sum of numbers of local columns doesnt match number of global columns!')
 
-    A%i1 = 1 + SUM( m_loc_all( 1:par%i  ))
-    A%i2 = 1 + SUM( m_loc_all( 1:par%i+1))-1
-    A%j1 = 1 + SUM( n_loc_all( 1:par%i  ))
-    A%j2 = 1 + SUM( n_loc_all( 1:par%i+1))-1
+    A%i1 = 1 + sum( m_loc_all( 1:par%i  ))
+    A%i2 = 1 + sum( m_loc_all( 1:par%i+1))-1
+    A%j1 = 1 + sum( n_loc_all( 1:par%i  ))
+    A%j2 = 1 + sum( n_loc_all( 1:par%i+1))-1
 
     ! Allocate memory
-    ALLOCATE( A%ptr( A%i1: A%i2+1    ), source = 1    )
-    ALLOCATE( A%ind( A%nnz_max), source = 0    )
-    ALLOCATE( A%val( A%nnz_max), source = 0._dp)
+    allocate( A%ptr( A%i1: A%i2+1    ), source = 1    )
+    allocate( A%ind( A%nnz_max), source = 0    )
+    allocate( A%val( A%nnz_max), source = 0._dp)
 
     ! Finalise routine path
-    CALL finalise_routine( routine_name)
+    call finalise_routine( routine_name)
 
-  END SUBROUTINE allocate_matrix_CSR_dist
+  end subroutine allocate_matrix_CSR_dist
 
-  SUBROUTINE deallocate_matrix_CSR_dist( A)
+  subroutine deallocate_matrix_CSR_dist( A)
     ! Deallocate memory for a CSR-format sparse matrix A
 
-    IMPLICIT NONE
-
     ! In- and output variables:
-    TYPE(type_sparse_matrix_CSR_dp),     INTENT(INOUT) :: A
+    type(type_sparse_matrix_CSR_dp),     intent(inout) :: A
 
     ! Local variables:
-    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'deallocate_matrix_CSR_dist'
+    character(len=256), parameter                      :: routine_name = 'deallocate_matrix_CSR_dist'
 
-    ! Add routine to path
-    CALL init_routine( routine_name)
+    ! Add routine to call stack
+    call init_routine( routine_name)
 
     ! Matrix dimensions
     A%m       = 0
@@ -111,29 +87,27 @@ CONTAINS
     A%nnz_max = 0
     A%nnz     = 0
 
-    IF (ALLOCATED( A%ptr)) DEALLOCATE( A%ptr)
-    IF (ALLOCATED( A%ind)) DEALLOCATE( A%ind)
-    IF (ALLOCATED( A%val)) DEALLOCATE( A%val)
+    if (allocateD( A%ptr)) deallocate( A%ptr)
+    if (allocateD( A%ind)) deallocate( A%ind)
+    if (allocateD( A%val)) deallocate( A%val)
 
     ! Finalise routine path
-    CALL finalise_routine( routine_name)
+    call finalise_routine( routine_name)
 
-  END SUBROUTINE deallocate_matrix_CSR_dist
+  end subroutine deallocate_matrix_CSR_dist
 
-  SUBROUTINE duplicate_matrix_CSR_dist( A, B)
+  subroutine duplicate_matrix_CSR_dist( A, B)
     ! Duplicate the CSR-format sparse matrix A
 
-    IMPLICIT NONE
-
     ! In- and output variables:
-    TYPE(type_sparse_matrix_CSR_dp),     INTENT(IN)    :: A
-    TYPE(type_sparse_matrix_CSR_dp),     INTENT(OUT)   :: B
+    type(type_sparse_matrix_CSR_dp),     intent(in)    :: A
+    type(type_sparse_matrix_CSR_dp),     intent(OUT)   :: B
 
     ! Local variables:
-    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'duplicate_matrix_CSR_dist'
+    character(len=256), parameter                      :: routine_name = 'duplicate_matrix_CSR_dist'
 
-    ! Add routine to path
-    CALL init_routine( routine_name)
+    ! Add routine to call stack
+    call init_routine( routine_name)
 
     ! Matrix dimensions
     B%m       = A%m
@@ -148,9 +122,9 @@ CONTAINS
     B%nnz     = A%nnz
 
     ! Allocate memory
-    ALLOCATE( B%ptr( B%i1: B%i2+1    ), source = 1    )
-    ALLOCATE( B%ind( B%nnz_max), source = 0    )
-    ALLOCATE( B%val( B%nnz_max), source = 0._dp)
+    allocate( B%ptr( B%i1: B%i2+1    ), source = 1    )
+    allocate( B%ind( B%nnz_max), source = 0    )
+    allocate( B%val( B%nnz_max), source = 0._dp)
 
     ! Copy data
     B%ptr = A%ptr
@@ -158,24 +132,22 @@ CONTAINS
     B%val = A%val
 
     ! Finalise routine path
-    CALL finalise_routine( routine_name)
+    call finalise_routine( routine_name)
 
-  END SUBROUTINE duplicate_matrix_CSR_dist
+  end subroutine duplicate_matrix_CSR_dist
 
-  SUBROUTINE add_entry_CSR_dist( A, i, j, v)
+  subroutine add_entry_CSR_dist( A, i, j, v)
     ! Add value v to row i, column j of CSR-formatted matrix A
     !
     ! NOTE: assumes all rows before i are finished and nothing exists yet for rows after i!
 
-    IMPLICIT NONE
-
     ! In- and output variables:
-    TYPE(type_sparse_matrix_CSR_dp),     INTENT(INOUT) :: A
-    INTEGER,                             INTENT(IN)    :: i,j
-    REAL(dp),                            INTENT(IN)    :: v
+    type(type_sparse_matrix_CSR_dp),     intent(inout) :: A
+    integer,                             intent(in)    :: i,j
+    real(dp),                            intent(in)    :: v
 
     ! Safety
-    IF (i < A%i1 .OR. i > A%i2) CALL crash('out of ownership range!')
+    if (i < A%i1 .OR. i > A%i2) call crash('out of ownership range!')
 
     ! Increase number of non-zeros
     A%nnz = A%nnz + 1
@@ -188,108 +160,100 @@ CONTAINS
     A%ptr( i+1) = A%nnz+1
 
     ! Extend memory if necessary
-    IF (A%nnz > A%nnz_max - 10) CALL extend_matrix_CSR_dist( A, 1000)
+    if (A%nnz > A%nnz_max - 10) call extend_matrix_CSR_dist( A, 1000)
 
-  END SUBROUTINE add_entry_CSR_dist
+  end subroutine add_entry_CSR_dist
 
-  SUBROUTINE add_empty_row_CSR_dist( A, i)
+  subroutine add_empty_row_CSR_dist( A, i)
     ! Add an empty row i to CSR-formatted matrix A
     !
     ! NOTE: assumes all rows before i are finished and nothing exists yet for rows after i!
 
-    IMPLICIT NONE
-
     ! In- and output variables:
-    TYPE(type_sparse_matrix_CSR_dp),     INTENT(INOUT) :: A
-    INTEGER,                             INTENT(IN)    :: i
+    type(type_sparse_matrix_CSR_dp),     intent(inout) :: A
+    integer,                             intent(in)    :: i
 
     ! Safety
-    IF (i < A%i1 .OR. i > A%i2) CALL crash('out of ownership range!')
+    if (i < A%i1 .OR. i > A%i2) call crash('out of ownership range!')
 
     ! Update pointer list
     A%ptr( i+1) = A%nnz+1
 
-  END SUBROUTINE add_empty_row_CSR_dist
+  end subroutine add_empty_row_CSR_dist
 
-  SUBROUTINE extend_matrix_CSR_dist( A, nnz_extra)
+  subroutine extend_matrix_CSR_dist( A, nnz_extra)
     ! Extend memory for a CSR-format sparse m-by-n matrix A
 
-    IMPLICIT NONE
-
     ! In- and output variables:
-    TYPE(type_sparse_matrix_CSR_dp),     INTENT(INOUT) :: A
-    INTEGER,                             INTENT(IN)    :: nnz_extra
+    type(type_sparse_matrix_CSR_dp),     intent(inout) :: A
+    integer,                             intent(in)    :: nnz_extra
 
     ! Local variables:
 
     ! Extend memory
     A%nnz_max = A%nnz + nnz_extra
-    CALL reallocate( A%ind, A%nnz_max)
-    CALL reallocate( A%val, A%nnz_max)
+    call reallocate( A%ind, A%nnz_max)
+    call reallocate( A%val, A%nnz_max)
 
-  END SUBROUTINE extend_matrix_CSR_dist
+  end subroutine extend_matrix_CSR_dist
 
-  SUBROUTINE crop_matrix_CSR_dist( A)
+  subroutine crop_matrix_CSR_dist( A)
     ! Crop memory for a CSR-format sparse m-by-n matrix A
 
-    IMPLICIT NONE
-
     ! In- and output variables:
-    TYPE(type_sparse_matrix_CSR_dp),     INTENT(INOUT) :: A
+    type(type_sparse_matrix_CSR_dp),     intent(inout) :: A
 
     ! Local variables:
-    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'crop_matrix_CSR_dist'
+    character(len=256), parameter                      :: routine_name = 'crop_matrix_CSR_dist'
 
-    ! Add routine to path
-    CALL init_routine( routine_name)
+    ! Add routine to call stack
+    call init_routine( routine_name)
 
     ! Crop memory
     A%nnz_max = A%nnz
-    CALL reallocate( A%ind, A%nnz_max)
-    CALL reallocate( A%val, A%nnz_max)
+    call reallocate( A%ind, A%nnz_max)
+    call reallocate( A%val, A%nnz_max)
 
     ! Finalise routine path
-    CALL finalise_routine( routine_name)
+    call finalise_routine( routine_name)
 
-  END SUBROUTINE crop_matrix_CSR_dist
+  end subroutine crop_matrix_CSR_dist
 
-  SUBROUTINE gather_CSR_dist_to_master( A, A_tot)
+  subroutine gather_CSR_dist_to_master( A, A_tot)
     ! Gather a CSR-format sparse m-by-n matrix A that is distributed over the processes, to the master
 
-    IMPLICIT NONE
-
     ! In- and output variables:
-    TYPE(type_sparse_matrix_CSR_dp),     INTENT(IN)    :: A
-    TYPE(type_sparse_matrix_CSR_dp),     INTENT(OUT)   :: A_tot
+    type(type_sparse_matrix_CSR_dp),     intent(in)    :: A
+    type(type_sparse_matrix_CSR_dp),     intent(OUT)   :: A_tot
 
     ! Local variables:
-    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'gather_CSR_dist_to_master'
-    INTEGER,  DIMENSION(par%n)                         :: m_glob_all, n_glob_all, m_loc_all, n_loc_all
-    INTEGER                                            :: nnz_tot
-    INTEGER                                            :: p
-    INTEGER                                            :: row, k1, k2, k, col
-    REAL(dp)                                           :: val
-    TYPE(type_sparse_matrix_CSR_dp)                    :: A_proc
+    character(len=256), parameter                      :: routine_name = 'gather_CSR_dist_to_master'
+    integer,  dimension(par%n)                         :: m_glob_all, n_glob_all, m_loc_all, n_loc_all
+    integer                                            :: nnz_tot
+    integer                                            :: p
+    integer                                            :: row, k1, k2, k, col
+    real(dp)                                           :: val
+    type(type_sparse_matrix_CSR_dp)                    :: A_proc
 
-    ! Add routine to path
-    CALL init_routine( routine_name)
+    ! Add routine to call stack
+    call init_routine( routine_name)
 
     ! Gather dimensions
-    CALL MPI_ALLGATHER( A%m    , 1, MPI_INTEGER, m_glob_all, 1, MPI_INTEGER, MPI_COMM_WORLD, ierr)
-    CALL MPI_ALLGATHER( A%n    , 1, MPI_INTEGER, n_glob_all, 1, MPI_INTEGER, MPI_COMM_WORLD, ierr)
-    CALL MPI_ALLGATHER( A%m_loc, 1, MPI_INTEGER, m_loc_all , 1, MPI_INTEGER, MPI_COMM_WORLD, ierr)
-    CALL MPI_ALLGATHER( A%n_loc, 1, MPI_INTEGER, n_loc_all , 1, MPI_INTEGER, MPI_COMM_WORLD, ierr)
+    call MPI_ALLGATHER( A%m    , 1, MPI_integer, m_glob_all, 1, MPI_integer, MPI_COMM_WORLD, ierr)
+    call MPI_ALLGATHER( A%n    , 1, MPI_integer, n_glob_all, 1, MPI_integer, MPI_COMM_WORLD, ierr)
+    call MPI_ALLGATHER( A%m_loc, 1, MPI_integer, m_loc_all , 1, MPI_integer, MPI_COMM_WORLD, ierr)
+    call MPI_ALLGATHER( A%n_loc, 1, MPI_integer, n_loc_all , 1, MPI_integer, MPI_COMM_WORLD, ierr)
 
-    CALL MPI_ALLREDUCE( A%nnz, nnz_tot, 1, MPI_INTEGER, MPI_SUM, MPI_COMM_WORLD, ierr)
+    call MPI_ALLREDUCE( A%nnz, nnz_tot, 1, MPI_integer, MPI_sum, MPI_COMM_WORLD, ierr)
 
     ! Safety - check if dimensions match
-    IF (ANY( m_glob_all /= A%m)) CALL crash('global numbers of rows do not match across the processes!')
-    IF (ANY( n_glob_all /= A%n)) CALL crash('global numbers of columns do not match across the processes!')
-    IF (SUM( m_loc_all) /= A%m ) CALL crash('local numbers of rows do not add up across the processes!')
-    IF (SUM( n_loc_all) /= A%n ) CALL crash('local numbers of columns do not add up across the processes!')
+    if (any( m_glob_all /= A%m)) call crash('global numbers of rows do not match across the processes!')
+    if (any( n_glob_all /= A%n)) call crash('global numbers of columns do not match across the processes!')
+    if (sum( m_loc_all) /= A%m ) call crash('local numbers of rows do not add up across the processes!')
+    if (sum( n_loc_all) /= A%n ) call crash('local numbers of columns do not add up across the processes!')
 
     ! Allocate memory
-    IF (par%master) THEN
+    if (par%master) then
       A_tot%m       = A%m
       A_tot%m_loc   = A%m
       A_tot%i1      = 1
@@ -300,10 +264,10 @@ CONTAINS
       A_tot%j2      = A%n
       A_tot%nnz     = 0
       A_tot%nnz_max = nnz_tot
-      ALLOCATE( A_tot%ptr( A%m+1)  , source = 1    )
-      ALLOCATE( A_tot%ind( nnz_tot), source = 0    )
-      ALLOCATE( A_tot%val( nnz_tot), source = 0._dp)
-    ELSE
+      allocate( A_tot%ptr( A%m+1)  , source = 1    )
+      allocate( A_tot%ind( nnz_tot), source = 0    )
+      allocate( A_tot%val( nnz_tot), source = 0._dp)
+    else
       A_tot%m       = A%m
       A_tot%m_loc   = 0
       A_tot%i1      = 1
@@ -314,110 +278,108 @@ CONTAINS
       A_tot%j2      = 0
       A_tot%nnz     = 0
       A_tot%nnz_max = 0
-    END IF
+    end if
 
     ! Start with the master's own data
-    IF (par%master) THEN
-      DO row = A%i1, A%i2
+    if (par%master) then
+      do row = A%i1, A%i2
         k1 = A%ptr( row)
         k2 = A%ptr( row+1) - 1
-        DO k = k1, k2
+        do k = k1, k2
           col = A%ind( k)
           val = A%val( k)
-          CALL add_entry_CSR_dist( A_tot, row, col, val)
-        END DO
-      END DO
-    END IF
+          call add_entry_CSR_dist( A_tot, row, col, val)
+        end do
+      end do
+    end if
 
     ! Collect data from the other processes
-    DO p = 1, par%n-1
+    do p = 1, par%n-1
 
-      IF     (par%i == p) THEN
+      if     (par%i == p) then
 
         ! Send matrix metadata to master
-        CALL MPI_SEND( A%m      , 1, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, ierr)
-        CALL MPI_SEND( A%m_loc  , 1, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, ierr)
-        CALL MPI_SEND( A%i1     , 1, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, ierr)
-        CALL MPI_SEND( A%i2     , 1, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, ierr)
-        CALL MPI_SEND( A%n      , 1, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, ierr)
-        CALL MPI_SEND( A%n_loc  , 1, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, ierr)
-        CALL MPI_SEND( A%j1     , 1, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, ierr)
-        CALL MPI_SEND( A%j2     , 1, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, ierr)
-        CALL MPI_SEND( A%nnz    , 1, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, ierr)
-        CALL MPI_SEND( A%nnz_max, 1, MPI_INTEGER, 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%m      , 1, MPI_integer, 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%m_loc  , 1, MPI_integer, 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%i1     , 1, MPI_integer, 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%i2     , 1, MPI_integer, 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%n      , 1, MPI_integer, 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%n_loc  , 1, MPI_integer, 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%j1     , 1, MPI_integer, 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%j2     , 1, MPI_integer, 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%nnz    , 1, MPI_integer, 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%nnz_max, 1, MPI_integer, 0, 0, MPI_COMM_WORLD, ierr)
 
         ! Send matrix data to master
-        CALL MPI_SEND( A%ptr, A%m_loc+1, MPI_INTEGER         , 0, 0, MPI_COMM_WORLD, ierr)
-        CALL MPI_SEND( A%ind, A%nnz_max, MPI_INTEGER         , 0, 0, MPI_COMM_WORLD, ierr)
-        CALL MPI_SEND( A%val, A%nnz_max, MPI_DOUBLE_PRECISION, 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%ptr, A%m_loc+1, MPI_integer         , 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%ind, A%nnz_max, MPI_integer         , 0, 0, MPI_COMM_WORLD, ierr)
+        call MPI_Send( A%val, A%nnz_max, MPI_DOUBLE_PRECISION, 0, 0, MPI_COMM_WORLD, ierr)
 
-      ELSEIF (par%master) THEN
+      elseif (par%master) then
 
         ! Receive matrix metadata from process
-        CALL MPI_RECV( A_proc%m      , 1, MPI_INTEGER, p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
-        CALL MPI_RECV( A_proc%m_loc  , 1, MPI_INTEGER, p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
-        CALL MPI_RECV( A_proc%i1     , 1, MPI_INTEGER, p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
-        CALL MPI_RECV( A_proc%i2     , 1, MPI_INTEGER, p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
-        CALL MPI_RECV( A_proc%n      , 1, MPI_INTEGER, p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
-        CALL MPI_RECV( A_proc%n_loc  , 1, MPI_INTEGER, p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
-        CALL MPI_RECV( A_proc%j1     , 1, MPI_INTEGER, p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
-        CALL MPI_RECV( A_proc%j2     , 1, MPI_INTEGER, p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
-        CALL MPI_RECV( A_proc%nnz    , 1, MPI_INTEGER, p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
-        CALL MPI_RECV( A_proc%nnz_max, 1, MPI_INTEGER, p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%m      , 1, MPI_integer, p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%m_loc  , 1, MPI_integer, p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%i1     , 1, MPI_integer, p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%i2     , 1, MPI_integer, p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%n      , 1, MPI_integer, p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%n_loc  , 1, MPI_integer, p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%j1     , 1, MPI_integer, p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%j2     , 1, MPI_integer, p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%nnz    , 1, MPI_integer, p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%nnz_max, 1, MPI_integer, p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
 
         ! Allocate memory
-        ALLOCATE( A_proc%ptr( A_proc%i1: A_proc%i2+1), source = 0    )
-        ALLOCATE( A_proc%ind( A_proc%nnz_max), source = 0    )
-        ALLOCATE( A_proc%val( A_proc%nnz_max), source = 0._dp)
+        allocate( A_proc%ptr( A_proc%i1: A_proc%i2+1), source = 0    )
+        allocate( A_proc%ind( A_proc%nnz_max), source = 0    )
+        allocate( A_proc%val( A_proc%nnz_max), source = 0._dp)
 
         ! Receive matrix data from process
-        CALL MPI_RECV( A_proc%ptr, A_proc%m_loc+1, MPI_INTEGER         , p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
-        CALL MPI_RECV( A_proc%ind, A_proc%nnz_max, MPI_INTEGER         , p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
-        CALL MPI_RECV( A_proc%val, A_proc%nnz_max, MPI_DOUBLE_PRECISION, p, MPI_ANY_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%ptr, A_proc%m_loc+1, MPI_integer         , p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%ind, A_proc%nnz_max, MPI_integer         , p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
+        call MPI_RECV( A_proc%val, A_proc%nnz_max, MPI_DOUBLE_PRECISION, p, MPI_any_TAG, MPI_COMM_WORLD, recv_status, ierr)
 
         ! Write to total matrix
-        DO row = A_proc%i1, A_proc%i2
+        do row = A_proc%i1, A_proc%i2
           k1 = A_proc%ptr( row)
           k2 = A_proc%ptr( row+1) - 1
-          DO k = k1, k2
+          do k = k1, k2
             col = A_proc%ind( k)
             val = A_proc%val( k)
-            CALL add_entry_CSR_dist( A_tot, row, col, val)
-          END DO
-        END DO
+            call add_entry_CSR_dist( A_tot, row, col, val)
+          end do
+        end do
 
         ! Clean up after yourself
-        DEALLOCATE( A_proc%ptr)
-        DEALLOCATE( A_proc%ind)
-        DEALLOCATE( A_proc%val)
+        deallocate( A_proc%ptr)
+        deallocate( A_proc%ind)
+        deallocate( A_proc%val)
 
-      END IF ! IF     (par%i == p) THEN
-      CALL sync
+      end if ! if     (par%i == p) then
+      call sync
 
-    END DO ! DO p = 1, par%n-1
+    end do ! do p = 1, par%n-1
 
     ! Finalise routine path
-    CALL finalise_routine( routine_name)
+    call finalise_routine( routine_name)
 
-  END SUBROUTINE gather_CSR_dist_to_master
+  end subroutine gather_CSR_dist_to_master
 
-  SUBROUTINE read_single_row_CSR_dist( A, i, ind, val, nnz)
+  subroutine read_single_row_CSR_dist( A, i, ind, val, nnz)
     ! Read the coefficients of a single row of A
 
-    IMPLICIT NONE
-
     ! In- and output variables:
-    TYPE(type_sparse_matrix_CSR_dp),     INTENT(IN)    :: A
-    INTEGER,                             INTENT(IN)    :: i
-    INTEGER,  DIMENSION(:    ),          INTENT(INOUT) :: ind
-    REAL(dp), DIMENSION(:    ),          INTENT(INOUT) :: val
-    INTEGER,                             INTENT(OUT)   :: nnz
+    type(type_sparse_matrix_CSR_dp),     intent(in)    :: A
+    integer,                             intent(in)    :: i
+    integer,  dimension(:    ),          intent(inout) :: ind
+    real(dp), dimension(:    ),          intent(inout) :: val
+    integer,                             intent(OUT)   :: nnz
 
     ! Local variables:
-    INTEGER                                            :: k1,k2
+    integer                                            :: k1,k2
 
     ! Safety
-    IF (i < A%i1 .OR. i > A%i2) CALL crash('row {int_01} is not owned by process {int_02}!', int_01 = i, int_02 = par%i)
+    if (i < A%i1 .OR. i > A%i2) call crash('row {int_01} is not owned by process {int_02}!', int_01 = i, int_02 = par%i)
 
     k1 = A%ptr( i)
     k2 = A%ptr( i+1) - 1
@@ -427,25 +389,23 @@ CONTAINS
     ind( 1:nnz) = A%ind( k1:k2)
     val( 1:nnz) = A%val( k1:k2)
 
-  END SUBROUTINE read_single_row_CSR_dist
+  end subroutine read_single_row_CSR_dist
 
   ! ===== CSR matrices in local memory =====
   ! ========================================
 
-  SUBROUTINE allocate_matrix_CSR_loc( A, m, n, nnz_max)
+  subroutine allocate_matrix_CSR_loc( A, m, n, nnz_max)
     ! Allocate memory for a CSR-format sparse m-by-n matrix A
 
-    IMPLICIT NONE
-
     ! In- and output variables:
-    TYPE(type_sparse_matrix_CSR_dp),     INTENT(INOUT) :: A
-    INTEGER,                             INTENT(IN)    :: m, n, nnz_max
+    type(type_sparse_matrix_CSR_dp),     intent(inout) :: A
+    integer,                             intent(in)    :: m, n, nnz_max
 
     ! Local variables:
-    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'allocate_matrix_CSR_loc'
+    character(len=256), parameter                      :: routine_name = 'allocate_matrix_CSR_loc'
 
-    ! Add routine to path
-    CALL init_routine( routine_name)
+    ! Add routine to call stack
+    call init_routine( routine_name)
 
     ! Matrix dimensions
     A%m       = m
@@ -461,13 +421,13 @@ CONTAINS
     A%j2 = n
 
     ! Allocate memory
-    ALLOCATE( A%ptr( A%m+1    ), source = 1    )
-    ALLOCATE( A%ind( A%nnz_max), source = 0    )
-    ALLOCATE( A%val( A%nnz_max), source = 0._dp)
+    allocate( A%ptr( A%m+1    ), source = 1    )
+    allocate( A%ind( A%nnz_max), source = 0    )
+    allocate( A%val( A%nnz_max), source = 0._dp)
 
     ! Finalise routine path
-    CALL finalise_routine( routine_name)
+    call finalise_routine( routine_name)
 
-  END SUBROUTINE allocate_matrix_CSR_loc
+  end subroutine allocate_matrix_CSR_loc
 
-END MODULE CSR_sparse_matrix_utilities
+end module CSR_sparse_matrix_utilities

--- a/src/validation/assertions_unit_tests.f90
+++ b/src/validation/assertions_unit_tests.f90
@@ -154,6 +154,7 @@ module assertions_unit_tests
     procedure test_tol_dp_2D_scalar, test_tol_dp_2D_array
     procedure test_tol_dp_3D_scalar, test_tol_dp_3D_array
     procedure test_tol_dp_4D_scalar, test_tol_dp_4D_array
+    procedure test_tol_CSR
   end interface test_tol
 
 contains
@@ -592,8 +593,8 @@ contains
     ! Local variables:
     logical :: test_result
 
-    ! First test that b2 >= b1
-    call test_ge( b2, b1, test_mode, message)
+    ! First assert that b2 >= b1
+    call test_ge( b2, b1, ASSERTION, message)
 
     test_result = a >= b1 .and. a <= b2
 
@@ -611,8 +612,8 @@ contains
     ! Local variables:
     logical :: test_result
 
-    ! First test that tol >= 0
-    call test_ge( tol, 0, test_mode, message)
+    ! First assert that tol >= 0
+    call test_ge( tol, 0, ASSERTION, message)
 
     test_result = a >= (b - tol) .and. a <= (b + tol)
 
@@ -732,8 +733,8 @@ contains
     ! Local variables:
     logical :: test_result
 
-    ! First test that b2 >= b1
-    call test_ge( b2, b1, test_mode, message)
+    ! First assert that b2 >= b1
+    call test_ge( b2, b1, ASSERTION, message)
 
     test_result = all(a >= b1 .and. a <= b2)
 
@@ -751,8 +752,8 @@ contains
     ! Local variables:
     logical :: test_result
 
-    ! First test that tol >= 0
-    call test_ge( tol, 0, test_mode, message)
+    ! First assert that tol >= 0
+    call test_ge( tol, 0, ASSERTION, message)
 
     test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -862,8 +863,8 @@ subroutine test_ge_le_int_1D_array( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -881,8 +882,8 @@ subroutine test_tol_int_1D_array( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -1002,8 +1003,8 @@ subroutine test_ge_le_int_2D_scalar( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -1021,8 +1022,8 @@ subroutine test_tol_int_2D_scalar( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -1132,8 +1133,8 @@ subroutine test_ge_le_int_2D_array( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -1151,8 +1152,8 @@ subroutine test_tol_int_2D_array( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -1272,8 +1273,8 @@ subroutine test_ge_le_int_3D_scalar( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -1291,8 +1292,8 @@ subroutine test_tol_int_3D_scalar( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -1402,8 +1403,8 @@ subroutine test_ge_le_int_3D_array( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -1421,8 +1422,8 @@ subroutine test_tol_int_3D_array( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -1542,8 +1543,8 @@ subroutine test_ge_le_int_4D_scalar( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -1561,8 +1562,8 @@ subroutine test_tol_int_4D_scalar( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -1672,8 +1673,8 @@ subroutine test_ge_le_int_4D_array( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -1691,8 +1692,8 @@ subroutine test_tol_int_4D_array( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -1812,8 +1813,8 @@ end subroutine test_tol_int_4D_array
     ! Local variables:
     logical :: test_result
 
-    ! First test that b2 >= b1
-    call test_ge( b2, b1, test_mode, message)
+    ! First assert that b2 >= b1
+    call test_ge( b2, b1, ASSERTION, message)
 
     test_result = a >= b1 .and. a <= b2
 
@@ -1831,8 +1832,8 @@ end subroutine test_tol_int_4D_array
     ! Local variables:
     logical :: test_result
 
-    ! First test that tol >= 0
-    call test_ge( tol, 0._dp, test_mode, message)
+    ! First assert that tol >= 0
+    call test_ge( tol, 0._dp, ASSERTION, message)
 
     test_result = a >= (b - tol) .and. a <= (b + tol)
 
@@ -1952,8 +1953,8 @@ end subroutine test_tol_int_4D_array
     ! Local variables:
     logical :: test_result
 
-    ! First test that b2 >= b1
-    call test_ge( b2, b1, test_mode, message)
+    ! First assert that b2 >= b1
+    call test_ge( b2, b1, ASSERTION, message)
 
     test_result = all(a >= b1 .and. a <= b2)
 
@@ -1971,8 +1972,8 @@ end subroutine test_tol_int_4D_array
     ! Local variables:
     logical :: test_result
 
-    ! First test that tol >= 0
-    call test_ge( tol, 0._dp, test_mode, message)
+    ! First assert that tol >= 0
+    call test_ge( tol, 0._dp, ASSERTION, message)
 
     test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -2082,8 +2083,8 @@ subroutine test_ge_le_dp_1D_array( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -2101,8 +2102,8 @@ subroutine test_tol_dp_1D_array( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0._dp, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0._dp, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -2222,8 +2223,8 @@ subroutine test_ge_le_dp_2D_scalar( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -2241,8 +2242,8 @@ subroutine test_tol_dp_2D_scalar( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0._dp, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0._dp, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -2352,8 +2353,8 @@ subroutine test_ge_le_dp_2D_array( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -2371,8 +2372,8 @@ subroutine test_tol_dp_2D_array( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0._dp, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0._dp, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -2492,8 +2493,8 @@ subroutine test_ge_le_dp_3D_scalar( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -2511,8 +2512,8 @@ subroutine test_tol_dp_3D_scalar( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0._dp, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0._dp, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -2622,8 +2623,8 @@ subroutine test_ge_le_dp_3D_array( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -2641,8 +2642,8 @@ subroutine test_tol_dp_3D_array( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0._dp, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0._dp, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -2762,8 +2763,8 @@ subroutine test_ge_le_dp_4D_scalar( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -2781,8 +2782,8 @@ subroutine test_tol_dp_4D_scalar( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0._dp, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0._dp, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
@@ -2892,8 +2893,8 @@ subroutine test_ge_le_dp_4D_array( a, b1, b2, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that b2 >= b1
-  call test_ge( b2, b1, test_mode, message)
+  ! First assert that b2 >= b1
+  call test_ge( b2, b1, ASSERTION, message)
 
   test_result = all(a >= b1 .and. a <= b2)
 
@@ -2911,14 +2912,60 @@ subroutine test_tol_dp_4D_array( a, b, tol, test_mode, message)
   ! Local variables:
   logical :: test_result
 
-  ! First test that tol >= 0
-  call test_ge( tol, 0._dp, test_mode, message)
+  ! First assert that tol >= 0
+  call test_ge( tol, 0._dp, ASSERTION, message)
 
   test_result = all(a >= (b - tol) .and. a <= (b + tol))
 
   call process_test_result( test_mode, test_result, message)
 
 end subroutine test_tol_dp_4D_array
+
+! ===== Sparse matrices =====
+! ===========================
+
+subroutine test_tol_CSR( a, b, tol, test_mode, message)
+  use CSR_sparse_matrix_type, only: type_sparse_matrix_CSR_dp
+  ! In/output variables:
+  type(type_sparse_matrix_CSR_dp), intent(in   ) :: a, b
+  real(dp),                        intent(in   ) :: tol
+  integer,                         intent(in   ) :: test_mode
+  character(len=*),                intent(in   ) :: message
+  ! Local variables:
+  logical :: test_result
+
+  ! First assert that tol >= 0
+  call test_ge( tol, 0._dp, ASSERTION, message)
+
+  test_result = .true.
+
+  test_result = test_result .and. a%m     == b%m
+  test_result = test_result .and. a%m_loc == b%m_loc
+  test_result = test_result .and. a%n     == b%n
+  test_result = test_result .and. a%n_loc == b%n_loc
+  test_result = test_result .and. a%nnz   == b%nnz
+
+  if (size(a%ptr) == size(b%ptr)) then
+    test_result = test_result .and. all(a%ptr == b%ptr)
+  else
+    test_result = .false.
+  end if
+
+  if (size(a%ptr) == size(b%ptr)) then
+    test_result = test_result .and. all(a%ind == b%ind)
+  else
+    test_result = .false.
+  end if
+
+  if (size(a%val) == size(b%val)) then
+    test_result = test_result .and. all(a%val >= b%val - tol) .and. all(a%val <= b%val + tol)
+  else
+    test_result = .false.
+  end if
+
+  call process_test_result( test_mode, test_result, message)
+
+end subroutine test_tol_CSR
 
 ! ===== Process test results =====
 ! ================================

--- a/src/validation/unit_tests_petsc.f90
+++ b/src/validation/unit_tests_petsc.f90
@@ -63,7 +63,6 @@ contains
     character(len=1024), parameter          :: test_name_local = 'multiply_CSR_matrix_with_vector_1D'
     character(len=1024)                     :: test_name
     type(type_sparse_matrix_CSR_dp)         :: AA
-    type(tMat)                              :: A
     real(dp), dimension(:    ), allocatable :: xx, yy, yy_correct
 
     ! Add routine to call stack
@@ -286,7 +285,6 @@ contains
     type(type_sparse_matrix_CSR_dp) :: AA, AA2
     type(tMat)                      :: A
     logical                         :: found_errors
-    integer                         :: i,k1,k2,k
 
     ! Add routine to call stack
     call init_routine( routine_name)
@@ -361,14 +359,7 @@ contains
     call mat_petsc2CSR( A , AA2)
 
     ! Check results
-    call test_eq ( AA%m    , AA2%m             , UNIT_TEST, trim(test_name) // '_m')
-    call test_eq ( AA%m_loc, AA2%m_loc         , UNIT_TEST, trim(test_name) // '_m_loc')
-    call test_eq ( AA%n    , AA2%n             , UNIT_TEST, trim(test_name) // '_n')
-    call test_eq ( AA%n_loc, AA2%n_loc         , UNIT_TEST, trim(test_name) // '_n_loc')
-    call test_eq ( AA%nnz  , AA2%nnz           , UNIT_TEST, trim(test_name) // '_nnz')
-    call test_eq ( AA%ptr  , AA2%ptr           , UNIT_TEST, trim(test_name) // '_ptr')
-    call test_eq ( AA%ind  , AA2%ind           , UNIT_TEST, trim(test_name) // '_ind')
-    call test_tol( AA%val  , AA2%val  , 1e-5_dp, UNIT_TEST, trim(test_name) // '_val')
+    call test_tol ( AA, AA2, 1e-12_dp, UNIT_TEST, test_name)
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)


### PR DESCRIPTION
Rearrange the code for CSR-format sparse matrices.

Moved the CRS type to a separate module, which can be compiled before compiling the assertions/unit tests module.

Added a test_tol_CSR routine. Used that in the PETSc unit test.