### PR TITLE
Fix ice base slope at calving front

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -298,6 +298,7 @@ UFEMISM_source = \
   ice_dynamics/utilities/map_velocities_to_c_grid.f90 \
   ice_dynamics/utilities/time_step_criteria.f90 \
   ice_dynamics/utilities/ice_mass_and_fluxes.f90 \
+  ice_dynamics/utilities/ice_shelf_base_slopes_onesided.f90 \
   ice_dynamics/rheology/constitutive_equation.f90 \
   ice_dynamics/conservation_of_momentum/SIA/SIA_main.f90 \
   ice_dynamics/conservation_of_momentum/SSA_DIVA/SSA_DIVA_utilities.f90 \

--- a/src/ice_dynamics/ice_dynamics_main.f90
+++ b/src/ice_dynamics/ice_dynamics_main.f90
@@ -44,6 +44,7 @@ module ice_dynamics_main
   use direct_scheme, only: run_ice_dynamics_model_direct
   use ice_model_memory, only: allocate_ice_model
   use mesh_disc_apply_operators, only: ddx_a_b_2D, ddy_a_b_2D
+  use ice_shelf_base_slopes_onesided, only: calc_ice_shelf_base_slopes_onesided
 
   implicit none
 
@@ -158,8 +159,7 @@ contains
     call calc_effective_thickness( region%mesh, region%ice, region%ice%Hi, region%ice%Hi_eff, region%ice%fraction_margin)
 
     ! Calculate ice shelf draft gradients
-    call ddx_a_b_2D( region%mesh, region%ice%Hib, region%ice%dHib_dx_b)
-    call ddy_a_b_2D( region%mesh, region%ice%Hib, region%ice%dHib_dy_b)
+    call calc_ice_shelf_base_slopes_onesided( region%mesh, region%ice)
 
     ! Calculate absolute surface gradient
     call ddx_a_a_2D( region%mesh, region%ice%Hs, dHs_dx)
@@ -282,10 +282,6 @@ contains
 
     end do ! do vi = mesh%vi1, mesh%vi2
 
-    ! Calculate ice shelf draft gradients
-    call ddx_a_b_2D( mesh, ice%Hib, ice%dHib_dx_b)
-    call ddy_a_b_2D( mesh, ice%Hib, ice%dHib_dy_b)
-
     ! Calculate zeta gradients
     call calc_zeta_gradients( mesh, ice)
 
@@ -310,6 +306,9 @@ contains
 
     ! Compute effective thickness at calving fronts
     call calc_effective_thickness( mesh, ice, ice%Hi, ice%Hi_eff, ice%fraction_margin)
+
+    ! Calculate ice shelf draft gradients
+    call calc_ice_shelf_base_slopes_onesided( mesh, ice)
 
     ! Surface gradients
     ! =================
@@ -747,8 +746,7 @@ contains
     end do ! do vi = mesh_new%vi1, mesh_new%vi2
 
     ! Horizontal derivatives
-    call ddx_a_b_2D( mesh_new, ice%Hib, ice%dHib_dx_b)
-    call ddy_a_b_2D( mesh_new, ice%Hib, ice%dHib_dy_b)
+    call calc_ice_shelf_base_slopes_onesided( mesh_new, ice)
 
     ! Calculate zeta gradients
     call calc_zeta_gradients( mesh_new, ice)

--- a/src/ice_dynamics/utilities/ice_shelf_base_slopes_onesided.f90
+++ b/src/ice_dynamics/utilities/ice_shelf_base_slopes_onesided.f90
@@ -1,0 +1,64 @@
+module ice_shelf_base_slopes_onesided
+
+  use precisions, only: dp
+  use control_resources_and_error_messaging, only: init_routine, finalise_routine, crash
+  use mesh_types, only: type_mesh
+  use ice_model_types, only: type_ice_model
+  use mesh_disc_apply_operators, only: ddx_a_b_2D, ddy_a_b_2D
+  use mpi_distributed_memory, only: gather_to_all
+  use ice_geometry_basics, only: ice_surface_elevation
+
+  implicit none
+
+  private
+
+  public :: calc_ice_shelf_base_slopes_onesided
+
+contains
+
+  subroutine calc_ice_shelf_base_slopes_onesided( mesh, ice)
+
+    ! In/output variables:
+    type(type_mesh),      intent(in   ) :: mesh
+    type(type_ice_model), intent(inout) :: ice
+
+    ! Local variables:
+    character(len=1024), parameter         :: routine_name = 'calc_ice_shelf_base_slopes_onesided'
+    logical,  dimension(mesh%nV)           :: mask_floating_ice_tot, mask_cf_fl_tot
+    integer                                :: ti, via, vib, vic
+    logical                                :: all_are_shelf, none_are_cf
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    ! Straightforward calculation everywhere
+    call ddx_a_b_2D( mesh, ice%Hib, ice%dHib_dx_b)
+    call ddy_a_b_2D( mesh, ice%Hib, ice%dHib_dy_b)
+
+    ! Gather global mask
+    call gather_to_all( ice%mask_floating_ice, mask_floating_ice_tot)
+    call gather_to_all( ice%mask_cf_fl       , mask_cf_fl_tot       )
+
+    ! Set slopes to zero on triangles that are only partly shelf
+    do ti = mesh%ti1, mesh%ti2
+
+      via = mesh%Tri( ti,1)
+      vib = mesh%Tri( ti,2)
+      vic = mesh%Tri( ti,3)
+
+      all_are_shelf = mask_floating_ice_tot( via) .and. mask_floating_ice_tot( vib) .and. mask_floating_ice_tot( vic)
+      none_are_cf = (.not. mask_cf_fl_tot( via)) .and. (.not. mask_cf_fl_tot( vib)) .and. (.not. mask_cf_fl_tot( vic))
+
+      if (.not. (all_are_shelf .and. none_are_cf)) then
+        ice%dHib_dx_b( ti) = 0._dp
+        ice%dHib_dy_b( ti) = 0._dp
+      end if
+
+    end do
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine calc_ice_shelf_base_slopes_onesided
+
+end module ice_shelf_base_slopes_onesided


### PR DESCRIPTION
Just set it to zero there. Seems to help a lot with numerical stability of Laddie.

Shown below are the convergence of the layer thickness and velocity (represented by the L2-norm of consecutive iterations), and the velocity field at the end of the 10-day initialisation run (for the MISOMIP integrated test).

Before this fix:
![Laddie_convergence](https://github.com/user-attachments/assets/90fca5bf-d445-4a8b-8a57-c31afb370b1e)
![Screenshot 2025-04-23 at 09 43 48](https://github.com/user-attachments/assets/0448e8c8-a928-4fa0-983a-340c2e5bc8cb)

After this fix:
![Laddie_convergence_new](https://github.com/user-attachments/assets/9c34a52c-3d41-4ce2-8d40-65a52e49598e)
![Screenshot 2025-04-23 at 09 44 31](https://github.com/user-attachments/assets/08b9611c-5bf5-4d45-b6c4-07bb8cc70240)
