### PR TITLE
BMB read_from_file

### DIFF
--- a/config-files/config_ant_template.cfg
+++ b/config-files/config_ant_template.cfg
@@ -454,16 +454,22 @@
     choice_basal_hydrology_model_config          = 'inversion'                      ! Choice of basal hydrology model: "saturated", "Martin2011", "inversion", "read_from_file"
     Martin2011_hydro_Hb_min_config               = 0.0                              ! Martin et al. (2011) basal hydrology model: low-end  Hb  value of bedrock-dependent pore-water pressure
     Martin2011_hydro_Hb_max_config               = 1000.0                           ! Martin et al. (2011) basal hydrology model: high-end Hb  value of bedrock-dependent pore-water pressure
-    ! Paths to files containing pore water fraction fields
-    filename_pore_water_NAM_config               = ''
-    filename_pore_water_EAS_config               = ''
-    filename_pore_water_GRL_config               = ''
-    filename_pore_water_ANT_config               = ''
-    ! Timeframes to read from the pore water file (set to 1E9    if the file has no time dimension)
-    timeframe_pore_water_NAM_config              = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
-    timeframe_pore_water_EAS_config              = 1E9
-    timeframe_pore_water_GRL_config              = 1E9
-    timeframe_pore_water_ANT_config              = 1E9
+
+    ! Initialisation of the pore water fraction
+    pore_water_fraction_choice_initialise_NAM_config = 'zero'                       ! How to initialise the pore water fraction: 'zero', 'read_from_file'
+    pore_water_fraction_choice_initialise_EAS_config = 'zero'
+    pore_water_fraction_choice_initialise_GRL_config = 'zero'
+    pore_water_fraction_choice_initialise_ANT_config = 'zero'
+    ! Paths to files containing pore water fraction fields 
+    filename_pore_water_fraction_NAM_config      = ''
+    filename_pore_water_fraction_EAS_config      = ''
+    filename_pore_water_fraction_GRL_config      = ''
+    filename_pore_water_fraction_ANT_config      = ''
+    ! Timeframes to read from the pore water fraction file (set to 1E9    if the file has no time dimension)
+    timeframe_pore_water_fraction_NAM_config     = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_pore_water_fraction_EAS_config     = 1E9
+    timeframe_pore_water_fraction_GRL_config     = 1E9
+    timeframe_pore_water_fraction_ANT_config     = 1E9
 
   ! == Basal hydrology inversion by nudging
   ! =======================================

--- a/config-files/config_ant_template.cfg
+++ b/config-files/config_ant_template.cfg
@@ -715,8 +715,8 @@
     BMB_inversion_t_end_config                   = +9.9E9                           ! [yr] End   time for BMB inversion based on computed thinning rates in marine areas
 
     ! Grounding line treatment
-    do_subgrid_BMB_at_grounding_line_config      = .FALSE.                          ! Whether or not to apply basal melt rates under a partially floating grounding line
-    choice_BMB_subgrid_config                    = 'FCMP'                           ! If True, choose between FCMP and PMP. False equals NMP. (following Leguy et al., 2021)
+    do_subgrid_BMB_at_grounding_line_config      = .FALSE.                          ! Whether or not to apply basal melt rates under a partially floating grounding line; if so, use choice_BMB_subgrid; if not, apply "NMP"
+    choice_BMB_subgrid_config                    = 'FCMP'                           ! Choice of sub-grid BMB scheme: "FCMP", "PMP" (following Leguy et al., 2021)
 
     ! Choice of BMB model
     choice_BMB_model_NAM_config                  = 'uniform'

--- a/config-files/config_ant_template.cfg
+++ b/config-files/config_ant_template.cfg
@@ -451,9 +451,19 @@
   ! ==================
 
     ! Basal hydrology
-    choice_basal_hydrology_model_config          = 'inversion'                      ! Choice of basal hydrology model: "saturated", "Martin2011", "inversion"
+    choice_basal_hydrology_model_config          = 'inversion'                      ! Choice of basal hydrology model: "saturated", "Martin2011", "inversion", "read_from_file"
     Martin2011_hydro_Hb_min_config               = 0.0                              ! Martin et al. (2011) basal hydrology model: low-end  Hb  value of bedrock-dependent pore-water pressure
     Martin2011_hydro_Hb_max_config               = 1000.0                           ! Martin et al. (2011) basal hydrology model: high-end Hb  value of bedrock-dependent pore-water pressure
+    ! Paths to files containing pore water fraction fields
+    filename_pore_water_NAM_config               = ''
+    filename_pore_water_EAS_config               = ''
+    filename_pore_water_GRL_config               = ''
+    filename_pore_water_ANT_config               = ''
+    ! Timeframes to read from the pore water file (set to 1E9    if the file has no time dimension)
+    timeframe_pore_water_NAM_config              = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_pore_water_EAS_config              = 1E9
+    timeframe_pore_water_GRL_config              = 1E9
+    timeframe_pore_water_ANT_config              = 1E9
 
   ! == Basal hydrology inversion by nudging
   ! =======================================

--- a/config-files/config_ant_template.cfg
+++ b/config-files/config_ant_template.cfg
@@ -708,6 +708,24 @@
     choice_BMB_model_GRL_config                  = 'uniform'
     choice_BMB_model_ANT_config                  = 'inverted'
 
+    ! Prescribed BMB forcing
+    choice_BMB_prescribed_NAM_config             = ''
+    choice_BMB_prescribed_EAS_config             = ''
+    choice_BMB_prescribed_GRL_config             = ''
+    choice_BMB_prescribed_ANT_config             = 'BMB_no_time'
+
+    ! Files containing prescribed BMB forcing
+    filename_BMB_prescribed_NAM_config           = ''                                ! In case choice_BMB_model is prescribed
+    filename_BMB_prescribed_EAS_config           = ''
+    filename_BMB_prescribed_GRL_config           = ''
+    filename_BMB_prescribed_ANT_config           = ''
+
+    ! Timeframes for reading prescribed BMB forcing from file (set to 1E9 if the file has no time dimension)
+    timeframe_BMB_prescribed_NAM_config          = 1E9
+    timeframe_BMB_prescribed_EAS_config          = 1E9
+    timeframe_BMB_prescribed_GRL_config          = 1E9
+    timeframe_BMB_prescribed_ANT_config          = 1E9
+
     ! Choice of idealised BMB model
     choice_BMB_model_idealised_config            = ''
 

--- a/config-files/config_ant_template.cfg
+++ b/config-files/config_ant_template.cfg
@@ -700,6 +700,7 @@
 
     ! Grounding line treatment
     do_subgrid_BMB_at_grounding_line_config      = .FALSE.                          ! Whether or not to apply basal melt rates under a partially floating grounding line
+    choice_BMB_subgrid_config                    = 'FCMP'                           ! If True, choose between FCMP and PMP. False equals NMP. (following Leguy et al., 2021)
 
     ! Choice of BMB model
     choice_BMB_model_NAM_config                  = 'uniform'

--- a/src/Makefile
+++ b/src/Makefile
@@ -121,6 +121,7 @@ UFEMISM_source = \
   surface_mass_balance/SMB_main.f90 \
   \
   basal_mass_balance/BMB_idealised.f90 \
+  basal_mass_balance/BMB_prescribed.f90 \
   basal_mass_balance/BMB_parameterised.f90 \
   basal_mass_balance/BMB_main.f90 \
   \

--- a/src/basal_conditions/basal_hydrology.f90
+++ b/src/basal_conditions/basal_hydrology.f90
@@ -1752,7 +1752,7 @@ CONTAINS
 
   ! == Pore water fraction from file
   SUBROUTINE calc_pore_water_pressure_from_file( mesh, ice)
-    ! Calculate the pore water pressure
+    ! Calculate the pore water pressure from a prescribed pore water fraction, read from file
     !
     ! Use the parameterisation from Martin et al. (2011)
 

--- a/src/basal_conditions/basal_hydrology.f90
+++ b/src/basal_conditions/basal_hydrology.f90
@@ -1735,7 +1735,7 @@ CONTAINS
       CALL read_field_from_file_2D( filename_pore_water, 'pore_water_fraction', mesh, ice%pore_water_fraction, time_to_read = timeframe_pore_water)
     END IF
 
-    CALL calc_pore_water_pressure_none( mesh, ice)
+    CALL calc_pore_water_pressure_from_file( mesh, ice)
 
     ! Finalise routine path
     CALL finalise_routine( routine_name)

--- a/src/basal_conditions/basal_hydrology.f90
+++ b/src/basal_conditions/basal_hydrology.f90
@@ -98,7 +98,7 @@ CONTAINS
     ! Local variables:
     CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'initialise_basal_hydrology_model'
     REAL(dp)                                           :: dummy1
-    CHARACTER(LEN=256)                                 :: pore_water_choice_initialise
+    CHARACTER(LEN=256)                                 :: pore_water_fraction_choice_initialise
 
     ! Add routine to path
     CALL init_routine( routine_name)
@@ -109,24 +109,24 @@ CONTAINS
 
     ! Determine choice of initial ice temperatures for this model region
     IF     (region_name == 'NAM') THEN
-      pore_water_choice_initialise = C%pore_water_choice_initialise_NAM
+      pore_water_fraction_choice_initialise = C%pore_water_fraction_choice_initialise_NAM
     ELSEIF (region_name == 'EAS') THEN
-      pore_water_choice_initialise = C%pore_water_choice_initialise_EAS
+      pore_water_fraction_choice_initialise = C%pore_water_fraction_choice_initialise_EAS
     ELSEIF (region_name == 'GRL') THEN
-      pore_water_choice_initialise = C%pore_water_choice_initialise_GRL
+      pore_water_fraction_choice_initialise = C%pore_water_fraction_choice_initialise_GRL
     ELSEIF (region_name == 'ANT') THEN
-      pore_water_choice_initialise = C%pore_water_choice_initialise_ANT
+      pore_water_fraction_choice_initialise = C%pore_water_fraction_choice_initialise_ANT
     ELSE
       CALL crash('unknown region_name "' // region_name // '"')
     END IF
 
     ! Initialise the chosen basal hydrology model
-    IF     (pore_water_choice_initialise == 'zero') THEN
+    IF     (pore_water_fraction_choice_initialise == 'zero') THEN
       ! Set values to zero
       ice%pore_water_fraction = 0._dp
-    ELSEIF (pore_water_choice_initialise == 'read_from_file') THEN
+    ELSEIF (pore_water_fraction_choice_initialise == 'read_from_file') THEN
       ! Read pore water fraction from file
-      CALL initialise_pore_water_from_file( mesh, ice, region_name)
+      CALL initialise_pore_water_fraction_from_file( mesh, ice, region_name)
     ELSE
       CALL crash('unknown choice_basal_hydrology_model "' // TRIM( C%choice_basal_hydrology_model) // '"')
     END IF
@@ -1693,7 +1693,7 @@ CONTAINS
 
   END SUBROUTINE trace_flowline_downstream
 
-  SUBROUTINE initialise_pore_water_from_file( mesh, ice, region_name)
+  SUBROUTINE initialise_pore_water_fraction_from_file( mesh, ice, region_name)
     ! Initialise the pore water fraction from file
     !
     ! pore water only, no time
@@ -1706,9 +1706,9 @@ CONTAINS
     CHARACTER(LEN=3),                       INTENT(IN)    :: region_name
 
     ! Local variables:
-    CHARACTER(LEN=256), PARAMETER                         :: routine_name = 'initialise_pore_water_from_file'
-    CHARACTER(LEN=256)                                    :: filename_pore_water
-    REAL(dp)                                              :: timeframe_pore_water
+    CHARACTER(LEN=256), PARAMETER                         :: routine_name = 'initialise_pore_water_fraction_from_file'
+    CHARACTER(LEN=256)                                    :: filename_pore_water_fraction
+    REAL(dp)                                              :: timeframe_pore_water_fraction
 
     ! Add routine to path
     CALL init_routine( routine_name)
@@ -1716,31 +1716,31 @@ CONTAINS
     ! Determine filename for this model region
     SELECT CASE (region_name)
       CASE ('NAM')
-        filename_pore_water  = C%filename_pore_water_NAM
-        timeframe_pore_water = C%timeframe_pore_water_NAM
+        filename_pore_water_fraction  = C%filename_pore_water_fraction_NAM
+        timeframe_pore_water_fraction = C%timeframe_pore_water_fraction_NAM
       CASE ('EAS')
-        filename_pore_water  = C%filename_pore_water_EAS
-        timeframe_pore_water = C%timeframe_pore_water_EAS
+        filename_pore_water_fraction  = C%filename_pore_water_fraction_EAS
+        timeframe_pore_water_fraction = C%timeframe_pore_water_fraction_EAS
       CASE ('GRL')
-        filename_pore_water  = C%filename_pore_water_GRL
-        timeframe_pore_water = C%timeframe_pore_water_GRL
+        filename_pore_water_fraction  = C%filename_pore_water_fraction_GRL
+        timeframe_pore_water_fraction = C%timeframe_pore_water_fraction_GRL
       CASE ('ANT')
-        filename_pore_water  = C%filename_pore_water_ANT
-        timeframe_pore_water = C%timeframe_pore_water_ANT
+        filename_pore_water_fraction  = C%filename_pore_water_fraction_ANT
+        timeframe_pore_water_fraction = C%timeframe_pore_water_fraction_ANT
       CASE DEFAULT
         CALL crash('unknown region_name "' // TRIM( region_name) // '"!')
     END SELECT
 
     ! Print to terminal
-    IF (par%master)  WRITE(*,"(A)") '   Initialising pore water fraction from file "' // colour_string( TRIM( filename_pore_water),'light blue') // '"...'
+    IF (par%master)  WRITE(*,"(A)") '   Initialising pore water fraction from file "' // colour_string( TRIM(filename_pore_water_fraction),'light blue') // '"...'
 
     ! Read pore water fraction from file
-    IF (timeframe_pore_water == 1E9_dp) THEN
+    IF (timeframe_pore_water_fraction == 1E9_dp) THEN
       ! Assume the file has no time dimension
-    CALL read_field_from_file_2D( filename_pore_water, 'pore_water_fraction', mesh, ice%pore_water_fraction)
+      CALL read_field_from_file_2D( filename_pore_water_fraction, 'pore_water_fraction', mesh, ice%pore_water_fraction)
     ELSE
       ! Assume the file has a time dimension, and read the specified timeframe
-      CALL read_field_from_file_2D( filename_pore_water, 'pore_water_fraction', mesh, ice%pore_water_fraction, time_to_read = timeframe_pore_water)
+      CALL read_field_from_file_2D( filename_pore_water_fraction, 'pore_water_fraction', mesh, ice%pore_water_fraction, time_to_read = timeframe_pore_water_fraction)
     END IF
 
     CALL calc_pore_water_pressure_from_file( mesh, ice)
@@ -1748,7 +1748,7 @@ CONTAINS
     ! Finalise routine path
     CALL finalise_routine( routine_name)
 
-  END SUBROUTINE initialise_pore_water_from_file
+  END SUBROUTINE initialise_pore_water_fraction_from_file
 
   ! == Pore water fraction from file
   SUBROUTINE calc_pore_water_pressure_from_file( mesh, ice)

--- a/src/basal_mass_balance/BMB_idealised.f90
+++ b/src/basal_mass_balance/BMB_idealised.f90
@@ -75,7 +75,7 @@ CONTAINS
     CALL init_routine( routine_name)
 
     ! Initialise
-    BMB%BMB = 0._dp
+    BMB%BMB_shelf = 0._dp
 
     DO vi = mesh%vi1, mesh%vi2
       IF (ice%mask_floating_ice( vi)) THEN
@@ -84,7 +84,7 @@ CONTAINS
         cavity_thickness = MAX( 0._dp, zd - ice%Hb( vi))
 
         ! Cornford et al. (2020), Eq. 7
-        BMB%BMB( vi) = -0.2_dp * TANH( cavity_thickness / 75._dp) * MAX( -100._dp - zd, 0._dp)
+        BMB%BMB_shelf( vi) = -0.2_dp * TANH( cavity_thickness / 75._dp) * MAX( -100._dp - zd, 0._dp)
 
       END IF ! IF (ice%mask_floating_ice( vi)) THEN
     END DO ! DO vi = mesh%vi1, mesh%vi2

--- a/src/basal_mass_balance/BMB_main.f90
+++ b/src/basal_mass_balance/BMB_main.f90
@@ -17,6 +17,7 @@ MODULE BMB_main
   USE SMB_model_types                                        , ONLY: type_SMB_model
   USE BMB_model_types                                        , ONLY: type_BMB_model
   USE BMB_idealised                                          , ONLY: initialise_BMB_model_idealised, run_BMB_model_idealised
+  USE BMB_prescribed                                         , ONLY: initialise_BMB_model_prescribed, run_BMB_model_prescribed
   USE BMB_parameterised                                      , ONLY: initialise_BMB_model_parameterised, run_BMB_model_parameterised
   USE reallocate_mod                                         , ONLY: reallocate_bounds
   USE math_utilities                                         , ONLY: is_floating
@@ -101,6 +102,8 @@ CONTAINS
             BMB%BMB_shelf( vi) = C%uniform_BMB
           END IF
         END DO
+      CASE ('prescribed')
+        CALL run_BMB_model_prescribed( mesh, ice, BMB, region_name, time)
       CASE ('idealised')
         CALL run_BMB_model_idealised( mesh, ice, BMB, time)
       CASE ('parameterised')
@@ -190,6 +193,8 @@ CONTAINS
     SELECT CASE (choice_BMB_model)
       CASE ('uniform')
         ! No need to do anything
+      CASE ('prescribed')
+        CALL initialise_BMB_model_prescribed( mesh, SMB, region_name)
       CASE ('idealised')
         CALL initialise_BMB_model_idealised( mesh, BMB)
       CASE ('parameterised')
@@ -240,6 +245,8 @@ CONTAINS
     ! Write to the restart file of the chosen BMB model
     SELECT CASE (choice_BMB_model)
       CASE ('uniform')
+        ! No need to do anything
+      CASE ('prescribed')
         ! No need to do anything
       CASE ('idealised')
         ! No need to do anything
@@ -335,6 +342,8 @@ CONTAINS
     ! Create the restart file of the chosen BMB model
     SELECT CASE (choice_BMB_model)
       CASE ('uniform')
+        ! No need to do anything
+      CASE ('prescribed')
         ! No need to do anything
       CASE ('idealised')
         ! No need to do anything
@@ -460,6 +469,8 @@ CONTAINS
     SELECT CASE (choice_BMB_model)
       CASE ('uniform')
         ! No need to do anything
+      CASE ('prescribed')
+        CALL initialise_BMB_model_prescribed( mesh_new, BMB, region_name)
       CASE ('idealised')
         ! No need to do anything
       CASE ('parameterised')

--- a/src/basal_mass_balance/BMB_main.f90
+++ b/src/basal_mass_balance/BMB_main.f90
@@ -89,6 +89,8 @@ CONTAINS
         SELECT CASE (choice_BMB_model)
           CASE ('inverted')
             ! No need to do anything
+          CASE ('prescribed_fixed')
+            ! No need to do anything
           CASE DEFAULT
             CALL apply_BMB_subgrid_scheme( mesh, ice, BMB)
         END SELECT
@@ -113,6 +115,8 @@ CONTAINS
         END DO
       CASE ('prescribed')
         CALL run_BMB_model_prescribed( mesh, ice, BMB, region_name, time)
+      CASE ('prescribed_fixed')
+        ! No need to do anything
       CASE ('idealised')
         CALL run_BMB_model_idealised( mesh, ice, BMB, time)
       CASE ('parameterised')
@@ -126,6 +130,8 @@ CONTAINS
     ! Apply subgrid scheme of old BMB to new mask
     SELECT CASE (choice_BMB_model)
       CASE ('inverted')
+        ! No need to do anything
+      CASE ('prescribed_fixed')
         ! No need to do anything
       CASE DEFAULT
         CALL apply_BMB_subgrid_scheme( mesh, ice, BMB)
@@ -204,6 +210,9 @@ CONTAINS
         ! No need to do anything
       CASE ('prescribed')
         CALL initialise_BMB_model_prescribed( mesh, BMB, region_name)
+      CASE ('prescribed_fixed')
+        CALL initialise_BMB_model_prescribed( mesh, BMB, region_name)
+        CALL apply_BMB_subgrid_scheme( mesh, ice, BMB)
       CASE ('idealised')
         CALL initialise_BMB_model_idealised( mesh, BMB)
       CASE ('parameterised')
@@ -256,6 +265,8 @@ CONTAINS
       CASE ('uniform')
         ! No need to do anything
       CASE ('prescribed')
+        ! No need to do anything
+      CASE ('prescribed_fixed')
         ! No need to do anything
       CASE ('idealised')
         ! No need to do anything
@@ -353,6 +364,8 @@ CONTAINS
       CASE ('uniform')
         ! No need to do anything
       CASE ('prescribed')
+        ! No need to do anything
+      CASE ('prescribed_fixed')
         ! No need to do anything
       CASE ('idealised')
         ! No need to do anything
@@ -480,6 +493,9 @@ CONTAINS
         ! No need to do anything
       CASE ('prescribed')
         CALL initialise_BMB_model_prescribed( mesh_new, BMB, region_name)
+      CASE ('prescribed_fixed')
+        CALL initialise_BMB_model_prescribed( mesh_new, BMB, region_name)
+        CALL apply_BMB_subgrid_scheme( mesh_new, ice, BMB)
       CASE ('idealised')
         ! No need to do anything
       CASE ('parameterised')

--- a/src/basal_mass_balance/BMB_main.f90
+++ b/src/basal_mass_balance/BMB_main.f90
@@ -194,7 +194,7 @@ CONTAINS
       CASE ('uniform')
         ! No need to do anything
       CASE ('prescribed')
-        CALL initialise_BMB_model_prescribed( mesh, SMB, region_name)
+        CALL initialise_BMB_model_prescribed( mesh, BMB, region_name)
       CASE ('idealised')
         CALL initialise_BMB_model_idealised( mesh, BMB)
       CASE ('parameterised')

--- a/src/basal_mass_balance/BMB_main.f90
+++ b/src/basal_mass_balance/BMB_main.f90
@@ -102,24 +102,20 @@ CONTAINS
             BMB%BMB_shelf( vi) = C%uniform_BMB
           END IF
         END DO
+        CALL apply_BMB_subgrid_scheme( mesh, ice, BMB)
       CASE ('prescribed')
         CALL run_BMB_model_prescribed( mesh, ice, BMB, region_name, time)
+        CALL apply_BMB_subgrid_scheme( mesh, ice, BMB)
       CASE ('idealised')
         CALL run_BMB_model_idealised( mesh, ice, BMB, time)
+        CALL apply_BMB_subgrid_scheme( mesh, ice, BMB)
       CASE ('parameterised')
         CALL run_BMB_model_parameterised( mesh, ice, ocean, BMB)
+        CALL apply_BMB_subgrid_scheme( mesh, ice, BMB)
       CASE ('inverted')
         CALL run_BMB_model_inverted( mesh, ice, BMB, time)
       CASE DEFAULT
         CALL crash('unknown choice_BMB_model "' // TRIM( choice_BMB_model) // '"')
-    END SELECT
-
-    ! Apply BMB subgrid scheme if required
-    SELECT CASE (choice_BMB_model)
-      CASE ('inverted')
-        ! No need to do anything
-      CASE DEFAULT
-        CALL apply_BMB_subgrid_scheme( mesh, ice, BMB)
     END SELECT
 
     ! Finalise routine path
@@ -668,7 +664,7 @@ CONTAINS
 
     ! Note: apply extrapolation_FCMP_to_PMP to non-laddie BMB models before applying sub-grid schemes
 
-    BMB%BMB = 0._dp
+    ! BMB%BMB = 0._dp
 
     DO vi = mesh%vi1, mesh%vi2
       ! Different sub-grid schemes for sub-shelf melt

--- a/src/basal_mass_balance/BMB_parameterised.f90
+++ b/src/basal_mass_balance/BMB_parameterised.f90
@@ -74,7 +74,7 @@ CONTAINS
     CALL init_routine( routine_name)
 
     ! Initialise
-    BMB%BMB = 0._dp
+    BMB%BMB_shelf = 0._dp
 
     DO vi = mesh%vi1, mesh%vi2
 
@@ -83,14 +83,14 @@ CONTAINS
 
       ! Favier et al. (2019), Eq. 4
       ! Altered to allow for negative basal melt (i.e. refreezing) when dT < 0
-      BMB%BMB( vi) =  -1._dp * sec_per_year * C%BMB_Favier2019_gamma * SIGN(dT,1._dp) * (seawater_density * cp_ocean * dT / (ice_density * L_fusion))**2._dp
+      BMB%BMB_shelf( vi) =  -1._dp * sec_per_year * C%BMB_Favier2019_gamma * SIGN(dT,1._dp) * (seawater_density * cp_ocean * dT / (ice_density * L_fusion))**2._dp
 
       ! Apply grounded fractions
       IF (ice%mask_gl_gr( vi) .AND. ice%Hib(vi) < ice%SL(vi)) THEN
         ! Subgrid basal melt rate
-        BMB%BMB( vi) = (1._dp - ice%fraction_gr( vi)) * BMB%BMB( vi)
+        ! BMB%BMB_shelf( vi) = (1._dp - ice%fraction_gr( vi)) * BMB%BMB_shelf( vi)
         ! Limit it to only melt (refreezing is tricky)
-        BMB%BMB( vi) = MAX( BMB%BMB( vi), 0._dp)
+        BMB%BMB_shelf( vi) = MAX( BMB%BMB_shelf( vi), 0._dp)
       END IF
 
     END DO

--- a/src/basal_mass_balance/BMB_prescribed.f90
+++ b/src/basal_mass_balance/BMB_prescribed.f90
@@ -1,0 +1,221 @@
+MODULE BMB_prescribed
+
+  ! Prescribed BMB forcing
+
+! ===== Preamble =====
+! ====================
+
+  USE precisions                                             , ONLY: dp
+  USE mpi_basic                                              , ONLY: par, sync
+  USE control_resources_and_error_messaging                  , ONLY: crash, warning, happy, init_routine, finalise_routine, colour_string
+  USE model_configuration                                    , ONLY: C
+  USE parameters
+  USE mesh_types                                             , ONLY: type_mesh
+  USE ice_model_types                                        , ONLY: type_ice_model
+  USE climate_model_types                                    , ONLY: type_climate_model
+  USE BMB_model_types                                        , ONLY: type_BMB_model
+  USE netcdf_input                                           , ONLY: read_field_from_file_2D
+
+  IMPLICIT NONE
+
+CONTAINS
+
+! ===== Main routines =====
+! =========================
+
+  SUBROUTINE run_BMB_model_prescribed( mesh, ice, BMB, region_name, time)
+    ! Calculate the basal mass balance
+    !
+    ! Prescribed BMB forcing
+
+    IMPLICIT NONE
+
+    ! In/output variables:
+    TYPE(type_mesh),                        INTENT(IN)    :: mesh
+    TYPE(type_ice_model),                   INTENT(IN)    :: ice
+    TYPE(type_BMB_model),                   INTENT(INOUT) :: BMB
+    CHARACTER(LEN=3),                       INTENT(IN)    :: region_name
+    REAL(dp),                               INTENT(IN)    :: time
+
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                         :: routine_name = 'run_BMB_model_prescribed'
+    REAL(dp)                                              :: dummy_dp
+    CHARACTER                                             :: dummy_char
+    CHARACTER(LEN=256)                                    :: choice_BMB_prescribed
+
+    ! Add routine to path
+    CALL init_routine( routine_name)
+
+    ! To prevent compiler warnings
+    dummy_dp   = mesh%xmin
+    dummy_dp   = ice%Hi( mesh%vi1)
+    dummy_dp   = BMB%BMB_shelf( mesh%vi1)
+    dummy_char = region_name( 1:1)
+    dummy_dp   = time
+
+    ! Determine the type of prescribed BMB forcing for this region
+    SELECT CASE (region_name)
+      CASE ('NAM')
+        choice_BMB_prescribed  = C%choice_BMB_prescribed_NAM
+      CASE ('EAS')
+        choice_BMB_prescribed  = C%choice_BMB_prescribed_EAS
+      CASE ('GRL')
+        choice_BMB_prescribed  = C%choice_BMB_prescribed_GRL
+      CASE ('ANT')
+        choice_BMB_prescribed  = C%choice_BMB_prescribed_ANT
+      CASE DEFAULT
+        CALL crash('unknown region_name "' // TRIM( region_name) // '"!')
+    END SELECT
+
+    ! Run the chosen type of prescribed BMB forcing
+    SELECT CASE (choice_BMB_prescribed)
+      CASE ('BMB_no_time')
+        ! BMB only, no time
+        CALL run_BMB_model_prescribed_notime( mesh, BMB)
+      CASE DEFAULT
+        CALL crash('unknown choice_BMB_prescribed "' // TRIM( choice_BMB_prescribed) // '"!')
+    END SELECT
+
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+
+  END SUBROUTINE run_BMB_model_prescribed
+
+  SUBROUTINE initialise_BMB_model_prescribed( mesh, BMB, region_name)
+    ! Initialise the BMB model
+    !
+    ! Prescribed BMB forcing
+
+    IMPLICIT NONE
+
+    ! In- and output variables
+    TYPE(type_mesh),                        INTENT(IN)    :: mesh
+    TYPE(type_BMB_model),                   INTENT(INOUT) :: BMB
+    CHARACTER(LEN=3),                       INTENT(IN)    :: region_name
+
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                         :: routine_name = 'initialise_BMB_model_prescribed'
+    CHARACTER(LEN=256)                                    :: choice_BMB_prescribed
+
+    ! Add routine to path
+    CALL init_routine( routine_name)
+
+    ! Determine the type of prescribed BMB forcing for this region
+    SELECT CASE (region_name)
+      CASE ('NAM')
+        choice_BMB_prescribed  = C%choice_BMB_prescribed_NAM
+      CASE ('EAS')
+        choice_BMB_prescribed  = C%choice_BMB_prescribed_EAS
+      CASE ('GRL')
+        choice_BMB_prescribed  = C%choice_BMB_prescribed_GRL
+      CASE ('ANT')
+        choice_BMB_prescribed  = C%choice_BMB_prescribed_ANT
+      CASE DEFAULT
+        CALL crash('unknown region_name "' // TRIM( region_name) // '"!')
+    END SELECT
+
+    ! Initialised the chosen type of prescribed BMB forcing
+    SELECT CASE (choice_BMB_prescribed)
+      CASE ('BMB_no_time')
+        CALL initialise_BMB_model_prescribed_notime( mesh, BMB, region_name)
+      CASE DEFAULT
+        CALL crash('unknown choice_BMB_prescribed "' // TRIM( choice_BMB_prescribed) // '"!')
+    END SELECT
+
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+
+  END SUBROUTINE initialise_BMB_model_prescribed
+
+  ! == BMB only, no time
+  ! ====================
+
+  SUBROUTINE run_BMB_model_prescribed_notime( mesh, BMB)
+    ! Calculate the basal mass balance
+    !
+    ! Prescribed BMB forcing
+    !
+    ! BMB only, no time
+
+    IMPLICIT NONE
+
+    ! In/output variables:
+    TYPE(type_mesh),                        INTENT(IN)    :: mesh
+    TYPE(type_BMB_model),                   INTENT(INOUT) :: BMB
+
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                         :: routine_name = 'run_BMB_model_prescribed_notime'
+    REAL(dp)                                              :: dummy_dp
+
+    ! Add routine to path
+    CALL init_routine( routine_name)
+
+    ! To prevent compiler warnings
+    dummy_dp = mesh%xmin
+    dummy_dp = BMB%BMB_shelf( mesh%vi1)
+
+    ! No need to do anything, as the BMB was already read during initialisation
+
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+
+  END SUBROUTINE run_BMB_model_prescribed_notime
+
+  SUBROUTINE initialise_BMB_model_prescribed_notime( mesh, BMB, region_name)
+    ! Initialise the BMB model
+    !
+    ! Prescribe BMB from a file without a time dimension
+    !
+    ! BMB only, no time
+
+    IMPLICIT NONE
+
+    ! In- and output variables
+    TYPE(type_mesh),                        INTENT(IN)    :: mesh
+    TYPE(type_BMB_model),                   INTENT(INOUT) :: BMB
+    CHARACTER(LEN=3),                       INTENT(IN)    :: region_name
+
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                         :: routine_name = 'initialise_BMB_model_prescribed_notime'
+    CHARACTER(LEN=256)                                    :: filename_BMB_prescribed
+    REAL(dp)                                              :: timeframe_BMB_prescribed
+
+    ! Add routine to path
+    CALL init_routine( routine_name)
+
+    ! Determine filename for this model region
+    SELECT CASE (region_name)
+      CASE ('NAM')
+        filename_BMB_prescribed  = C%filename_BMB_prescribed_NAM
+        timeframe_BMB_prescribed = C%timeframe_BMB_prescribed_NAM
+      CASE ('EAS')
+        filename_BMB_prescribed  = C%filename_BMB_prescribed_EAS
+        timeframe_BMB_prescribed = C%timeframe_BMB_prescribed_EAS
+      CASE ('GRL')
+        filename_BMB_prescribed  = C%filename_BMB_prescribed_GRL
+        timeframe_BMB_prescribed = C%timeframe_BMB_prescribed_GRL
+      CASE ('ANT')
+        filename_BMB_prescribed  = C%filename_BMB_prescribed_ANT
+        timeframe_BMB_prescribed = C%timeframe_BMB_prescribed_ANT
+      CASE DEFAULT
+        CALL crash('unknown region_name "' // TRIM( region_name) // '"!')
+    END SELECT
+
+    ! Print to terminal
+    IF (par%master)  WRITE(*,"(A)") '   Initialising BMB from file "' // colour_string( TRIM( filename_BMB_prescribed),'light blue') // '"...'
+
+    ! Read BMB from file
+    IF (timeframe_BMB_prescribed == 1E9_dp) THEN
+      ! Assume the file has no time dimension
+    CALL read_field_from_file_2D( filename_BMB_prescribed, 'BMB||basal_mass_balance||', mesh, BMB%BMB_shelf)
+    ELSE
+      ! Assume the file has a time dimension, and read the specified timeframe
+      CALL read_field_from_file_2D( filename_BMB_prescribed, 'BMB||basal_mass_balance||', mesh, BMB%BMB_shelf, time_to_read = timeframe_BMB_prescribed)
+    END IF
+
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+
+  END SUBROUTINE initialise_BMB_model_prescribed_notime
+
+END MODULE BMB_prescribed

--- a/src/basal_mass_balance/BMB_prescribed.f90
+++ b/src/basal_mass_balance/BMB_prescribed.f90
@@ -2,6 +2,13 @@ MODULE BMB_prescribed
 
   ! Prescribed BMB forcing
 
+  ! Prescribed BMB forcing. Read in a fixed 2D field of BMB values. At each time step, the applied BMB is determined by the chosen
+  ! subgrid melt scheme. So in case of FCMP, for example, BMB_gr will be zero throughout the run.
+  !
+  ! If the BMB model = 'prescribed_fixed', the subgrid melt schem is only applied during initialisation. Hence, the integrated
+  ! metric BMB_total will be constant throughout the run, regardless of GL migration or calving. GL advance will lead to nonzero
+  ! BMB_gr, which may be useful to maintain the GL position. 
+
 ! ===== Preamble =====
 ! ====================
 
@@ -25,8 +32,6 @@ CONTAINS
 
   SUBROUTINE run_BMB_model_prescribed( mesh, ice, BMB, region_name, time)
     ! Calculate the basal mass balance
-    !
-    ! Prescribed BMB forcing
 
     IMPLICIT NONE
 
@@ -207,7 +212,7 @@ CONTAINS
     ! Read BMB from file
     IF (timeframe_BMB_prescribed == 1E9_dp) THEN
       ! Assume the file has no time dimension
-    CALL read_field_from_file_2D( filename_BMB_prescribed, 'BMB||basal_mass_balance||', mesh, BMB%BMB_shelf)
+      CALL read_field_from_file_2D( filename_BMB_prescribed, 'BMB||basal_mass_balance||', mesh, BMB%BMB_shelf)
     ELSE
       ! Assume the file has a time dimension, and read the specified timeframe
       CALL read_field_from_file_2D( filename_BMB_prescribed, 'BMB||basal_mass_balance||', mesh, BMB%BMB_shelf, time_to_read = timeframe_BMB_prescribed)

--- a/src/basic/model_configuration.f90
+++ b/src/basic/model_configuration.f90
@@ -491,20 +491,20 @@ MODULE model_configuration
     REAL(dp)            :: Martin2011_hydro_Hb_max_config               = 1000._dp                         ! Martin et al. (2011) basal hydrology model: high-end Hb  value of bedrock-dependent pore-water pressure
             
     ! Initialisation of the pore water fraction
-    CHARACTER(LEN=256)  :: pore_water_choice_initialise_NAM_config      = 'zero'                           ! How to initialise the pore water fraction: 'zero', 'read_from_file'
-    CHARACTER(LEN=256)  :: pore_water_choice_initialise_EAS_config      = 'zero'
-    CHARACTER(LEN=256)  :: pore_water_choice_initialise_GRL_config      = 'zero'
-    CHARACTER(LEN=256)  :: pore_water_choice_initialise_ANT_config      = 'zero'
+    CHARACTER(LEN=256)  :: pore_water_fraction_choice_initialise_NAM_config = 'zero'                       ! How to initialise the pore water fraction: 'zero', 'read_from_file'
+    CHARACTER(LEN=256)  :: pore_water_fraction_choice_initialise_EAS_config = 'zero'
+    CHARACTER(LEN=256)  :: pore_water_fraction_choice_initialise_GRL_config = 'zero'
+    CHARACTER(LEN=256)  :: pore_water_fraction_choice_initialise_ANT_config = 'zero'
     ! Paths to files containing pore water fraction fields
-    CHARACTER(LEN=256)  :: filename_pore_water_NAM_config               = ''
-    CHARACTER(LEN=256)  :: filename_pore_water_EAS_config               = ''
-    CHARACTER(LEN=256)  :: filename_pore_water_GRL_config               = ''
-    CHARACTER(LEN=256)  :: filename_pore_water_ANT_config               = ''
-    ! Timeframes to read from the pore water file (set to 1E9    if the file has no time dimension)
-    REAL(dp)            :: timeframe_pore_water_NAM_config              = 1E9_dp                           ! Can be different from C%start_time_of_run, be careful though!
-    REAL(dp)            :: timeframe_pore_water_EAS_config              = 1E9_dp
-    REAL(dp)            :: timeframe_pore_water_GRL_config              = 1E9_dp
-    REAL(dp)            :: timeframe_pore_water_ANT_config              = 1E9_dp
+    CHARACTER(LEN=256)  :: filename_pore_water_fraction_NAM_config      = ''
+    CHARACTER(LEN=256)  :: filename_pore_water_fraction_EAS_config      = ''
+    CHARACTER(LEN=256)  :: filename_pore_water_fraction_GRL_config      = ''
+    CHARACTER(LEN=256)  :: filename_pore_water_fraction_ANT_config      = ''
+    ! Timeframes to read from the pore water fraction file (set to 1E9    if the file has no time dimension)
+    REAL(dp)            :: timeframe_pore_water_fraction_NAM_config     = 1E9_dp                           ! Can be different from C%start_time_of_run, be careful though!
+    REAL(dp)            :: timeframe_pore_water_fraction_EAS_config     = 1E9_dp
+    REAL(dp)            :: timeframe_pore_water_fraction_GRL_config     = 1E9_dp
+    REAL(dp)            :: timeframe_pore_water_fraction_ANT_config     = 1E9_dp
 
   ! == Basal hydrology inversion by nudging
   ! =======================================
@@ -1397,20 +1397,20 @@ MODULE model_configuration
     REAL(dp)            :: Martin2011_hydro_Hb_max
 
     ! Initialisation of the pore water fraction
-    CHARACTER(LEN=256)  :: pore_water_choice_initialise_NAM
-    CHARACTER(LEN=256)  :: pore_water_choice_initialise_EAS
-    CHARACTER(LEN=256)  :: pore_water_choice_initialise_GRL
-    CHARACTER(LEN=256)  :: pore_water_choice_initialise_ANT
+    CHARACTER(LEN=256)  :: pore_water_fraction_choice_initialise_NAM
+    CHARACTER(LEN=256)  :: pore_water_fraction_choice_initialise_EAS
+    CHARACTER(LEN=256)  :: pore_water_fraction_choice_initialise_GRL
+    CHARACTER(LEN=256)  :: pore_water_fraction_choice_initialise_ANT
     ! Paths to files containing pore water fraction fields
-    CHARACTER(LEN=256)  :: filename_pore_water_NAM
-    CHARACTER(LEN=256)  :: filename_pore_water_EAS
-    CHARACTER(LEN=256)  :: filename_pore_water_GRL
-    CHARACTER(LEN=256)  :: filename_pore_water_ANT
-    ! Timeframes to read from the pore water file (set to 1E9    if the file has no time dimension)
-    REAL(dp)            :: timeframe_pore_water_NAM
-    REAL(dp)            :: timeframe_pore_water_EAS
-    REAL(dp)            :: timeframe_pore_water_GRL
-    REAL(dp)            :: timeframe_pore_water_ANT
+    CHARACTER(LEN=256)  :: filename_pore_water_fraction_NAM
+    CHARACTER(LEN=256)  :: filename_pore_water_fraction_EAS
+    CHARACTER(LEN=256)  :: filename_pore_water_fraction_GRL
+    CHARACTER(LEN=256)  :: filename_pore_water_fraction_ANT
+    ! Timeframes to read from the pore water fraction file (set to 1E9    if the file has no time dimension)
+    REAL(dp)            :: timeframe_pore_water_fraction_NAM
+    REAL(dp)            :: timeframe_pore_water_fraction_EAS
+    REAL(dp)            :: timeframe_pore_water_fraction_GRL
+    REAL(dp)            :: timeframe_pore_water_fraction_ANT
 
   ! == Pore water inversion by nudging
   ! =====================================
@@ -2301,18 +2301,18 @@ CONTAINS
       choice_basal_hydrology_model_config                         , &
       Martin2011_hydro_Hb_min_config                              , &
       Martin2011_hydro_Hb_max_config                              , &
-      pore_water_choice_initialise_NAM_config                     , &
-      pore_water_choice_initialise_EAS_config                     , &
-      pore_water_choice_initialise_GRL_config                     , &
-      pore_water_choice_initialise_ANT_config                     , &
-      filename_pore_water_NAM_config                              , &
-      filename_pore_water_EAS_config                              , &
-      filename_pore_water_GRL_config                              , &
-      filename_pore_water_ANT_config                              , &
-      timeframe_pore_water_NAM_config                             , &
-      timeframe_pore_water_EAS_config                             , &
-      timeframe_pore_water_GRL_config                             , &
-      timeframe_pore_water_ANT_config                             , &
+      pore_water_fraction_choice_initialise_NAM_config            , &
+      pore_water_fraction_choice_initialise_EAS_config            , &
+      pore_water_fraction_choice_initialise_GRL_config            , &
+      pore_water_fraction_choice_initialise_ANT_config            , &
+      filename_pore_water_fraction_NAM_config                     , &
+      filename_pore_water_fraction_EAS_config                     , &
+      filename_pore_water_fraction_GRL_config                     , &
+      filename_pore_water_fraction_ANT_config                     , &
+      timeframe_pore_water_fraction_NAM_config                    , &
+      timeframe_pore_water_fraction_EAS_config                    , &
+      timeframe_pore_water_fraction_GRL_config                    , &
+      timeframe_pore_water_fraction_ANT_config                    , &
       do_pore_water_nudging_config                                , &
       choice_pore_water_nudging_method_config                     , &
       pore_water_nudging_dt_config                                , &
@@ -3087,20 +3087,20 @@ CONTAINS
     C%Martin2011_hydro_Hb_max                                = Martin2011_hydro_Hb_max_config
     
     ! Initialisation of the pore water fraction
-    C%pore_water_choice_initialise_NAM                       = pore_water_choice_initialise_NAM_config
-    C%pore_water_choice_initialise_EAS                       = pore_water_choice_initialise_EAS_config
-    C%pore_water_choice_initialise_GRL                       = pore_water_choice_initialise_GRL_config
-    C%pore_water_choice_initialise_ANT                       = pore_water_choice_initialise_ANT_config
+    C%pore_water_fraction_choice_initialise_NAM              = pore_water_fraction_choice_initialise_NAM_config
+    C%pore_water_fraction_choice_initialise_EAS              = pore_water_fraction_choice_initialise_EAS_config
+    C%pore_water_fraction_choice_initialise_GRL              = pore_water_fraction_choice_initialise_GRL_config
+    C%pore_water_fraction_choice_initialise_ANT              = pore_water_fraction_choice_initialise_ANT_config
     ! Paths to files containing pore water fraction fields
-    C%filename_pore_water_NAM                                = filename_pore_water_NAM_config
-    C%filename_pore_water_EAS                                = filename_pore_water_EAS_config
-    C%filename_pore_water_GRL                                = filename_pore_water_GRL_config
-    C%filename_pore_water_ANT                                = filename_pore_water_ANT_config
+    C%filename_pore_water_fraction_NAM                       = filename_pore_water_fraction_NAM_config
+    C%filename_pore_water_fraction_EAS                       = filename_pore_water_fraction_EAS_config
+    C%filename_pore_water_fraction_GRL                       = filename_pore_water_fraction_GRL_config
+    C%filename_pore_water_fraction_ANT                       = filename_pore_water_fraction_ANT_config
     ! Timeframes to read from the pore water file (set to 1E9    if the file has no time dimension
-    C%timeframe_pore_water_NAM                               = timeframe_pore_water_NAM_config
-    C%timeframe_pore_water_EAS                               = timeframe_pore_water_EAS_config
-    C%timeframe_pore_water_GRL                               = timeframe_pore_water_GRL_config
-    C%timeframe_pore_water_ANT                               = timeframe_pore_water_ANT_config
+    C%timeframe_pore_water_fraction_NAM                      = timeframe_pore_water_fraction_NAM_config
+    C%timeframe_pore_water_fraction_EAS                      = timeframe_pore_water_fraction_EAS_config
+    C%timeframe_pore_water_fraction_GRL                      = timeframe_pore_water_fraction_GRL_config
+    C%timeframe_pore_water_fraction_ANT                      = timeframe_pore_water_fraction_ANT_config
 
   ! == Pore water inversion by nudging
   ! ==================================

--- a/src/basic/model_configuration.f90
+++ b/src/basic/model_configuration.f90
@@ -738,6 +738,7 @@ MODULE model_configuration
 
     ! Grounding line treatment
     LOGICAL             :: do_subgrid_BMB_at_grounding_line_config      = .FALSE.                          ! Whether or not to apply basal melt rates under a partially floating grounding line
+    CHARACTER(LEN=256)  :: choice_BMB_subgrid_config                    = ''                               ! Choice of sub-grid BMB scheme: "FCMP", "PMP", "NMP" (following Leguy et al., 2021)
 
     ! Choice of BMB model
     CHARACTER(LEN=256)  :: choice_BMB_model_NAM_config                  = 'uniform'
@@ -1612,6 +1613,7 @@ MODULE model_configuration
 
     ! Grounding line treatment
     LOGICAL             :: do_subgrid_BMB_at_grounding_line
+    CHARACTER(LEN=256)  :: choice_BMB_subgrid
 
     ! Choice of BMB model
     CHARACTER(LEN=256)  :: choice_BMB_model_NAM
@@ -2379,6 +2381,7 @@ CONTAINS
       BMB_inversion_t_start_config                                , &
       BMB_inversion_t_end_config                                  , &
       do_subgrid_BMB_at_grounding_line_config                     , &
+      choice_BMB_subgrid_config                                   , &
       choice_BMB_model_NAM_config                                 , &
       choice_BMB_model_EAS_config                                 , &
       choice_BMB_model_GRL_config                                 , &
@@ -3238,6 +3241,7 @@ CONTAINS
 
     ! Grounding line treatment
     C%do_subgrid_BMB_at_grounding_line                       = do_subgrid_BMB_at_grounding_line_config
+    C%choice_BMB_subgrid                                     = choice_BMB_subgrid_config
 
     ! Choice of BMB model
     C%choice_BMB_model_NAM                                   = choice_BMB_model_NAM_config

--- a/src/basic/model_configuration.f90
+++ b/src/basic/model_configuration.f90
@@ -489,12 +489,18 @@ MODULE model_configuration
     CHARACTER(LEN=256)  :: choice_basal_hydrology_model_config          = 'Martin2011'                     ! Choice of basal hydrology model: "none", "Martin2011", "inversion", "read_from_file"
     REAL(dp)            :: Martin2011_hydro_Hb_min_config               = 0._dp                            ! Martin et al. (2011) basal hydrology model: low-end  Hb  value of bedrock-dependent pore-water pressure
     REAL(dp)            :: Martin2011_hydro_Hb_max_config               = 1000._dp                         ! Martin et al. (2011) basal hydrology model: high-end Hb  value of bedrock-dependent pore-water pressure
-    
-    ! Pore water fraction from file
+            
+    ! Initialisation of the pore water fraction
+    CHARACTER(LEN=256)  :: pore_water_choice_initialise_NAM_config      = 'zero'                           ! How to initialise the pore water fraction: 'zero', 'read_from_file'
+    CHARACTER(LEN=256)  :: pore_water_choice_initialise_EAS_config      = 'zero'
+    CHARACTER(LEN=256)  :: pore_water_choice_initialise_GRL_config      = 'zero'
+    CHARACTER(LEN=256)  :: pore_water_choice_initialise_ANT_config      = 'zero'
+    ! Paths to files containing pore water fraction fields
     CHARACTER(LEN=256)  :: filename_pore_water_NAM_config               = ''
     CHARACTER(LEN=256)  :: filename_pore_water_EAS_config               = ''
     CHARACTER(LEN=256)  :: filename_pore_water_GRL_config               = ''
     CHARACTER(LEN=256)  :: filename_pore_water_ANT_config               = ''
+    ! Timeframes to read from the pore water file (set to 1E9    if the file has no time dimension)
     REAL(dp)            :: timeframe_pore_water_NAM_config              = 1E9_dp                           ! Can be different from C%start_time_of_run, be careful though!
     REAL(dp)            :: timeframe_pore_water_EAS_config              = 1E9_dp
     REAL(dp)            :: timeframe_pore_water_GRL_config              = 1E9_dp
@@ -1390,11 +1396,17 @@ MODULE model_configuration
     REAL(dp)            :: Martin2011_hydro_Hb_min
     REAL(dp)            :: Martin2011_hydro_Hb_max
 
-    ! Pore water faction from file
+    ! Initialisation of the pore water fraction
+    CHARACTER(LEN=256)  :: pore_water_choice_initialise_NAM
+    CHARACTER(LEN=256)  :: pore_water_choice_initialise_EAS
+    CHARACTER(LEN=256)  :: pore_water_choice_initialise_GRL
+    CHARACTER(LEN=256)  :: pore_water_choice_initialise_ANT
+    ! Paths to files containing pore water fraction fields
     CHARACTER(LEN=256)  :: filename_pore_water_NAM
     CHARACTER(LEN=256)  :: filename_pore_water_EAS
     CHARACTER(LEN=256)  :: filename_pore_water_GRL
     CHARACTER(LEN=256)  :: filename_pore_water_ANT
+    ! Timeframes to read from the pore water file (set to 1E9    if the file has no time dimension)
     REAL(dp)            :: timeframe_pore_water_NAM
     REAL(dp)            :: timeframe_pore_water_EAS
     REAL(dp)            :: timeframe_pore_water_GRL
@@ -2289,6 +2301,10 @@ CONTAINS
       choice_basal_hydrology_model_config                         , &
       Martin2011_hydro_Hb_min_config                              , &
       Martin2011_hydro_Hb_max_config                              , &
+      pore_water_choice_initialise_NAM_config                     , &
+      pore_water_choice_initialise_EAS_config                     , &
+      pore_water_choice_initialise_GRL_config                     , &
+      pore_water_choice_initialise_ANT_config                     , &
       filename_pore_water_NAM_config                              , &
       filename_pore_water_EAS_config                              , &
       filename_pore_water_GRL_config                              , &
@@ -3070,11 +3086,17 @@ CONTAINS
     C%Martin2011_hydro_Hb_min                                = Martin2011_hydro_Hb_min_config
     C%Martin2011_hydro_Hb_max                                = Martin2011_hydro_Hb_max_config
     
-    ! Pore water fraction from file
+    ! Initialisation of the pore water fraction
+    C%pore_water_choice_initialise_NAM                       = pore_water_choice_initialise_NAM_config
+    C%pore_water_choice_initialise_EAS                       = pore_water_choice_initialise_EAS_config
+    C%pore_water_choice_initialise_GRL                       = pore_water_choice_initialise_GRL_config
+    C%pore_water_choice_initialise_ANT                       = pore_water_choice_initialise_ANT_config
+    ! Paths to files containing pore water fraction fields
     C%filename_pore_water_NAM                                = filename_pore_water_NAM_config
     C%filename_pore_water_EAS                                = filename_pore_water_EAS_config
     C%filename_pore_water_GRL                                = filename_pore_water_GRL_config
     C%filename_pore_water_ANT                                = filename_pore_water_ANT_config
+    ! Timeframes to read from the pore water file (set to 1E9    if the file has no time dimension
     C%timeframe_pore_water_NAM                               = timeframe_pore_water_NAM_config
     C%timeframe_pore_water_EAS                               = timeframe_pore_water_EAS_config
     C%timeframe_pore_water_GRL                               = timeframe_pore_water_GRL_config

--- a/src/basic/model_configuration.f90
+++ b/src/basic/model_configuration.f90
@@ -753,8 +753,8 @@ MODULE model_configuration
     REAL(dp)            :: BMB_inversion_t_end_config                   = +9.9E9_dp                        ! [yr] End   time for BMB inversion based on computed thinning rates in marine areas
 
     ! Grounding line treatment
-    LOGICAL             :: do_subgrid_BMB_at_grounding_line_config      = .FALSE.                          ! Whether or not to apply basal melt rates under a partially floating grounding line
-    CHARACTER(LEN=256)  :: choice_BMB_subgrid_config                    = ''                               ! Choice of sub-grid BMB scheme: "FCMP", "PMP", "NMP" (following Leguy et al., 2021)
+    LOGICAL             :: do_subgrid_BMB_at_grounding_line_config      = .FALSE.                          ! Whether or not to apply basal melt rates under a partially floating grounding line; if so, use choice_BMB_subgrid; if not, apply "NMP"
+    CHARACTER(LEN=256)  :: choice_BMB_subgrid_config                    = ''                               ! Choice of sub-grid BMB scheme: "FCMP", "PMP" (following Leguy et al., 2021)
 
     ! Choice of BMB model
     CHARACTER(LEN=256)  :: choice_BMB_model_NAM_config                  = 'uniform'

--- a/src/basic/model_configuration.f90
+++ b/src/basic/model_configuration.f90
@@ -746,6 +746,24 @@ MODULE model_configuration
     CHARACTER(LEN=256)  :: choice_BMB_model_GRL_config                  = 'uniform'
     CHARACTER(LEN=256)  :: choice_BMB_model_ANT_config                  = 'uniform'
 
+    ! Prescribed BMB forcing
+    CHARACTER(LEN=256)  :: choice_BMB_prescribed_NAM_config             = ''
+    CHARACTER(LEN=256)  :: choice_BMB_prescribed_EAS_config             = ''
+    CHARACTER(LEN=256)  :: choice_BMB_prescribed_GRL_config             = ''
+    CHARACTER(LEN=256)  :: choice_BMB_prescribed_ANT_config             = ''
+
+    ! Files containing prescribed BMB forcing
+    CHARACTER(LEN=256)  :: filename_BMB_prescribed_NAM_config           = ''
+    CHARACTER(LEN=256)  :: filename_BMB_prescribed_EAS_config           = ''
+    CHARACTER(LEN=256)  :: filename_BMB_prescribed_GRL_config           = ''
+    CHARACTER(LEN=256)  :: filename_BMB_prescribed_ANT_config           = ''
+
+    ! Timeframes for reading prescribed BMB forcing from file (set to 1E9_dp if the file has no time dimension)
+    REAL(dp)            :: timeframe_BMB_prescribed_NAM_config          = 1E9_dp
+    REAL(dp)            :: timeframe_BMB_prescribed_EAS_config          = 1E9_dp
+    REAL(dp)            :: timeframe_BMB_prescribed_GRL_config          = 1E9_dp
+    REAL(dp)            :: timeframe_BMB_prescribed_ANT_config          = 1E9_dp
+
     ! Choice of idealised BMB model
     CHARACTER(LEN=256)  :: choice_BMB_model_idealised_config            = ''
 
@@ -1621,6 +1639,24 @@ MODULE model_configuration
     CHARACTER(LEN=256)  :: choice_BMB_model_GRL
     CHARACTER(LEN=256)  :: choice_BMB_model_ANT
 
+    ! Prescribed BMB forcing
+    CHARACTER(LEN=256)  :: choice_BMB_prescribed_NAM
+    CHARACTER(LEN=256)  :: choice_BMB_prescribed_EAS
+    CHARACTER(LEN=256)  :: choice_BMB_prescribed_GRL
+    CHARACTER(LEN=256)  :: choice_BMB_prescribed_ANT
+
+    ! Files containing prescribed BMB forcing
+    CHARACTER(LEN=256)  :: filename_BMB_prescribed_NAM
+    CHARACTER(LEN=256)  :: filename_BMB_prescribed_EAS
+    CHARACTER(LEN=256)  :: filename_BMB_prescribed_GRL
+    CHARACTER(LEN=256)  :: filename_BMB_prescribed_ANT
+
+    ! Timeframes for reading prescribed BMB forcing from file (set to 1E9_dp if the file has no time dimension)
+    REAL(dp)            :: timeframe_BMB_prescribed_NAM
+    REAL(dp)            :: timeframe_BMB_prescribed_EAS
+    REAL(dp)            :: timeframe_BMB_prescribed_GRL
+    REAL(dp)            :: timeframe_BMB_prescribed_ANT
+
     ! Choice of idealised BMB model
     CHARACTER(LEN=256)  :: choice_BMB_model_idealised
 
@@ -2386,6 +2422,18 @@ CONTAINS
       choice_BMB_model_EAS_config                                 , &
       choice_BMB_model_GRL_config                                 , &
       choice_BMB_model_ANT_config                                 , &
+      choice_BMB_prescribed_NAM_config                            , &
+      choice_BMB_prescribed_EAS_config                            , &
+      choice_BMB_prescribed_GRL_config                            , &
+      choice_BMB_prescribed_ANT_config                            , &
+      filename_BMB_prescribed_NAM_config                          , &
+      filename_BMB_prescribed_EAS_config                          , &
+      filename_BMB_prescribed_GRL_config                          , &
+      filename_BMB_prescribed_ANT_config                          , &
+      timeframe_BMB_prescribed_NAM_config                         , &
+      timeframe_BMB_prescribed_EAS_config                         , &
+      timeframe_BMB_prescribed_GRL_config                         , &
+      timeframe_BMB_prescribed_ANT_config                         , &
       choice_BMB_model_idealised_config                           , &
       choice_BMB_model_parameterised_config                       , &
       uniform_BMB_config                                          , &
@@ -3248,6 +3296,24 @@ CONTAINS
     C%choice_BMB_model_EAS                                   = choice_BMB_model_EAS_config
     C%choice_BMB_model_GRL                                   = choice_BMB_model_GRL_config
     C%choice_BMB_model_ANT                                   = choice_BMB_model_ANT_config
+
+    ! Prescribed BMB forcing
+    C%choice_BMB_prescribed_NAM                              = choice_BMB_prescribed_NAM_config
+    C%choice_BMB_prescribed_EAS                              = choice_BMB_prescribed_EAS_config
+    C%choice_BMB_prescribed_GRL                              = choice_BMB_prescribed_GRL_config
+    C%choice_BMB_prescribed_ANT                              = choice_BMB_prescribed_ANT_config
+
+    ! Files containing prescribed BMB forcing
+    C%filename_BMB_prescribed_NAM                            = filename_BMB_prescribed_NAM_config
+    C%filename_BMB_prescribed_EAS                            = filename_BMB_prescribed_EAS_config
+    C%filename_BMB_prescribed_GRL                            = filename_BMB_prescribed_GRL_config
+    C%filename_BMB_prescribed_ANT                            = filename_BMB_prescribed_ANT_config
+
+    ! Timeframes for reading prescribed BMB forcing from file (set to 1E9_dp if the file has no time dimension)
+    C%timeframe_BMB_prescribed_NAM                           = timeframe_BMB_prescribed_NAM_config
+    C%timeframe_BMB_prescribed_EAS                           = timeframe_BMB_prescribed_EAS_config
+    C%timeframe_BMB_prescribed_GRL                           = timeframe_BMB_prescribed_GRL_config
+    C%timeframe_BMB_prescribed_ANT                           = timeframe_BMB_prescribed_ANT_config
 
     ! Choice of idealised BMB model
     C%choice_BMB_model_idealised                             = choice_BMB_model_idealised_config

--- a/src/basic/model_configuration.f90
+++ b/src/basic/model_configuration.f90
@@ -486,9 +486,19 @@ MODULE model_configuration
   ! ==================
 
     ! Basal hydrology
-    CHARACTER(LEN=256)  :: choice_basal_hydrology_model_config          = 'Martin2011'                     ! Choice of basal hydrology model: "none", "Martin2011", "inversion"
+    CHARACTER(LEN=256)  :: choice_basal_hydrology_model_config          = 'Martin2011'                     ! Choice of basal hydrology model: "none", "Martin2011", "inversion", "read_from_file"
     REAL(dp)            :: Martin2011_hydro_Hb_min_config               = 0._dp                            ! Martin et al. (2011) basal hydrology model: low-end  Hb  value of bedrock-dependent pore-water pressure
     REAL(dp)            :: Martin2011_hydro_Hb_max_config               = 1000._dp                         ! Martin et al. (2011) basal hydrology model: high-end Hb  value of bedrock-dependent pore-water pressure
+    
+    ! Pore water fraction from file
+    CHARACTER(LEN=256)  :: filename_pore_water_NAM_config               = ''
+    CHARACTER(LEN=256)  :: filename_pore_water_EAS_config               = ''
+    CHARACTER(LEN=256)  :: filename_pore_water_GRL_config               = ''
+    CHARACTER(LEN=256)  :: filename_pore_water_ANT_config               = ''
+    REAL(dp)            :: timeframe_pore_water_NAM_config              = 1E9_dp                           ! Can be different from C%start_time_of_run, be careful though!
+    REAL(dp)            :: timeframe_pore_water_EAS_config              = 1E9_dp
+    REAL(dp)            :: timeframe_pore_water_GRL_config              = 1E9_dp
+    REAL(dp)            :: timeframe_pore_water_ANT_config              = 1E9_dp
 
   ! == Basal hydrology inversion by nudging
   ! =======================================
@@ -1380,6 +1390,16 @@ MODULE model_configuration
     REAL(dp)            :: Martin2011_hydro_Hb_min
     REAL(dp)            :: Martin2011_hydro_Hb_max
 
+    ! Pore water faction from file
+    CHARACTER(LEN=256)  :: filename_pore_water_NAM
+    CHARACTER(LEN=256)  :: filename_pore_water_EAS
+    CHARACTER(LEN=256)  :: filename_pore_water_GRL
+    CHARACTER(LEN=256)  :: filename_pore_water_ANT
+    REAL(dp)            :: timeframe_pore_water_NAM
+    REAL(dp)            :: timeframe_pore_water_EAS
+    REAL(dp)            :: timeframe_pore_water_GRL
+    REAL(dp)            :: timeframe_pore_water_ANT
+
   ! == Pore water inversion by nudging
   ! =====================================
 
@@ -2269,6 +2289,14 @@ CONTAINS
       choice_basal_hydrology_model_config                         , &
       Martin2011_hydro_Hb_min_config                              , &
       Martin2011_hydro_Hb_max_config                              , &
+      filename_pore_water_NAM_config                              , &
+      filename_pore_water_EAS_config                              , &
+      filename_pore_water_GRL_config                              , &
+      filename_pore_water_ANT_config                              , &
+      timeframe_pore_water_NAM_config                             , &
+      timeframe_pore_water_EAS_config                             , &
+      timeframe_pore_water_GRL_config                             , &
+      timeframe_pore_water_ANT_config                             , &
       do_pore_water_nudging_config                                , &
       choice_pore_water_nudging_method_config                     , &
       pore_water_nudging_dt_config                                , &
@@ -3041,6 +3069,16 @@ CONTAINS
     C%choice_basal_hydrology_model                           = choice_basal_hydrology_model_config
     C%Martin2011_hydro_Hb_min                                = Martin2011_hydro_Hb_min_config
     C%Martin2011_hydro_Hb_max                                = Martin2011_hydro_Hb_max_config
+    
+    ! Pore water fraction from file
+    C%filename_pore_water_NAM                                = filename_pore_water_NAM_config
+    C%filename_pore_water_EAS                                = filename_pore_water_EAS_config
+    C%filename_pore_water_GRL                                = filename_pore_water_GRL_config
+    C%filename_pore_water_ANT                                = filename_pore_water_ANT_config
+    C%timeframe_pore_water_NAM                               = timeframe_pore_water_NAM_config
+    C%timeframe_pore_water_EAS                               = timeframe_pore_water_EAS_config
+    C%timeframe_pore_water_GRL                               = timeframe_pore_water_GRL_config
+    C%timeframe_pore_water_ANT                               = timeframe_pore_water_ANT_config
 
   ! == Pore water inversion by nudging
   ! ==================================

--- a/src/ice/ice_model_main.f90
+++ b/src/ice/ice_model_main.f90
@@ -359,7 +359,7 @@ CONTAINS
 
     ! Allocate and initialise basal conditions
     CALL initialise_geothermal_heat_flux(  mesh, ice)
-    CALL initialise_basal_hydrology_model( mesh, ice)
+    CALL initialise_basal_hydrology_model( mesh, ice, region_name)
     CALL initialise_bed_roughness(         mesh, ice, region_name)
 
     ! Velocities
@@ -816,7 +816,7 @@ CONTAINS
 
     ! Allocate and initialise basal conditions
     CALL initialise_geothermal_heat_flux(  mesh_new, ice)
-    CALL initialise_basal_hydrology_model( mesh_new, ice)
+    CALL initialise_basal_hydrology_model( mesh_new, ice, region_name)
 
     ! FIXME: something should happen here once we start working on remapping of inverted bed roughness!
     CALL initialise_bed_roughness(         mesh_new, ice, region_name)

--- a/src/types/BMB_model_types.f90
+++ b/src/types/BMB_model_types.f90
@@ -17,6 +17,7 @@ MODULE BMB_model_types
 
     ! Main data fields
     REAL(dp), DIMENSION(:    ), ALLOCATABLE :: BMB                         ! [m.i.e./yr] Basal mass balance
+    REAL(dp), DIMENSION(:    ), ALLOCATABLE :: BMB_shelf                   ! [m.i.e./yr] Basal mass balance of floating ice, extrapolated below grounded ice
     REAL(dp), DIMENSION(:    ), ALLOCATABLE :: BMB_inv                     ! [m.i.e./yr] Inverted basal mass balance
     REAL(dp), DIMENSION(:    ), ALLOCATABLE :: BMB_ref                     ! [m.i.e./yr] Reference basal mass balance (e.g. inverted or prescribed)
     LOGICAL,  DIMENSION(:    ), ALLOCATABLE :: mask_floating_ice           ! T: floating vertex, F: otherwise


### PR DESCRIPTION
Added a few options:
## BMB
### Subgrid schemes
- NMP (called when do_subgrid_BMB_at_grounding_line_config      = .FALSE.)
- FCMP or PMP (when above = .TRUE.)

### Model options
- 'prescribed' (read from file, apply subgrid scheme at each time step to follow GL migration)
- 'prescribed_fixed' (read from file and ignore GL advance. Apply subgrid scheme only during initialisation, so if GL advances, BMB is applied to the newly grounded ice. May be useful to keep GL in place)

## Basal hydrology
### Pore water options
- 'read_from_file': use to restart. Note: not writing out a restart-file yet, so need to be read from main_xxx.nc

## Notes
I added a bunch of additional config-options, meaning old configuration files will no longer work.. (although somehow the unit tests do work). Not sure how to deal with that.