### PR TITLE
Add config variable start_time_of_applying_SGD_config"

### DIFF
--- a/src/LADDIE/main/LADDIE_main_model.f90
+++ b/src/LADDIE/main/LADDIE_main_model.f90
@@ -73,8 +73,13 @@ contains
       case ('none')
         ! Do nothing
       case ('idealised','read_from_file')
-        ! Compute SGD
-        call compute_subglacial_discharge( mesh, laddie, forcing)
+        if (time >= C%start_time_of_applying_SGD) then 
+          ! Compute SGD
+          call compute_subglacial_discharge( mesh, laddie, forcing)
+        else
+          ! Set SGD to zero
+          laddie%SGD = 0._dp
+        end if
     end select
 
     if (C%do_repartition_laddie) then

--- a/src/UPSY/basic/model_configuration.f90
+++ b/src/UPSY/basic/model_configuration.f90
@@ -992,8 +992,9 @@ MODULE model_configuration
     ! Subglacial discharge (SGD)
     CHARACTER(LEN=256)  :: choice_laddie_SGD_config                     = 'none'                           ! Choose option for subglacial discharge. Options: 'none', 'idealised', 'read_from_file'
     CHARACTER(LEN=256)  :: choice_laddie_SGD_idealised_config           = 'MISMIPplus_PC'                  ! Choose option for idealised SGD. Options: 'MISMIPplus_PC', 'MISMIPplus_PW', 'MISMIPplus_PE'
-    REAL(dp)            :: laddie_SGD_flux_config                       = 72._dp                           ! [m^3 s^-1] Total subglacial discharge flux
+    REAL(dp)            :: laddie_SGD_flux_config                       = 50._dp                           ! [m^3 s^-1] Total subglacial discharge flux
     CHARACTER(LEN=256)  :: filename_laddie_mask_SGD_config              = ''                               ! Gridded file containing the subglacial discharge mask
+    REAL(dp)            :: start_time_of_applying_SGD_config            = -9E9_dp                          ! [yr] Start time of applying SGD when choice_laddie_SGD_config is 'idealised' or 'read_from_file'
 
   ! == Lateral mass balance
   ! =======================
@@ -2150,6 +2151,7 @@ MODULE model_configuration
     CHARACTER(LEN=256)  :: choice_laddie_SGD_idealised
     REAL(dp)            :: laddie_SGD_flux
     CHARACTER(LEN=256)  :: filename_laddie_mask_SGD
+    REAL(dp)            :: start_time_of_applying_SGD
 
   ! == Lateral mass balance
   ! =======================
@@ -3162,6 +3164,7 @@ CONTAINS
       choice_laddie_SGD_idealised_config                          , &
       laddie_SGD_flux_config                                      , &
       filename_laddie_mask_SGD_config                             , &
+      start_time_of_applying_SGD_config                           , &
       choice_laddie_tides_config                                  , &
       uniform_laddie_tidal_velocity_config                        , &
       dt_LMB_config                                               , &
@@ -4304,6 +4307,7 @@ CONTAINS
     C%choice_laddie_SGD_idealised                            = choice_laddie_SGD_idealised_config
     C%laddie_SGD_flux                                        = laddie_SGD_flux_config
     C%filename_laddie_mask_SGD                               = filename_laddie_mask_SGD_config
+    C%start_time_of_applying_SGD                             = start_time_of_applying_SGD_config
 
   ! == Lateral mass balance
   ! =======================


### PR DESCRIPTION
Introduces a config variable start_time_of_applying_SGD_config for LADDIE. The model will compute and apply SGD only after this time; before that, SGD is ignored.

Default is -9e9 so that, by default, SGD runs throughout the experiment when choice_laddie_SGD_config is set to 'idealised' or 'read_from_file'.