### PR TITLE
Bug fixing month indexing in Climate Matrix temperatures

### DIFF
--- a/src/UFEMISM/climate/climate_matrix.f90
+++ b/src/UFEMISM/climate/climate_matrix.f90
@@ -187,7 +187,7 @@ contains
 
       ! Adapt temperature to model orography using matrix-derived lapse-rate
       do m = 1, 12
-        climate%T2m( vi,:) = T_ref_GCM( vi, m) - lambda_GCM( vi) * (ice%Hs( vi) - Hs_GCM( vi))  ! Berends et al., 2018 - Eq. 11
+        climate%T2m( vi,m) = T_ref_GCM( vi, m) - lambda_GCM( vi) * (ice%Hs( vi) - Hs_GCM( vi))  ! Berends et al., 2018 - Eq. 11
       end do
 
     end do


### PR DESCRIPTION
December temperatures were being assigned to all months in the climate matrix, which was causing a very high warm bias: ~15K warmer than borehole temperatures for several different ice-core drill sites (and likely explains the "interesting" results I got... drat)