### PR TITLE
Test tracer tracking slab on slope

### DIFF
--- a/src/basic/math_utilities/math_utilities.f90
+++ b/src/basic/math_utilities/math_utilities.f90
@@ -3545,12 +3545,14 @@ CONTAINS
   end subroutine remap_cons_2nd_order_1D
 
   subroutine interpolate_inside_triangle_dp_2D( pa, pb, pc, fa, fb, fc, p, f, tol_dist)
+
     ! In/output variables
     real(dp), dimension(2), intent(in   ) :: pa, pb, pc
     real(dp),               intent(in   ) :: fa, fb, fc
     real(dp), dimension(2), intent(in   ) :: p
     real(dp),               intent(  out) :: f
     real(dp),               intent(in   ) :: tol_dist
+
     ! Local variables
     real(dp) :: Atri_abp, Atri_bcp, Atri_cap, Atri_tot, wa, wb, wc
 

--- a/src/mesh/mesh_utilities.f90
+++ b/src/mesh/mesh_utilities.f90
@@ -1438,14 +1438,9 @@ CONTAINS
     REAL(dp),                                INTENT(OUT  ) :: d_int
 
     ! Local variables:
-    REAL(dp)               :: d_min
     INTEGER                :: via, vib, vic
     REAL(dp)               :: da, db, dc
     REAL(dp), DIMENSION(2) :: pa, pb, pc
-
-    ! Find the global minimum value of d
-    d_min = MINVAL( d)
-    CALL MPI_ALLREDUCE( MPI_IN_PLACE, d_min, 1, MPI_DOUBLE_PRECISION, MPI_MIN, MPI_COMM_WORLD, ierr)
 
     ! Find the triangle containing p
     CALL find_containing_triangle( mesh, p, ti_in)
@@ -1464,21 +1459,21 @@ CONTAINS
     IF (via >= mesh%vi1 .AND. via <= mesh%vi2) THEN
       da = d( via)
     ELSE
-      da = d_min
+      da = -huge( da)
     END IF
     CALL MPI_ALLREDUCE( MPI_IN_PLACE, da, 1, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_COMM_WORLD, ierr)
 
     IF (vib >= mesh%vi1 .AND. vib <= mesh%vi2) THEN
       db = d( vib)
     ELSE
-      db = d_min
+      db = -huge( db)
     END IF
     CALL MPI_ALLREDUCE( MPI_IN_PLACE, db, 1, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_COMM_WORLD, ierr)
 
     IF (vic >= mesh%vi1 .AND. vic <= mesh%vi2) THEN
       dc = d( vic)
     ELSE
-      dc = d_min
+      dc = -huge( dc)
     END IF
     CALL MPI_ALLREDUCE( MPI_IN_PLACE, dc, 1, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_COMM_WORLD, ierr)
 

--- a/src/tracer_tracking/tracer_tracking_particles.f90
+++ b/src/tracer_tracking/tracer_tracking_particles.f90
@@ -21,7 +21,8 @@ module tracer_tracking_model_particles
   private
 
   public :: initialise_tracer_tracking_model_particles, calc_particle_zeta, &
-    interpolate_3d_velocities_to_3D_point, calc_particles_to_mesh_map
+    interpolate_3d_velocities_to_3D_point, calc_particles_to_mesh_map, add_particle, &
+    move_and_remove_particle
 
   integer, parameter :: n_particles_init  = 100
   integer, parameter :: n_tracers         = 1
@@ -97,7 +98,7 @@ contains
 
     ! Using the interpolated velocities from the last time
     ! this model was run, move the particle to its new position
-    particles%r = particles%r + particles%u * dt
+    particles%r( ip,:) = particles%r( ip,:) + particles%u( ip,:) * dt
 
     ! If the new position is outside the mesh domain, remove the particle
     if ((.not. test_ge_le( particles%r( ip,1), mesh%xmin, mesh%xmax)) .or. &
@@ -118,7 +119,7 @@ contains
       particles%zeta( ip), Hi_interp_ = Hi_interp)
 
     ! If the new position is outside the ice sheet, remove the particle
-    if (particles%zeta( ip) < 0._dp .or. particles%zeta( ip) > 0._dp .or. Hi_interp < 0.1_dp) then
+    if (particles%zeta( ip) < 0._dp .or. particles%zeta( ip) > 1._dp .or. Hi_interp < 0.1_dp) then
       call remove_particle( particles, ip)
       call finalise_routine( routine_name)
       return
@@ -296,7 +297,7 @@ contains
     real(dp), dimension(2) :: p
     real(dp)               :: Hi_interp, Hs_interp
 
-    ! Interpolate Hib,Hs horizontally to [x,y]
+    ! Interpolate Hi, Hs horizontally to [x,y]
     p = [x,y]
     call interpolate_to_point_dp_2D( mesh, Hi, p, ti_in, Hi_interp)
     call interpolate_to_point_dp_2D( mesh, Hs, p, ti_in, Hs_interp)

--- a/src/validation/unit_tests/ut_tracer_tracking.f90
+++ b/src/validation/unit_tests/ut_tracer_tracking.f90
@@ -511,7 +511,7 @@ contains
 
     end do
 
-    call unit_test( verified, test_name)
+    call unit_test( verified, trim( test_name) // '/position')
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)
@@ -644,7 +644,7 @@ contains
 
     end do
 
-    call unit_test( max_diff < 5e3_dp, test_name)
+    call unit_test( max_diff < 5e3_dp, trim( test_name) // '/position')
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)

--- a/src/validation/unit_tests/ut_tracer_tracking.f90
+++ b/src/validation/unit_tests/ut_tracer_tracking.f90
@@ -77,6 +77,7 @@ contains
     call test_interpolate_3d_velocities_to_3D_point( test_name, mesh)
     call test_calc_particles_to_mesh_map           ( test_name, mesh)
     call test_particle_movement_slab_on_a_slope    ( test_name, mesh)
+    call test_particle_movement_vortex             ( test_name, mesh)
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)
@@ -440,11 +441,12 @@ contains
     ! Ice flows parallel to the surface, with the speed increasing from
     ! zero at the base to u_abs at the surface.
 
+    ice%v_3D_b = 0._dp
     u_surf = uabs * cos( theta * pi / 180._dp)
     w_surf = uabs * sin( theta * pi / 180._dp)
     do k = 1, mesh%nz
-      ice%u_3D_b( :,k) = u_surf * mesh%zeta( k)
-      ice%w_3D  ( :,k) = w_surf * mesh%zeta( k)
+      ice%u_3D_b( :,k) = u_surf * (1._dp - mesh%zeta( k))
+      ice%w_3D  ( :,k) = w_surf * (1._dp - mesh%zeta( k))
     end do
 
     call initialise_tracer_tracking_model_particles( mesh, ice, particles)
@@ -498,9 +500,9 @@ contains
         call move_and_remove_particle( mesh, ice, particles, ip, dt)
 
         r_expected = [ &
-          particles%r_origin( ip,1) + u_surf * zeta_orig( ip) * time, &
+          particles%r_origin( ip,1) + u_surf * (1._dp - zeta_orig( ip)) * time, &
           particles%r_origin( ip,2), &
-          particles%r_origin( ip,3) + w_surf * zeta_orig( ip) * time]
+          particles%r_origin( ip,3) + w_surf * (1._dp - zeta_orig( ip)) * time]
 
         ! Check that the particle has not strayed too far from the analytical solution
         verified = verified .and. norm2( particles%r( ip,:) - r_expected) < 1e-5_dp
@@ -515,6 +517,139 @@ contains
     call finalise_routine( routine_name)
 
   end subroutine test_particle_movement_slab_on_a_slope
+
+  subroutine test_particle_movement_vortex( test_name_parent, mesh)
+
+    ! In/output variables:
+    character(len=*), intent(in) :: test_name_parent
+    type(type_mesh),  intent(in) :: mesh
+
+    ! Local variables:
+    character(len=1024), parameter             :: routine_name = 'test_particle_movement_vortex'
+    character(len=1024), parameter             :: test_name_local = 'particle_movement_vortex'
+    character(len=1024)                        :: test_name
+    type(type_ice_model)                       :: ice
+    integer                                    :: ti,k,i,j,ip
+    real(dp), parameter                        :: Hi = 1000._dp
+    real(dp), parameter                        :: time_rev_surf = 1000._dp
+    type(type_tracer_tracking_model_particles) :: particles
+    integer                                    :: n_particles_x, n_particles_y, n_particles_z, n_particles
+    real(dp), dimension(:), allocatable        :: zeta_orig
+    real(dp)                                   :: xmin, xmax, ymin, ymax, zetamin, zetamax, x, y, zeta
+    real(dp)                                   :: Hs, z
+    real(dp), parameter                        :: tstart = 0._dp
+    real(dp), parameter                        :: tstop  = 100._dp
+    real(dp), parameter                        :: dt     = 1._dp
+    real(dp)                                   :: time
+    real(dp)                                   :: r_orig, theta_orig, theta_expected
+    real(dp), dimension(3)                     :: r_expected
+    real(dp)                                   :: diff, max_diff
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Add test name to list
+    test_name = trim( test_name_parent) // '/' // trim( test_name_local)
+
+    ! Set up a simple ice slab
+    call allocate_ice_model( mesh, ice)
+
+    ice%Hi = Hi
+    ice%Hb = 0._dp
+    ice%Hs = ice%Hb + ice%Hi
+    ice%SL = -1000._dp
+
+    ! Set up a simple velocity field
+
+    ! Horizontal vortex, counter-clockwise around the origin.
+    ! Takes 1,000 years for a revolution at the surface,
+    ! infinity years at the base (rotation speed decreases
+    ! linearly with depth)
+
+    ice%w_3D = 0._dp
+    do ti = mesh%ti1, mesh%ti2
+    do k = 1, mesh%nz
+      x = mesh%Tricc( ti,1)
+      y = mesh%Tricc( ti,2)
+      ice%u_3D_b( ti,k) = -y * 2_dp * pi / time_rev_surf * (1._dp - mesh%zeta( k))
+      ice%v_3D_b( ti,k) =  x * 2_dp * pi / time_rev_surf * (1._dp - mesh%zeta( k))
+    end do
+    end do
+
+    call initialise_tracer_tracking_model_particles( mesh, ice, particles)
+
+    xmin    = mesh%xmin * 0.45_dp
+    xmax    = mesh%xmax * 0.45_dp
+    ymin    = mesh%ymin * 0.45_dp
+    ymax    = mesh%ymax * 0.45_dp
+    zetamin = 0.05_dp
+    zetamax = 0.95_dp
+
+    n_particles_x = 10
+    n_particles_y = 10
+    n_particles_z = 10
+    n_particles = n_particles_x * n_particles_y * n_particles_z
+
+    allocate( zeta_orig( n_particles))
+
+    ip = 0
+    do i = 1, n_particles_x
+      do j = 1, n_particles_y
+        do k = 1, n_particles_z
+
+          ip = ip + 1
+
+          x    = xmin    + (xmax    - xmin   ) * real(i-1,dp) / real(n_particles_x-1,dp)
+          y    = ymin    + (ymax    - ymin   ) * real(j-1,dp) / real(n_particles_y-1,dp)
+          zeta = zetamin + (zetamax - zetamin) * real(k-1,dp) / real(n_particles_z-1,dp)
+
+          zeta_orig( ip) = zeta
+
+          Hs = Hi
+          z = Hs - zeta * Hi
+
+          call add_particle( mesh, ice, particles, x, y, z, 0._dp)
+
+        end do
+      end do
+    end do
+
+    ! Move particles through time
+    max_diff = 0._dp
+
+    time = tstart
+    do while (time < tstop)
+
+      time = time + dt
+
+      do ip = 1, n_particles
+
+        call move_and_remove_particle( mesh, ice, particles, ip, dt)
+
+        r_orig     = norm2( particles%r_origin( ip,1:2))
+        theta_orig = atan2( particles%r_origin( ip,2), particles%r_origin( ip,1))
+
+        theta_expected = theta_orig + 2._dp * pi * time / time_rev_surf * (1._dp - zeta_orig( ip))
+        if (theta_expected > pi) theta_expected = theta_expected - 2._dp * pi
+
+        r_expected = [ &
+          r_orig * cos( theta_expected), &
+          r_orig * sin( theta_expected), &
+          particles%r_origin( ip,3)]
+
+        diff = norm2( r_expected - particles%r(ip,:))
+        max_diff = max( max_diff, diff)
+
+      end do
+
+    end do
+
+    call unit_test( max_diff < 5e3_dp, test_name)
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine test_particle_movement_vortex
 
   subroutine calc_simple_test_geometry( xmin, xmax, ymin, ymax, x, y, &
     Hi, Hb, Hs, z, zeta, zeta_q, u, v, w)


### PR DESCRIPTION
Add two unit tests (although they're more on the scale of component tests...) for particle movement in the new tracer tracking module. Both involve a very simple ice geometry, with a flow field chosen to have a simple analytical solution for the flowline (straight lines in the first case, circles around the domain centre in the second case). Fixed a few small bugs in the move_particle code, seems to actually work now.