### PR TITLE
Add raw particle NetCDF output

### DIFF
--- a/src/tracer_tracking/tracer_tracking_main.f90
+++ b/src/tracer_tracking/tracer_tracking_main.f90
@@ -41,7 +41,7 @@ contains
     allocate( tracer_tracking%age    ( mesh%nV, C%nz           ))
     allocate( tracer_tracking%tracers( mesh%nV, C%nz, n_tracers))
 
-    call initialise_tracer_tracking_model_particles( mesh, ice, tracer_tracking%particles)
+    ! call initialise_tracer_tracking_model_particles( mesh, ice, tracer_tracking%particles)
 
     ! Finalise routine path
     call finalise_routine( routine_name)

--- a/src/types/tracer_tracking_model_types.f90
+++ b/src/types/tracer_tracking_model_types.f90
@@ -10,35 +10,57 @@ module tracer_tracking_model_types
     type_map_particles_to_mesh
 
   type type_map_particles_to_mesh
-    integer                                 :: n    !
-    integer,  dimension(:,:,:), allocatable :: ip   ! Indices of   the n nearest particles
-    real(dp), dimension(:,:,:), allocatable :: d    ! Distances to the n nearest particles
+    !< Indices and interpolation weights to map tracers from the particles to the model mesh
+
+    integer                                 :: n    !< Number of nearest particles to interpolate between
+    integer,  dimension(:,:,:), allocatable :: ip   !< Indices of   the n nearest particles
+    real(dp), dimension(:,:,:), allocatable :: d    !< Distances to the n nearest particles
+
   end type type_map_particles_to_mesh
 
-  type type_tracer_tracking_model_particles
-    ! The data structure for the particle-based tracer tracking model
+  type type_tracer_tracking_model_particles_netcdf
+    !< NetCDF IDs for the particle-tracing output file
 
-    integer                                    :: n           ! Size of allocated memory
-    logical,       dimension(:  ), allocatable :: is_in_use   ! Whether or not memory slot i is in use
-    integer(int8), dimension(:  ), allocatable :: id          ! Unique ID for each particle
-    integer(int8)                              :: id_max      ! Largest ID used so far (i.e. how many particles have existed in this simulation)
-    real(dp),      dimension(:,:), allocatable :: r           ! Particle coordinates (x,y,z)
-    real(dp),      dimension(:  ), allocatable :: zeta        ! Particle zeta coordinate
-    integer,       dimension(:  ), allocatable :: vi_in       ! Which mesh vertex' Voronoi cell each particle is located in
-    integer,       dimension(:  ), allocatable :: ti_in       ! Which mesh triangle             each particle is located in
-    real(dp),      dimension(:,:), allocatable :: u           ! Particle velocity (u,v,w)
-    real(dp),      dimension(:,:), allocatable :: r_origin    ! Coordinates of particle origin (x,y,z)
-    real(dp),      dimension(:  ), allocatable :: t_origin    ! Time of particle origin (i.e. time of snow deposition)
-    real(dp),      dimension(:,:), allocatable :: tracers     ! Values of different tracers
-    type(type_map_particles_to_mesh)           :: map         ! Map from the particles to the mesh
+    character(len=1024) :: filename
+
+    integer :: id_dim_n
+    integer :: id_dim_three
+    integer :: id_dim_time
+
+    integer :: id_var_time
+    integer :: id_var_id
+    integer :: id_var_r
+    integer :: id_var_t_origin
+
+  end type type_tracer_tracking_model_particles_netcdf
+
+  type type_tracer_tracking_model_particles
+    !< The data structure for the particle-based tracer tracking model
+
+    integer                                    :: n_max       !< Size of allocated memory
+    logical,       dimension(:  ), allocatable :: is_in_use   !< Whether or not memory slot i is in use
+    integer(int8), dimension(:  ), allocatable :: id          !< Unique ID for each particle
+    integer(int8)                              :: id_max      !< Largest ID used so far (i.e. how many particles have existed in this simulation)
+    real(dp),      dimension(:,:), allocatable :: r           !< Particle coordinates (x,y,z)
+    real(dp),      dimension(:  ), allocatable :: zeta        !< Particle zeta coordinate
+    integer,       dimension(:  ), allocatable :: vi_in       !< Which mesh vertex' Voronoi cell each particle is located in
+    integer,       dimension(:  ), allocatable :: ti_in       !< Which mesh triangle             each particle is located in
+    real(dp),      dimension(:,:), allocatable :: u           !< Particle velocity (u,v,w)
+    real(dp),      dimension(:,:), allocatable :: r_origin    !< Coordinates of particle origin (x,y,z)
+    real(dp),      dimension(:  ), allocatable :: t_origin    !< Time of particle origin (i.e. time of snow deposition)
+    real(dp),      dimension(:,:), allocatable :: tracers     !< Values of different tracers
+
+    type(type_map_particles_to_mesh)           :: map         !< Map from the particles to the mesh
+
+    type(type_tracer_tracking_model_particles_netcdf) :: nc   !< NetCDF IDs for the output file
 
   end type type_tracer_tracking_model_particles
 
   type type_tracer_tracking_model
-    ! The main tracer tracking model data structure.
+    !< The main tracer tracking model data structure.
 
-    real(dp), dimension(:,:  ), allocatable :: age           ! Age of ice [nV, zeta]
-    real(dp), dimension(:,:,:), allocatable :: tracers       ! Age of ice [nV, zeta, i_tracer]
+    real(dp), dimension(:,:  ), allocatable :: age           !< Age of ice [nV, zeta]
+    real(dp), dimension(:,:,:), allocatable :: tracers       !< Age of ice [nV, zeta, i_tracer]
 
     type(type_tracer_tracking_model_particles) :: particles
 

--- a/src/validation/unit_tests/ut_tracer_tracking.f90
+++ b/src/validation/unit_tests/ut_tracer_tracking.f90
@@ -300,12 +300,12 @@ contains
     nx = 25
     ny = 25
     nz = 16
-    particles%n = nx * ny * nz
-    allocate( particles%is_in_use( particles%n   ), source = .true.)
-    allocate( particles%r        ( particles%n, 3), source = 0._dp)
-    allocate( particles%zeta     ( particles%n   ), source = 0._dp)
-    allocate( particles%vi_in    ( particles%n   ), source = 1    )
-    allocate( particles%ti_in    ( particles%n   ), source = 1    )
+    particles%n_max = nx * ny * nz
+    allocate( particles%is_in_use( particles%n_max   ), source = .true.)
+    allocate( particles%r        ( particles%n_max, 3), source = 0._dp)
+    allocate( particles%zeta     ( particles%n_max   ), source = 0._dp)
+    allocate( particles%vi_in    ( particles%n_max   ), source = 1    )
+    allocate( particles%ti_in    ( particles%n_max   ), source = 1    )
 
     ip = 0
     do i = 1, nx
@@ -340,8 +340,8 @@ contains
       end do
     end do
 
-    allocate(rs_particles( particles%n, 3))
-    do ip = 1, particles%n
+    allocate(rs_particles( particles%n_max, 3))
+    do ip = 1, particles%n_max
       rs_particles( ip,1) = (particles%r( ip,1) - mesh%xmin) / (mesh%xmax - mesh%xmin)
       rs_particles( ip,2) = (particles%r( ip,2) - mesh%ymin) / (mesh%ymax - mesh%ymin)
       rs_particles( ip,3) = particles%zeta( ip)
@@ -355,7 +355,7 @@ contains
 
     do vi = 1, mesh%nV
       do k = 1, C%nz
-        do ip = 1, particles%n
+        do ip = 1, particles%n_max
           ! Calculate the scaled distance between particle ip and vertex-layer [vi,k]
           dist = norm2( rs_particles( ip,:) - rs_mesh( vi,k,:))
           do ii = 1, map_bruteforce%n
@@ -449,8 +449,6 @@ contains
       ice%w_3D  ( :,k) = w_surf * (1._dp - mesh%zeta( k))
     end do
 
-    call initialise_tracer_tracking_model_particles( mesh, ice, particles)
-
     xmin    = mesh%xmin * 0.95_dp
     xmax    = 0._dp
     ymin    = mesh%ymin * 0.95_dp
@@ -462,6 +460,8 @@ contains
     n_particles_y = 20
     n_particles_z = 20
     n_particles = n_particles_x * n_particles_y * n_particles_z
+
+    call initialise_tracer_tracking_model_particles( mesh, ice, particles, n_particles)
 
     allocate( zeta_orig( n_particles))
 
@@ -576,8 +576,6 @@ contains
     end do
     end do
 
-    call initialise_tracer_tracking_model_particles( mesh, ice, particles)
-
     xmin    = mesh%xmin * 0.45_dp
     xmax    = mesh%xmax * 0.45_dp
     ymin    = mesh%ymin * 0.45_dp
@@ -589,6 +587,8 @@ contains
     n_particles_y = 10
     n_particles_z = 10
     n_particles = n_particles_x * n_particles_y * n_particles_z
+
+    call initialise_tracer_tracking_model_particles( mesh, ice, particles, n_particles)
 
     allocate( zeta_orig( n_particles))
 


### PR DESCRIPTION
Added code for output raw particle data to NetCDF.

Also removed the 'flexible memory' for particles. Instead, a fixed (large) amount of memory is allocated during initialisation, and if the number of particles exceeds that, the model crashes. While this might sometimes cause a bit more user frustration, it makes it infinitely easier for me to create NetCDF output.