### PR TITLE
Small bugfix

### DIFF
--- a/src/basic/math_utilities/plane_geometry.f90
+++ b/src/basic/math_utilities/plane_geometry.f90
@@ -336,6 +336,7 @@ contains
     logical                            :: isso
     real(dp)                           :: as_x, as_y, s1, s2, s3
     real(dp), parameter                :: tol = 1E-9_dp
+    real(dp)                           :: tol_dist
 
     as_x = p( 1) - pa( 1)
     as_y = p( 2) - pa( 2)
@@ -350,6 +351,11 @@ contains
       isso = .true.
       return
     end if
+
+    tol_dist = tol * norm2( pa - pb)
+    isso = isso .or. lies_on_line_segment( pa, pb, p, tol_dist)
+    isso = isso .or. lies_on_line_segment( pb, pc, p, tol_dist)
+    isso = isso .or. lies_on_line_segment( pc, pa, p, tol_dist)
 
   end function is_in_triangle
 

--- a/src/mesh/mesh_utilities.f90
+++ b/src/mesh/mesh_utilities.f90
@@ -1359,6 +1359,8 @@ CONTAINS
 
       ! If no more non-checked neighbours could be found, terminate and throw an error.
       IF (stackN2 == 0 .AND. .NOT. FoundIt) THEN
+        ! Write the problem-causing mesh to a text file for debugging
+        call write_mesh_to_text_file( mesh, trim(C%output_dir) // '/problem_mesh.txt')
         CALL crash('find_containing_triangle - couldnt find triangle containing p = [{dp_01}, {dp_02}]', dp_01 = p(1), dp_02 = p(2))
       END IF
 


### PR DESCRIPTION
Add extra checks for when p lies on the edges of a triangle (within tolerance). Also add code to save the mesh when find_containing_triangle fails, for debugging purposes. Now the component tests run in the performance compilation too (though still need to figure out why the two compilations generate different meshes...).