### PR TITLE
Put model state in a separate type

### DIFF
--- a/src/UPSY/models/demo_model/demo_model_a.f90
+++ b/src/UPSY/models/demo_model/demo_model_a.f90
@@ -6,6 +6,7 @@ module demo_model_a
   use mesh_types, only: type_mesh
   use Arakawa_grid_mod, only: Arakawa_grid
   use fields_main, only: third_dimension
+  use demo_model_state, only: type_demo_model_state
   use demo_model_basic, only: atype_demo_model, type_demo_model_context_allocate, &
     type_demo_model_context_initialise, type_demo_model_context_run, &
     type_demo_model_context_remap
@@ -150,19 +151,19 @@ contains
     call init_routine( routine_name)
 
     ! Retrieve input variables from context object
-    call run_demo_model_a( self%mesh, self, context%dH)
+    call run_demo_model_a( self%mesh, self%s, context%dH)
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)
 
   end subroutine run_demo_model_a_abs
 
-  subroutine run_demo_model_a( mesh, self, dH)
+  subroutine run_demo_model_a( mesh, demo, dH)
 
     ! In/output variables:
-    type(type_mesh),         intent(in   ) :: mesh
-    type(type_demo_model_a), intent(inout) :: self
-    real(dp),                intent(in   ) :: dH
+    type(type_mesh),             intent(in   ) :: mesh
+    type(type_demo_model_state), intent(inout) :: demo
+    real(dp),                    intent(in   ) :: dH
 
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'run_demo_model_a'
@@ -170,7 +171,7 @@ contains
     ! Add routine to call stack
     call init_routine( routine_name)
 
-    self%H( mesh%vi1: mesh%vi2) = self%H( mesh%vi1: mesh%vi2) + dH
+    demo%H( mesh%vi1: mesh%vi2) = demo%H( mesh%vi1: mesh%vi2) + dH
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)

--- a/src/UPSY/models/demo_model/demo_model_allocate.f90
+++ b/src/UPSY/models/demo_model/demo_model_allocate.f90
@@ -53,7 +53,7 @@ contains
     call init_routine( routine_name)
 
     ! Part common to all models of atype_demo_model
-    call allocate_model_common( self, context)
+    call allocate_model_common( self%mesh, self, self%s, context)
 
     ! Part specific to the model classes inheriting from atype_demo_model
     call self%allocate_demo_model( context)
@@ -63,10 +63,12 @@ contains
 
   end subroutine allocate_model
 
-  subroutine allocate_model_common( self, context)
+  subroutine allocate_model_common( mesh, self, demo, context)
 
     ! In/output variables:
+    type(type_mesh),                                intent(in   ) :: mesh
     class(atype_demo_model),                        intent(inout) :: self
+    type(type_demo_model_state),                    intent(inout) :: demo
     type(type_demo_model_context_allocate), target, intent(in   ) :: context
 
     ! Local variables:
@@ -75,36 +77,36 @@ contains
     ! Add routine to call stack
     call init_routine( routine_name)
 
-    call self%create_field( self%H, self%wH, &
-      self%mesh, Arakawa_grid%a(), &
+    call self%create_field( demo%H, demo%wH, &
+      mesh, Arakawa_grid%a(), &
       name      = 'H', &
       long_name = 'ice thickness', &
       units     = 'm', &
       remap_method = '2nd_order_conservative')
 
-    call self%create_field( self%u_3D, self%wu_3D, &
-      self%mesh, Arakawa_grid%b(), third_dimension%ice_zeta( context%nz, 'regular'), &
+    call self%create_field( demo%u_3D, demo%wu_3D, &
+      mesh, Arakawa_grid%b(), third_dimension%ice_zeta( context%nz, 'regular'), &
       name      = 'u_3D', &
       long_name = 'depth-dependent horizontal ice velocity in x-direction', &
       units     = 'm yr^-1', &
       remap_method = '2nd_order_conservative')
 
-    call self%create_field( self%v_3D, self%wv_3D, &
-      self%mesh, Arakawa_grid%b(), third_dimension%ice_zeta( context%nz, 'regular'), &
+    call self%create_field( demo%v_3D, demo%wv_3D, &
+      mesh, Arakawa_grid%b(), third_dimension%ice_zeta( context%nz, 'regular'), &
       name      = 'v_3D', &
       long_name = 'depth-dependent horizontal ice velocity in y-direction', &
       units     = 'm yr^-1', &
       remap_method = '2nd_order_conservative')
 
-    call self%create_field( self%mask_ice, self%wmask_ice, &
-      self%mesh, Arakawa_grid%a(), &
+    call self%create_field( demo%mask_ice, demo%wmask_ice, &
+      mesh, Arakawa_grid%a(), &
       name      = 'mask_ice', &
       long_name = 'ice mask', &
       units     = '-', &
       remap_method = 'reallocate')
 
-    call self%create_field( self%T2m, self%wT2m, &
-      self%mesh, Arakawa_grid%a(), third_dimension%month(), &
+    call self%create_field( demo%T2m, demo%wT2m, &
+      mesh, Arakawa_grid%a(), third_dimension%month(), &
       name      = 'T2m', &
       long_name = 'Monthly 2-m air temperature', &
       units     = 'K', &
@@ -127,7 +129,7 @@ contains
     call init_routine( routine_name)
 
     ! Part common to all models of atype_demo_model
-    call deallocate_model_common( self)
+    call deallocate_model_common( self%s)
 
     ! Part specific to the model classes inheriting from atype_demo_model
     call self%deallocate_demo_model
@@ -137,10 +139,10 @@ contains
 
   end subroutine deallocate_model
 
-  subroutine deallocate_model_common( self)
+  subroutine deallocate_model_common( demo)
 
     ! In/output variables:
-    class(atype_demo_model), intent(inout) :: self
+    type(type_demo_model_state), intent(inout) :: demo
 
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'deallocate_model_common'
@@ -148,11 +150,11 @@ contains
     ! Add routine to call stack
     call init_routine( routine_name)
 
-    nullify( self%H)
-    nullify( self%u_3D)
-    nullify( self%v_3D)
-    nullify( self%mask_ice)
-    nullify( self%T2m)
+    nullify( demo%H)
+    nullify( demo%u_3D)
+    nullify( demo%v_3D)
+    nullify( demo%mask_ice)
+    nullify( demo%T2m)
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)

--- a/src/UPSY/models/demo_model/demo_model_b.f90
+++ b/src/UPSY/models/demo_model/demo_model_b.f90
@@ -6,6 +6,7 @@ module demo_model_b
   use mesh_types, only: type_mesh
   use Arakawa_grid_mod, only: Arakawa_grid
   use fields_main, only: third_dimension
+  use demo_model_state, only: type_demo_model_state
   use demo_model_basic, only: atype_demo_model, type_demo_model_context_allocate, &
     type_demo_model_context_initialise, type_demo_model_context_run, &
     type_demo_model_context_remap
@@ -150,19 +151,19 @@ contains
     call init_routine( routine_name)
 
     ! Retrieve input variables from context object
-    call run_demo_model_b( self%mesh, self, context%H_new)
+    call run_demo_model_b( self%mesh, self%s, context%H_new)
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)
 
   end subroutine run_demo_model_b_abs
 
-  subroutine run_demo_model_b( mesh, self, H_new)
+  subroutine run_demo_model_b( mesh, demo, H_new)
 
     ! In/output variables:
-    type(type_mesh),         intent(in   ) :: mesh
-    type(type_demo_model_b), intent(inout) :: self
-    real(dp),                intent(in   ) :: H_new
+    type(type_mesh),             intent(in   ) :: mesh
+    type(type_demo_model_state), intent(inout) :: demo
+    real(dp),                    intent(in   ) :: H_new
 
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'run_demo_model_b'
@@ -170,7 +171,7 @@ contains
     ! Add routine to call stack
     call init_routine( routine_name)
 
-    self%H( mesh%vi1: mesh%vi2) = H_new
+    demo%H( mesh%vi1: mesh%vi2) = H_new
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)

--- a/src/UPSY/models/demo_model/demo_model_basic.f90
+++ b/src/UPSY/models/demo_model/demo_model_basic.f90
@@ -8,6 +8,7 @@ module demo_model_basic
   use fields_main, only: third_dimension
   use models_basic, only: atype_model, atype_model_context_allocate, &
     atype_model_context_initialise, atype_model_context_run, atype_model_context_remap
+  use demo_model_state, only: type_demo_model_state
   use mpi_f08, only: MPI_WIN
 
   implicit none
@@ -20,13 +21,7 @@ module demo_model_basic
 
   type, abstract, extends(atype_model) :: atype_demo_model
 
-      ! Some ice-model-esque data fields
-      real(dp), dimension(:  ), contiguous, pointer :: H        => null()
-      real(dp), dimension(:,:), contiguous, pointer :: u_3D     => null()
-      real(dp), dimension(:,:), contiguous, pointer :: v_3D     => null()
-      logical,  dimension(:  ), contiguous, pointer :: mask_ice => null()
-      real(dp), dimension(:,:), contiguous, pointer :: T2m      => null()
-      type(MPI_WIN) :: wH, wu_3D, wv_3D, wmask_ice, wT2m
+      type(type_demo_model_state) :: s
 
     contains
 

--- a/src/UPSY/models/demo_model/demo_model_initialise.f90
+++ b/src/UPSY/models/demo_model/demo_model_initialise.f90
@@ -51,7 +51,7 @@ contains
     call init_routine( routine_name)
 
     ! Part common to all models of atype_demo_model
-    call initialise_model_common( self%mesh, self, context%H0)
+    call initialise_model_common( self%mesh, self%s, context%H0)
 
     ! Part specific to the model classes inheriting from atype_demo_model
     call self%initialise_demo_model( context)
@@ -61,12 +61,12 @@ contains
 
   end subroutine initialise_model
 
-  subroutine initialise_model_common( mesh, self, H0)
+  subroutine initialise_model_common( mesh, demo, H0)
 
     ! In/output variables:
-    type(type_mesh),         intent(in   ) :: mesh
-    class(atype_demo_model), intent(inout) :: self
-    real(dp),                intent(in   ) :: H0
+    type(type_mesh),              intent(in   ) :: mesh
+    class(type_demo_model_state), intent(inout) :: demo
+    real(dp),                     intent(in   ) :: H0
 
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'initialise_model_common'
@@ -86,11 +86,11 @@ contains
       x = mesh%V( vi,1)
       y = mesh%V( vi,2)
 
-      self%H( vi) = max( H0, cos( x * pi / cx) * cos( y * pi / cy) - 0.2_dp)
-      self%mask_ice( vi) = self%H( vi) > 0._dp
+      demo%H( vi) = max( H0, cos( x * pi / cx) * cos( y * pi / cy) - 0.2_dp)
+      demo%mask_ice( vi) = demo%H( vi) > 0._dp
 
       do m = 1, 12
-        self%T2m( vi,m) = hypot( x,y) + sin( real(m,dp) * 2._dp * pi / 12._dp)
+        demo%T2m( vi,m) = hypot( x,y) + sin( real(m,dp) * 2._dp * pi / 12._dp)
       end do
 
     end do
@@ -100,9 +100,9 @@ contains
       x = mesh%Trigc( ti,1)
       y = mesh%Trigc( ti,2)
 
-      do k = 1, size( self%u_3D,2)
-        self%u_3D( ti,k) = max( 0._dp, cos( x * pi / cx) * cos( y * pi / cy) - 0.2_dp) + real( k,dp)
-        self%v_3D( ti,k) =             sin( x * pi / cx) * sin( y * pi / cy)           + real( k,dp)
+      do k = 1, size( demo%u_3D,2)
+        demo%u_3D( ti,k) = max( 0._dp, cos( x * pi / cx) * cos( y * pi / cy) - 0.2_dp) + real( k,dp)
+        demo%v_3D( ti,k) =             sin( x * pi / cx) * sin( y * pi / cy)           + real( k,dp)
       end do
 
     end do

--- a/src/UPSY/models/demo_model/demo_model_remap.f90
+++ b/src/UPSY/models/demo_model/demo_model_remap.f90
@@ -47,7 +47,7 @@ contains
     call init_routine( routine_name)
 
     ! Part common to all models of atype_demo_model
-    call remap_model_common( self, context%mesh_new)
+    call remap_model_common( self, self%s, context%mesh_new)
 
     ! Part specific to the model classes inheriting from atype_demo_model
     call self%remap_demo_model( context)
@@ -57,11 +57,12 @@ contains
 
   end subroutine remap_model
 
-  subroutine remap_model_common( self, mesh_new)
+  subroutine remap_model_common( self, demo, mesh_new)
 
     ! In/output variables:
-    class(atype_demo_model), intent(inout) :: self
-    type(type_mesh),         intent(in   ) :: mesh_new
+    class(atype_demo_model),     intent(inout) :: self
+    type(type_demo_model_state), intent(inout) :: demo
+    type(type_mesh),             intent(in   ) :: mesh_new
 
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'remap_model_common'
@@ -69,11 +70,11 @@ contains
     ! Add routine to call stack
     call init_routine( routine_name)
 
-    call self%remap_field( mesh_new, 'H'       , self%H       )
-    call self%remap_field( mesh_new, 'u_3D'    , self%u_3D    )
-    call self%remap_field( mesh_new, 'v_3D'    , self%v_3D    )
-    call self%remap_field( mesh_new, 'mask_ice', self%mask_ice)
-    call self%remap_field( mesh_new, 'T2m'     , self%T2m     )
+    call self%remap_field( mesh_new, 'H'       , demo%H       )
+    call self%remap_field( mesh_new, 'u_3D'    , demo%u_3D    )
+    call self%remap_field( mesh_new, 'v_3D'    , demo%v_3D    )
+    call self%remap_field( mesh_new, 'mask_ice', demo%mask_ice)
+    call self%remap_field( mesh_new, 'T2m'     , demo%T2m     )
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)

--- a/src/UPSY/models/demo_model/demo_model_state.f90
+++ b/src/UPSY/models/demo_model/demo_model_state.f90
@@ -1,0 +1,24 @@
+module demo_model_state
+
+  use precisions, only: dp
+  use mpi_f08, only: MPI_WIN
+
+  implicit none
+
+  private
+
+  public :: type_demo_model_state
+
+  type :: type_demo_model_state
+
+      ! Some ice-model-esque data fields
+      real(dp), dimension(:  ), contiguous, pointer :: H        => null()
+      real(dp), dimension(:,:), contiguous, pointer :: u_3D     => null()
+      real(dp), dimension(:,:), contiguous, pointer :: v_3D     => null()
+      logical,  dimension(:  ), contiguous, pointer :: mask_ice => null()
+      real(dp), dimension(:,:), contiguous, pointer :: T2m      => null()
+      type(MPI_WIN) :: wH, wu_3D, wv_3D, wmask_ice, wT2m
+
+  end type type_demo_model_state
+
+end module demo_model_state

--- a/src/UPSY/validation/unit_tests/models/ut_demo_model.f90
+++ b/src/UPSY/validation/unit_tests/models/ut_demo_model.f90
@@ -75,15 +75,15 @@ contains
       a1%name()        == 'demo_model_a1' .and. &
       a1%region_name() == 'aaa' .and. &
       a1%mesh%name     == mesh1%name .and. &
-      size( a1%H   ,1) == mesh1%pai_V%n_nih .and. &
-      size( a1%u_3D,1) == mesh1%pai_Tri%n_nih .and. &
-      size( a1%u_3D,2) == nz &
+      size( a1%s%H   ,1) == mesh1%pai_V%n_nih .and. &
+      size( a1%s%u_3D,1) == mesh1%pai_Tri%n_nih .and. &
+      size( a1%s%u_3D,2) == nz &
       ), trim( test_name) // '/allocate')
 
     ! Initialise the demo model and test if that worked
     call a1%initialise( a1%ct_initialise( H0, till_friction_angle_uniform, beta_sq_uniform))
     call unit_test( (&
-      minval( a1%H) == H0 .and. &
+      minval( a1%s%H) == H0 .and. &
       minval( a1%till_friction_angle) == till_friction_angle_uniform .and. &
       maxval( a1%till_friction_angle) == till_friction_angle_uniform &
       ), trim( test_name) // '/initialise')
@@ -91,16 +91,16 @@ contains
     ! Run the demo model and test if that worked
     call a1%run( a1%ct_run( H_new, dH))
     call unit_test( (&
-      minval( a1%H) == H0 + dH &
+      minval( a1%s%H) == H0 + dH &
       ), trim( test_name) // '/run')
 
     ! Remap the demo model and test if that worked
     call a1%remap( a1%ct_remap( mesh2))
     call unit_test( ( &
       a1%mesh%name     == mesh2%name .and. &
-      size( a1%H   ,1) == mesh2%pai_V%n_nih .and. &
-      size( a1%u_3D,1) == mesh2%pai_Tri%n_nih .and. &
-      size( a1%u_3D,2) == nz &
+      size( a1%s%H   ,1) == mesh2%pai_V%n_nih .and. &
+      size( a1%s%u_3D,1) == mesh2%pai_Tri%n_nih .and. &
+      size( a1%s%u_3D,2) == nz &
       ), trim( test_name) // '/remap')
 
     ! Write the demo model to a restart file,
@@ -117,11 +117,11 @@ contains
       a1%name() == 'empty_model' .and. &
       a1%region_name() == '!!!' .and. &
       .not. associated( a1%mesh) .and. &
-      .not. associated( a1%H) .and. &
-      .not. associated( a1%u_3D) .and. &
-      .not. associated( a1%v_3D) .and. &
-      .not. associated( a1%mask_ice) .and. &
-      .not. associated( a1%T2m) .and. &
+      .not. associated( a1%s%H) .and. &
+      .not. associated( a1%s%u_3D) .and. &
+      .not. associated( a1%s%v_3D) .and. &
+      .not. associated( a1%s%mask_ice) .and. &
+      .not. associated( a1%s%T2m) .and. &
       .not. associated( a1%till_friction_angle) &
       ), trim( test_name) // '/deallocate')
 
@@ -164,15 +164,15 @@ contains
       b1%name()        == 'demo_model_b1' .and. &
       b1%region_name() == 'aaa' .and. &
       b1%mesh%name     == mesh1%name .and. &
-      size( b1%H   ,1) == mesh1%pai_V%n_nih .and. &
-      size( b1%u_3D,1) == mesh1%pai_Tri%n_nih .and. &
-      size( b1%u_3D,2) == nz &
+      size( b1%s%H   ,1) == mesh1%pai_V%n_nih .and. &
+      size( b1%s%u_3D,1) == mesh1%pai_Tri%n_nih .and. &
+      size( b1%s%u_3D,2) == nz &
       ), trim( test_name) // '/allocate')
 
     ! Initialise the demo model and test if that worked
     call b1%initialise( b1%ct_initialise( H0, till_friction_angle_uniform, beta_sq_uniform))
     call unit_test( (&
-      minval( b1%H) == H0 .and. &
+      minval( b1%s%H) == H0 .and. &
       minval( b1%beta_sq) == beta_sq_uniform .and. &
       maxval( b1%beta_sq) == beta_sq_uniform &
       ), trim( test_name) // '/initialise')
@@ -180,17 +180,17 @@ contains
     ! Run the demo model and test if that worked
     call b1%run( b1%ct_run( H_new, dH))
     call unit_test( (&
-      minval( b1%H) == H_new .and. &
-      maxval( b1%H) == H_new &
+      minval( b1%s%H) == H_new .and. &
+      maxval( b1%s%H) == H_new &
       ), trim( test_name) // '/run')
 
     ! Remap the demo model and test if that worked
     call b1%remap( b1%ct_remap( mesh2))
     call unit_test( ( &
       b1%mesh%name     == mesh2%name .and. &
-      size( b1%H   ,1) == mesh2%pai_V%n_nih .and. &
-      size( b1%u_3D,1) == mesh2%pai_Tri%n_nih .and. &
-      size( b1%u_3D,2) == nz &
+      size( b1%s%H   ,1) == mesh2%pai_V%n_nih .and. &
+      size( b1%s%u_3D,1) == mesh2%pai_Tri%n_nih .and. &
+      size( b1%s%u_3D,2) == nz &
       ), trim( test_name) // '/remap')
 
     ! Write the demo model to a restart file,
@@ -207,11 +207,11 @@ contains
       b1%name() == 'empty_model' .and. &
       b1%region_name() == '!!!' .and. &
       .not. associated( b1%mesh) .and. &
-      .not. associated( b1%H) .and. &
-      .not. associated( b1%u_3D) .and. &
-      .not. associated( b1%v_3D) .and. &
-      .not. associated( b1%mask_ice) .and. &
-      .not. associated( b1%T2m) .and. &
+      .not. associated( b1%s%H) .and. &
+      .not. associated( b1%s%u_3D) .and. &
+      .not. associated( b1%s%v_3D) .and. &
+      .not. associated( b1%s%mask_ice) .and. &
+      .not. associated( b1%s%T2m) .and. &
       .not. associated( b1%beta_sq) &
       ), trim( test_name) // '/deallocate')
 
@@ -255,30 +255,30 @@ contains
       demo1%name()        == 'demo_model_a1' .and. &
       demo1%region_name() == 'aaa' .and. &
       demo1%mesh%name     == mesh1%name .and. &
-      size( demo1%H   ,1) == mesh1%pai_V%n_nih .and. &
-      size( demo1%u_3D,1) == mesh1%pai_Tri%n_nih .and. &
-      size( demo1%u_3D,2) == nz &
+      size( demo1%s%H   ,1) == mesh1%pai_V%n_nih .and. &
+      size( demo1%s%u_3D,1) == mesh1%pai_Tri%n_nih .and. &
+      size( demo1%s%u_3D,2) == nz &
       ), trim( test_name) // '/allocate')
 
     ! Initialise the demo model and test if that worked
     call demo1%initialise( demo1%ct_initialise( H0, till_friction_angle_uniform, beta_sq_uniform))
     call unit_test( (&
-      minval( demo1%H) == H0 &
+      minval( demo1%s%H) == H0 &
       ), trim( test_name) // '/initialise')
 
     ! Run the demo model and test if that worked
     call demo1%run( demo1%ct_run( H_new, dH))
     call unit_test( (&
-      minval( demo1%H) == H0 + dH &
+      minval( demo1%s%H) == H0 + dH &
       ), trim( test_name) // '/run')
 
     ! Remap the demo model and test if that worked
     call demo1%remap( demo1%ct_remap( mesh2))
     call unit_test( ( &
       demo1%mesh%name     == mesh2%name .and. &
-      size( demo1%H   ,1) == mesh2%pai_V%n_nih .and. &
-      size( demo1%u_3D,1) == mesh2%pai_Tri%n_nih .and. &
-      size( demo1%u_3D,2) == nz &
+      size( demo1%s%H   ,1) == mesh2%pai_V%n_nih .and. &
+      size( demo1%s%u_3D,1) == mesh2%pai_Tri%n_nih .and. &
+      size( demo1%s%u_3D,2) == nz &
       ), trim( test_name) // '/remap')
 
     ! Write the demo model to a restart file,
@@ -296,11 +296,11 @@ contains
       demo1%name() == 'empty_model' .and. &
       demo1%region_name() == '!!!' .and. &
       .not. associated( demo1%mesh) .and. &
-      .not. associated( demo1%H) .and. &
-      .not. associated( demo1%u_3D) .and. &
-      .not. associated( demo1%v_3D) .and. &
-      .not. associated( demo1%mask_ice) .and. &
-      .not. associated( demo1%T2m) &
+      .not. associated( demo1%s%H) .and. &
+      .not. associated( demo1%s%u_3D) .and. &
+      .not. associated( demo1%s%v_3D) .and. &
+      .not. associated( demo1%s%mask_ice) .and. &
+      .not. associated( demo1%s%T2m) &
       ), trim( test_name) // '/deallocate')
 
     ! Clean up after yourself
@@ -343,30 +343,30 @@ contains
       demo1%name()        == 'demo_model_b1' .and. &
       demo1%region_name() == 'aaa' .and. &
       demo1%mesh%name     == mesh1%name .and. &
-      size( demo1%H   ,1) == mesh1%pai_V%n_nih .and. &
-      size( demo1%u_3D,1) == mesh1%pai_Tri%n_nih .and. &
-      size( demo1%u_3D,2) == nz &
+      size( demo1%s%H   ,1) == mesh1%pai_V%n_nih .and. &
+      size( demo1%s%u_3D,1) == mesh1%pai_Tri%n_nih .and. &
+      size( demo1%s%u_3D,2) == nz &
       ), trim( test_name) // '/allocate')
 
     ! Initialise the demo model and test if that worked
     call demo1%initialise( demo1%ct_initialise( H0, till_friction_angle_uniform, beta_sq_uniform))
     call unit_test( (&
-      minval( demo1%H) == H0 &
+      minval( demo1%s%H) == H0 &
       ), trim( test_name) // '/initialise')
 
     ! Run the demo model and test if that worked
     call demo1%run( demo1%ct_run( H_new, dH))
     call unit_test( (&
-      minval( demo1%H) == H_new &
+      minval( demo1%s%H) == H_new &
       ), trim( test_name) // '/run')
 
     ! Remap the demo model and test if that worked
     call demo1%remap( demo1%ct_remap( mesh2))
     call unit_test( ( &
       demo1%mesh%name     == mesh2%name .and. &
-      size( demo1%H   ,1) == mesh2%pai_V%n_nih .and. &
-      size( demo1%u_3D,1) == mesh2%pai_Tri%n_nih .and. &
-      size( demo1%u_3D,2) == nz &
+      size( demo1%s%H   ,1) == mesh2%pai_V%n_nih .and. &
+      size( demo1%s%u_3D,1) == mesh2%pai_Tri%n_nih .and. &
+      size( demo1%s%u_3D,2) == nz &
       ), trim( test_name) // '/remap')
 
     ! Write the demo model to a restart file,
@@ -384,11 +384,11 @@ contains
       demo1%name() == 'empty_model' .and. &
       demo1%region_name() == '!!!' .and. &
       .not. associated( demo1%mesh) .and. &
-      .not. associated( demo1%H) .and. &
-      .not. associated( demo1%u_3D) .and. &
-      .not. associated( demo1%v_3D) .and. &
-      .not. associated( demo1%mask_ice) .and. &
-      .not. associated( demo1%T2m) &
+      .not. associated( demo1%s%H) .and. &
+      .not. associated( demo1%s%u_3D) .and. &
+      .not. associated( demo1%s%v_3D) .and. &
+      .not. associated( demo1%s%mask_ice) .and. &
+      .not. associated( demo1%s%T2m) &
       ), trim( test_name) // '/deallocate')
 
     ! Clean up after yourself


### PR DESCRIPTION
So that it can be compiled before compiling the actual model, preventing circular dependency issues (e.g. when climate_model%run requires the SMB, while SMB_model%run requires the climate). The model state types can just be the current existing model types.