### PR TITLE
Output stability info

### DIFF
--- a/src/basic/petsc_basic.f90
+++ b/src/basic/petsc_basic.f90
@@ -23,7 +23,7 @@ MODULE petsc_basic
 CONTAINS
 
 ! == Solve a square CSR matrix equation with PETSc
-  SUBROUTINE solve_matrix_equation_CSR_PETSc( AA, bb, xx, rtol, abstol)
+  SUBROUTINE solve_matrix_equation_CSR_PETSc( AA, bb, xx, rtol, abstol, n_Axb_its)
 
     IMPLICIT NONE
 
@@ -32,6 +32,7 @@ CONTAINS
     REAL(dp), DIMENSION(:    ),          INTENT(IN)    :: bb
     REAL(dp), DIMENSION(:    ),          INTENT(INOUT) :: xx
     REAL(dp),                            INTENT(IN)    :: rtol, abstol
+    integer,                             intent(out)   :: n_Axb_its
 
     ! Local variables
     CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'solve_matrix_equation_CSR_PETSc'
@@ -44,7 +45,7 @@ CONTAINS
     CALL mat_CSR2petsc( AA, A)
 
     ! Solve the PETSC matrix equation
-    CALL solve_matrix_equation_PETSc( A, bb, xx, rtol, abstol)
+    CALL solve_matrix_equation_PETSc( A, bb, xx, rtol, abstol, n_Axb_its)
 
     ! Clean up after yourself
     CALL MatDestroy( A, perr)
@@ -54,7 +55,7 @@ CONTAINS
 
   END SUBROUTINE solve_matrix_equation_CSR_PETSc
 
-  SUBROUTINE solve_matrix_equation_PETSc( A, bb, xx, rtol, abstol)
+  SUBROUTINE solve_matrix_equation_PETSc( A, bb, xx, rtol, abstol, n_Axb_its)
     ! Solve the matrix equation using a Krylov solver from PETSc
 
     IMPLICIT NONE
@@ -64,6 +65,7 @@ CONTAINS
     REAL(dp), DIMENSION(:    ),          INTENT(IN)    :: bb
     REAL(dp), DIMENSION(:    ),          INTENT(INOUT) :: xx
     REAL(dp),                            INTENT(IN)    :: rtol, abstol
+    integer,                             intent(out)   :: n_Axb_its
 
     ! Local variables:
     CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'solve_matrix_equation_PETSc'
@@ -71,7 +73,6 @@ CONTAINS
     TYPE(tVec)                                         :: b
     TYPE(tVec)                                         :: x
     TYPE(tKSP)                                         :: KSP_solver
-    INTEGER                                            :: its
 
     ! Add routine to path
     CALL init_routine( routine_name)
@@ -116,8 +117,7 @@ CONTAINS
     CALL solve_matrix_equation_PETSc_KSPSolve( KSP_solver, b, x)
 
     ! Find out how many iterations it took
-    CALL KSPGetIterationNumber( KSP_solver, its, perr)
-    !IF (par%master) WRITE(0,*) '   PETSc solved Ax=b in ', its, ' iterations'
+    call KSPGetIterationNumber( KSP_solver, n_Axb_its, perr)
 
     ! Get the solution back to the native UFEMISM storage structure
     CALL vec_petsc2double( x, xx)

--- a/src/ice/ice_model_main.f90
+++ b/src/ice/ice_model_main.f90
@@ -378,15 +378,15 @@ CONTAINS
 
     ! Numerical stability info
     ice%n_dt_ice                 = 0
-    ice%min_dt_ice               = 0._dp
+    ice%min_dt_ice               = huge( ice%min_dt_ice
     ice%max_dt_ice               = 0._dp
     ice%mean_dt_ice              = 0._dp
     ice%n_visc_its               = 0
-    ice%min_visc_its             = 0
+    ice%min_visc_its             = huge( ice%min_visc_its)
     ice%max_visc_its             = 0
     ice%mean_visc_its            = 0._dp
     ice%n_Axb_its                = 0
-    ice%min_Axb_its_per_visc_it  = 0
+    ice%min_Axb_its_per_visc_it  = huge( ice%min_Axb_its_per_visc_it)
     ice%max_Axb_its_per_visc_it  = 0
     ice%mean_Axb_its_per_visc_it = 0._dp
 

--- a/src/ice/ice_model_main.f90
+++ b/src/ice/ice_model_main.f90
@@ -376,6 +376,20 @@ CONTAINS
       CALL crash('unknown choice_timestepping "' // TRIM( C%choice_timestepping) // '"!')
     END IF
 
+    ! Numerical stability info
+    ice%n_dt_ice                 = 0
+    ice%min_dt_ice               = 0._dp
+    ice%max_dt_ice               = 0._dp
+    ice%mean_dt_ice              = 0._dp
+    ice%n_visc_its               = 0
+    ice%min_visc_its             = 0
+    ice%max_visc_its             = 0
+    ice%mean_visc_its            = 0._dp
+    ice%n_Axb_its                = 0
+    ice%min_Axb_its_per_visc_it  = 0
+    ice%max_Axb_its_per_visc_it  = 0
+    ice%mean_Axb_its_per_visc_it = 0._dp
+
     ! Finalise routine path
     CALL finalise_routine( routine_name)
 

--- a/src/ice/ice_thickness.f90
+++ b/src/ice/ice_thickness.f90
@@ -302,6 +302,7 @@ CONTAINS
     INTEGER                                                         :: vi, k1, k2, k, vj
     REAL(dp)                                                        :: dt_max
     REAL(dp), DIMENSION(mesh%vi1:mesh%vi2)                          :: dHi_dt_dummy
+    INTEGER                                                         :: n_Axb_its
 
     ! Add routine to path
     CALL init_routine( routine_name)
@@ -353,7 +354,8 @@ CONTAINS
     CALL apply_ice_thickness_BC_matrix( mesh, mask_noice, AA, bb, Hi_tplusdt, BC_prescr_mask, BC_prescr_Hi)
 
     ! Solve for Hi_tplusdt
-    CALL solve_matrix_equation_CSR_PETSc( AA, bb, Hi_tplusdt, C%dHi_PETSc_rtol, C%dHi_PETSc_abstol)
+    CALL solve_matrix_equation_CSR_PETSc( AA, bb, Hi_tplusdt, C%dHi_PETSc_rtol, C%dHi_PETSc_abstol, &
+      n_Axb_its)
 
     ! Store the corresponding dH/dt in the artificial mass balance field
     AMB = (Hi_tplusdt - Hi) / dt
@@ -461,6 +463,7 @@ CONTAINS
     INTEGER                                                         :: vi, k1, k2, k, vj
     REAL(dp)                                                        :: dt_max
     REAL(dp), DIMENSION(mesh%vi1:mesh%vi2)                          :: dHi_dt_dummy
+    INTEGER                                                         :: n_Axb_its
 
     ! Add routine to path
     CALL init_routine( routine_name)
@@ -512,7 +515,8 @@ CONTAINS
     CALL apply_ice_thickness_BC_matrix( mesh, mask_noice, AA, bb, Hi_tplusdt, BC_prescr_mask, BC_prescr_Hi)
 
     ! Solve for Hi_tplusdt
-    CALL solve_matrix_equation_CSR_PETSc( AA, bb, Hi_tplusdt, C%dHi_PETSc_rtol, C%dHi_PETSc_abstol)
+    CALL solve_matrix_equation_CSR_PETSc( AA, bb, Hi_tplusdt, C%dHi_PETSc_rtol, C%dHi_PETSc_abstol, &
+      n_Axb_its)
 
     ! Store the corresponding dH/dt in the artificial mass balance field
     AMB = (Hi_tplusdt - Hi) / dt

--- a/src/main/main_regional_output.f90
+++ b/src/main/main_regional_output.f90
@@ -1366,6 +1366,7 @@ CONTAINS
     CALL write_to_field_multopt_dp_0D( region%output_filename_scalar, ncid, 'margin_land_flux',  region%scalars%margin_land_flux)
     CALL write_to_field_multopt_dp_0D( region%output_filename_scalar, ncid, 'margin_ocean_flux', region%scalars%margin_ocean_flux)
 
+    ! Numerical stability info
     call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'n_dt_ice',         region%ice%n_dt_ice)
     call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'min_dt_ice',       region%ice%min_dt_ice)
     call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'max_dt_ice',       region%ice%max_dt_ice)
@@ -1380,6 +1381,20 @@ CONTAINS
     call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'min_Axb_its_per_visc_it',  region%ice%min_Axb_its_per_visc_it)
     call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'max_Axb_its_per_visc_it',  region%ice%max_Axb_its_per_visc_it)
     call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'mean_Axb_its_per_visc_it', region%ice%mean_Axb_its_per_visc_it)
+
+    ! Reset stability info
+    region%ice%n_dt_ice                 = 0
+    region%ice%min_dt_ice               = huge( ice%min_dt_ice
+    region%ice%max_dt_ice               = 0._dp
+    region%ice%mean_dt_ice              = 0._dp
+    region%ice%n_visc_its               = 0
+    region%ice%min_visc_its             = huge( ice%min_visc_its)
+    region%ice%max_visc_its             = 0
+    region%ice%mean_visc_its            = 0._dp
+    region%ice%n_Axb_its                = 0
+    region%ice%min_Axb_its_per_visc_it  = huge( ice%min_Axb_its_per_visc_it)
+    region%ice%max_Axb_its_per_visc_it  = 0
+    region%ice%mean_Axb_its_per_visc_it = 0._dp
 
     ! Close the file
     CALL close_netcdf_file( ncid)

--- a/src/main/main_regional_output.f90
+++ b/src/main/main_regional_output.f90
@@ -1370,29 +1370,32 @@ CONTAINS
     call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'n_dt_ice',         region%ice%n_dt_ice)
     call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'min_dt_ice',       region%ice%min_dt_ice)
     call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'max_dt_ice',       region%ice%max_dt_ice)
+    region%ice%mean_dt_ice = C%dt_output / real( region%ice%n_dt_ice,dp)
     call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'mean_dt_ice',      region%ice%mean_dt_ice)
 
     call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'n_visc_its',           region%ice%n_visc_its)
-    call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'min_visc_its_per_dt',  region%ice%min_visc_its)
-    call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'max_visc_its_per_dt',  region%ice%max_visc_its)
-    call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'mean_visc_its_per_dt', region%ice%mean_visc_its)
+    call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'min_visc_its_per_dt',  region%ice%min_visc_its_per_dt)
+    call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'max_visc_its_per_dt',  region%ice%max_visc_its_per_dt)
+    region%ice%mean_visc_its_per_dt = real( region%ice%n_visc_its,dp) / real( region%ice%n_dt_ice,dp)
+    call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'mean_visc_its_per_dt', region%ice%mean_visc_its_per_dt)
 
     call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'n_Axb_its',                region%ice%n_Axb_its)
     call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'min_Axb_its_per_visc_it',  region%ice%min_Axb_its_per_visc_it)
     call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'max_Axb_its_per_visc_it',  region%ice%max_Axb_its_per_visc_it)
+    region%ice%mean_visc_its_per_dt = real( region%ice%n_Axb_its,dp) / real( region%ice%n_visc_its,dp)
     call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'mean_Axb_its_per_visc_it', region%ice%mean_Axb_its_per_visc_it)
 
     ! Reset stability info
     region%ice%n_dt_ice                 = 0
-    region%ice%min_dt_ice               = huge( ice%min_dt_ice
+    region%ice%min_dt_ice               = huge( region%ice%min_dt_ice)
     region%ice%max_dt_ice               = 0._dp
     region%ice%mean_dt_ice              = 0._dp
     region%ice%n_visc_its               = 0
-    region%ice%min_visc_its             = huge( ice%min_visc_its)
-    region%ice%max_visc_its             = 0
-    region%ice%mean_visc_its            = 0._dp
+    region%ice%min_visc_its_per_dt      = huge( region%ice%min_visc_its_per_dt)
+    region%ice%max_visc_its_per_dt      = 0
+    region%ice%mean_visc_its_per_dt     = 0._dp
     region%ice%n_Axb_its                = 0
-    region%ice%min_Axb_its_per_visc_it  = huge( ice%min_Axb_its_per_visc_it)
+    region%ice%min_Axb_its_per_visc_it  = huge( region%ice%min_Axb_its_per_visc_it)
     region%ice%max_Axb_its_per_visc_it  = 0
     region%ice%mean_Axb_its_per_visc_it = 0._dp
 

--- a/src/main/main_regional_output.f90
+++ b/src/main/main_regional_output.f90
@@ -35,7 +35,7 @@ MODULE main_regional_output
                                                                      write_to_field_multopt_grid_dp_2D, write_to_field_multopt_grid_dp_2D_notime, &
                                                                      write_to_field_multopt_grid_dp_2D_monthly, write_to_field_multopt_grid_dp_2D_monthly_notime, &
                                                                      write_to_field_multopt_grid_dp_3D, write_to_field_multopt_grid_dp_3D_notime, &
-                                                                     write_to_field_multopt_dp_0D, &
+                                                                     write_to_field_multopt_dp_0D, write_to_field_multopt_int_0D, &
                                                                      write_matrix_operators_to_netcdf_file
   use remapping_main, only: map_from_mesh_to_xy_grid_2D, map_from_mesh_to_xy_grid_3D, map_from_mesh_to_xy_grid_2D_minval
 
@@ -1306,7 +1306,7 @@ CONTAINS
     IMPLICIT NONE
 
     ! In/output variables:
-    TYPE(type_model_region)                            , INTENT(IN)    :: region
+    TYPE(type_model_region)                            , INTENT(INOUT) :: region
 
     ! Local variables:
     CHARACTER(LEN=256), PARAMETER                                      :: routine_name = 'write_to_scalar_regional_output_file'
@@ -1365,6 +1365,21 @@ CONTAINS
     CALL write_to_field_multopt_dp_0D( region%output_filename_scalar, ncid, 'cf_fl_flux',        region%scalars%cf_fl_flux)
     CALL write_to_field_multopt_dp_0D( region%output_filename_scalar, ncid, 'margin_land_flux',  region%scalars%margin_land_flux)
     CALL write_to_field_multopt_dp_0D( region%output_filename_scalar, ncid, 'margin_ocean_flux', region%scalars%margin_ocean_flux)
+
+    call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'n_dt_ice',         region%ice%n_dt_ice)
+    call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'min_dt_ice',       region%ice%min_dt_ice)
+    call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'max_dt_ice',       region%ice%max_dt_ice)
+    call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'mean_dt_ice',      region%ice%mean_dt_ice)
+
+    call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'n_visc_its',           region%ice%n_visc_its)
+    call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'min_visc_its_per_dt',  region%ice%min_visc_its)
+    call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'max_visc_its_per_dt',  region%ice%max_visc_its)
+    call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'mean_visc_its_per_dt', region%ice%mean_visc_its)
+
+    call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'n_Axb_its',                region%ice%n_Axb_its)
+    call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'min_Axb_its_per_visc_it',  region%ice%min_Axb_its_per_visc_it)
+    call write_to_field_multopt_int_0D( region%output_filename_scalar, ncid, 'max_Axb_its_per_visc_it',  region%ice%max_Axb_its_per_visc_it)
+    call write_to_field_multopt_dp_0D ( region%output_filename_scalar, ncid, 'mean_Axb_its_per_visc_it', region%ice%mean_Axb_its_per_visc_it)
 
     ! Close the file
     CALL close_netcdf_file( ncid)
@@ -2788,7 +2803,7 @@ CONTAINS
 
       ! Mean number of iterations in iterative solver for linearised momentum balance per non-linear viscosity iteration
       case ('mean_Axb_its_per_visc_it')
-        call add_field_dp_0D( filename, ncid, 'min_Axb_its_per_visc_it', long_name = 'Mean number of iterations in iterative solver for linearised momentum balance per non-linear viscosity iteration')
+        call add_field_dp_0D( filename, ncid, 'mean_Axb_its_per_visc_it', long_name = 'Mean number of iterations in iterative solver for linearised momentum balance per non-linear viscosity iteration')
 
     ! ===== End of user-defined output fields =====
     ! =============================================

--- a/src/netcdf/netcdf_output.f90
+++ b/src/netcdf/netcdf_output.f90
@@ -1601,6 +1601,58 @@ CONTAINS
   END SUBROUTINE write_to_field_multopt_mesh_dp_3D_b_notime
 
   ! Write a scalar variable
+  SUBROUTINE write_to_field_multopt_int_0D( filename, ncid, field_name_options, d)
+    ! Write a 0-D data field to a NetCDF file variable
+    !
+    ! Write to the last time frame of the variable
+
+    IMPLICIT NONE
+
+    ! In/output variables:
+    CHARACTER(LEN=*),                    INTENT(IN)    :: filename
+    INTEGER,                             INTENT(IN)    :: ncid
+    CHARACTER(LEN=*),                    INTENT(IN)    :: field_name_options
+    integer,                             INTENT(IN)    :: d
+
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'write_to_field_multopt_int_0D'
+    INTEGER                                            :: id_var, id_dim_time, ti
+    CHARACTER(LEN=256)                                 :: var_name
+    INTEGER                                            :: var_type
+    INTEGER                                            :: ndims_of_var
+    INTEGER, DIMENSION( NF90_MAX_VAR_DIMS)             :: dims_of_var
+
+    ! Add routine to path
+    CALL init_routine( routine_name)
+
+    ! Inquire the variable
+    CALL inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
+    IF (id_var == -1) CALL crash('no variables for name options "' // TRIM( field_name_options) // '" were found in file "' // TRIM( filename) // '"!')
+
+    ! Check if the file has a time dimension and variable
+    CALL check_time( filename, ncid)
+
+    ! Inquire variable info
+    CALL inquire_var_info( filename, ncid, id_var, var_type = var_type, ndims_of_var = ndims_of_var, dims_of_var = dims_of_var)
+
+    ! Inquire file time dimension
+    CALL inquire_dim_multopt( filename, ncid, field_name_options_time, id_dim_time)
+
+    ! Check if the variable has time as a dimension
+    IF (ndims_of_var /= 1) CALL crash('variable "' // TRIM( var_name) // '" in file "' // TRIM( filename) // '" has {int_01} dimensions!', int_01 = ndims_of_var)
+    IF (.NOT. ANY( dims_of_var == id_dim_time)) CALL crash('variable "' // TRIM( var_name) // '" in file "' // TRIM( filename) // '" does not have time as a dimension!')
+
+    ! Inquire length of time dimension
+    CALL inquire_dim_multopt( filename, ncid, field_name_options_time, id_dim_time, dim_length = ti)
+
+    ! Write data to the variable
+    CALL write_var_master_int_1D( filename, ncid, id_var, (/ d /), start = (/ ti /), count = (/ 1 /) )
+
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+
+  END SUBROUTINE write_to_field_multopt_int_0D
+
   SUBROUTINE write_to_field_multopt_dp_0D( filename, ncid, field_name_options, d)
     ! Write a 0-D data field to a NetCDF file variable
     !

--- a/src/netcdf/netcdf_output.f90
+++ b/src/netcdf/netcdf_output.f90
@@ -4139,6 +4139,43 @@ CONTAINS
 
   END SUBROUTINE add_field_dp_0D
 
+  SUBROUTINE add_field_int_0D( filename, ncid, var_name, long_name, units)
+    ! Add a 0-D variable to an existing NetCDF file
+
+    IMPLICIT NONE
+
+    ! In/output variables:
+    CHARACTER(LEN=*),                    INTENT(IN)    :: filename
+    INTEGER,                             INTENT(IN)    :: ncid
+    CHARACTER(LEN=*),                    INTENT(IN)    :: var_name
+    CHARACTER(LEN=*),          OPTIONAL, INTENT(IN)    :: long_name
+    CHARACTER(LEN=*),          OPTIONAL, INTENT(IN)    :: units
+
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'add_field_int_0D'
+    INTEGER                                            :: id_dim_time, id_var
+
+    ! Add routine to path
+    CALL init_routine( routine_name)
+
+    ! Inquire dimensions
+    CALL inquire_dim_multopt( filename, ncid, field_name_options_time  , id_dim_time)
+
+    ! Safety
+    IF (id_dim_time == -1) CALL crash('no time dimension could be found in file "' // TRIM( filename) // '"!')
+
+    ! Create variable
+    CALL create_variable( filename, ncid, var_name, NF90_INT, (/ id_dim_time /), id_var)
+
+    ! Add attributes
+    IF (PRESENT( long_name)) CALL add_attribute_char( filename, ncid, id_var, 'long_name', long_name)
+    IF (PRESENT( units    )) CALL add_attribute_char( filename, ncid, id_var, 'units'    , units    )
+
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+
+  END SUBROUTINE add_field_int_0D
+
   ! ===== Generate procedural file names =====
   ! ==========================================
 

--- a/src/types/ice_model_types.f90
+++ b/src/types/ice_model_types.f90
@@ -438,9 +438,9 @@ MODULE ice_model_types
     real(dp)                                :: max_dt_ice                  ! [yr] Largest ice-dynamical time step
     real(dp)                                :: mean_dt_ice                 ! [yr] Mean ice-dynamical time step
     integer                                 :: n_visc_its                  !      Total number of non-linear viscosity iterations
-    integer                                 :: min_visc_its                !      Smallest number of non-linear viscosity iterations in a single ice-dynamical time step
-    integer                                 :: max_visc_its                !      Largest number of non-linear viscosity iterations in a single ice-dynamical time step
-    real(dp)                                :: mean_visc_its               !      Mean number of non-linear viscosity iterations in a single ice-dynamical time step
+    integer                                 :: min_visc_its_per_dt         !      Smallest number of non-linear viscosity iterations in a single ice-dynamical time step
+    integer                                 :: max_visc_its_per_dt         !      Largest number of non-linear viscosity iterations in a single ice-dynamical time step
+    real(dp)                                :: mean_visc_its_per_dt        !      Mean number of non-linear viscosity iterations in a single ice-dynamical time step
     integer                                 :: n_Axb_its                   !      Total number of iterations in iterative solver for linearised momentum balance
     integer                                 :: min_Axb_its_per_visc_it     !      Smallest number of iterations in iterative solver for linearised momentum balance per non-linear viscosity iteration
     integer                                 :: max_Axb_its_per_visc_it     !      Largest number of iterations in iterative solver for linearised momentum balance per non-linear viscosity iteration

--- a/src/types/ice_model_types.f90
+++ b/src/types/ice_model_types.f90
@@ -430,6 +430,22 @@ MODULE ice_model_types
     REAL(dp), DIMENSION(:,:  ), ALLOCATABLE :: Ti_next                     ! [m]  The next state
     CHARACTER(LEN=256)                      :: thermo_restart_filename     !      Filename for thermodynamics restart file
 
+  ! === Numerical stability info ===
+  ! ================================
+
+    integer                                 :: n_dt_ice                    !      Total number of ice-dynamical time steps
+    real(dp)                                :: min_dt_ice                  ! [yr] Smallest ice-dynamical time step
+    real(dp)                                :: max_dt_ice                  ! [yr] Largest ice-dynamical time step
+    real(dp)                                :: mean_dt_ice                 ! [yr] Mean ice-dynamical time step
+    integer                                 :: n_visc_its                  !      Total number of non-linear viscosity iterations
+    integer                                 :: min_visc_its                !      Smallest number of non-linear viscosity iterations in a single ice-dynamical time step
+    integer                                 :: max_visc_its                !      Largest number of non-linear viscosity iterations in a single ice-dynamical time step
+    real(dp)                                :: mean_visc_its               !      Mean number of non-linear viscosity iterations in a single ice-dynamical time step
+    integer                                 :: n_Axb_its                   !      Total number of iterations in iterative solver for linearised momentum balance
+    integer                                 :: min_Axb_its_per_visc_it     !      Smallest number of iterations in iterative solver for linearised momentum balance per non-linear viscosity iteration
+    integer                                 :: max_Axb_its_per_visc_it     !      Largest number of iterations in iterative solver for linearised momentum balance per non-linear viscosity iteration
+    real(dp)                                :: mean_Axb_its_per_visc_it    !      Mean number of iterations in iterative solver for linearised momentum balance per non-linear viscosity iteration
+
   END TYPE type_ice_model
 
 CONTAINS


### PR DESCRIPTION
Add some information on the numerical stability of the model to the scalar output file:
- number of ice-dynamical time steps per output time step
- minimum/maximum/mean ice-dynamical time step per output time step
- number of non-linear viscosity iterations per output time step
- minimum/maximum/mean non-linear viscosity iterations per ice-dynamical time step
- number of iterations used by the iterative solver for the linearised momentum balance per output time step
- minimum/maximum/mean number of those iterations per ice-dynamical time step

These will be included in the cost functions of the integrated tests in a later merge.