### PR TITLE
Update_calc_effective_thickness

### DIFF
--- a/src/LADDIE/forcing/laddie_forcing_main.f90
+++ b/src/LADDIE/forcing/laddie_forcing_main.f90
@@ -126,7 +126,7 @@ contains
     ! =======================
 
     ! Compute effective thickness at calving fronts
-    call calc_effective_thickness( mesh, ice, ice%Hi, ice%Hi_eff, ice%fraction_margin)
+     call calc_effective_thickness( mesh, ice%Hi,ice%Hb,ice%SL, ice%Hi_eff, ice%fraction_margin)
 
     ! Calculate ice shelf draft gradients
     call calc_ice_shelf_base_slopes_onesided( mesh, ice)

--- a/src/UFEMISM/ice_dynamics/ice_dynamics_main.f90
+++ b/src/UFEMISM/ice_dynamics/ice_dynamics_main.f90
@@ -153,7 +153,7 @@ contains
     call determine_masks( region%mesh, region%ice)
 
     ! Calculate new effective thickness
-    call calc_effective_thickness( region%mesh, region%ice, region%ice%Hi, region%ice%Hi_eff, region%ice%fraction_margin)
+    call calc_effective_thickness( region%mesh, region%ice%Hi, region%ice%Hb,region%ice%SL,region%ice%Hi_eff, region%ice%fraction_margin)
 
     ! Calculate ice shelf draft gradients
     call calc_ice_shelf_base_slopes_onesided( region%mesh, region%ice)
@@ -307,7 +307,7 @@ contains
     ! =======================
 
     ! Compute effective thickness at calving fronts
-    call calc_effective_thickness( mesh, ice, ice%Hi, ice%Hi_eff, ice%fraction_margin)
+     call calc_effective_thickness( mesh, ice%Hi,ice%Hb,ice%SL, ice%Hi_eff, ice%fraction_margin)
 
     ! Calculate ice shelf draft gradients
     call calc_ice_shelf_base_slopes_onesided( mesh, ice)
@@ -779,7 +779,7 @@ contains
     ! =======================
 
     ! Calculate new effective thickness
-    call calc_effective_thickness( mesh_new, ice, ice%Hi, ice%Hi_eff, ice%fraction_margin)
+     call calc_effective_thickness( mesh_new, ice%Hi,ice%Hb,ice%SL, ice%Hi_eff, ice%fraction_margin)
 
     ! Surface gradients
     ! =================
@@ -1434,7 +1434,7 @@ contains
       call determine_masks( region%mesh, region%ice)
 
       ! Calculate new effective thickness
-      call calc_effective_thickness( region%mesh, region%ice, region%ice%Hi, region%ice%Hi_eff, region%ice%fraction_margin)
+      call calc_effective_thickness( region%mesh, region%ice%Hi, region%ice%Hb,region%ice%SL,region%ice%Hi_eff, region%ice%fraction_margin)
 
       ! NOTE: as calculating the zeta gradients is quite expensive, only do so when necessary,
       !       i.e. when solving the heat equation or the Blatter-Pattyn stress balance

--- a/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
+++ b/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
@@ -96,7 +96,7 @@ contains
     call calc_grounded_fractions( region%mesh, region%ice)
 
       ! Update effective ice thickness
-    call calc_effective_thickness( region%mesh, region%ice, region%ice%Hi, region%ice%Hi_eff, region%ice%fraction_margin)
+    call calc_effective_thickness( region%mesh, region%ice%Hi, region%ice%Hb,region%ice%SL,region%ice%Hi_eff, region%ice%fraction_margin)
 
     ! == Time step iteration: if, at the end of the PC timestep, the truncation error
     !    turns out to be too large, run it again with a smaller dt, until the truncation
@@ -136,7 +136,8 @@ contains
         region%ice%pc%dHi_dt_Hi_n_u_n - (region%ice%pc%zeta_t / 2._dp) * region%ice%pc%dHi_dt_Hi_nm1_u_nm1)
 
       ! if so desired, modify the predicted ice thickness field based on user-defined settings
-      call alter_ice_thickness( region%mesh, region%ice, region%ice%Hi_prev, region%ice%pc%Hi_star_np1, region%refgeo_PD, region%time)
+      call alter_ice_thickness( region%mesh, region%ice, region%ice%Hi_prev, region%ice%Hb, region%ice%SL, region%ice%pc%Hi_star_np1, region%refgeo_PD, region%time)
+      
 
       ! Adjust the predicted dHi_dt to compensate for thickness modifications
       ! This is just Robinson et al., 2020, Eq 30 above rearranged to retrieve
@@ -200,7 +201,7 @@ contains
       call calc_grounded_fractions( region%mesh, region%ice)
 
       ! Update effective ice thickness
-      call calc_effective_thickness( region%mesh, region%ice, region%ice%Hi, region%ice%Hi_eff, region%ice%fraction_margin)
+      call calc_effective_thickness( region%mesh, region%ice%Hi, region%ice%Hb,region%ice%SL,region%ice%Hi_eff, region%ice%fraction_margin)
 
       ! Calculate thinning rates for the current ice thickness and predicted velocity
       call calc_dHi_dt( region%mesh, region%ice%Hi, region%ice%Hb, region%ice%SL, region%ice%u_vav_b, region%ice%v_vav_b, region%SMB%SMB, region%BMB%BMB, region%LMB%LMB, region%AMB%AMB, region%ice%fraction_margin, &
@@ -221,7 +222,7 @@ contains
       region%ice%dHi_dt_raw = (region%ice%pc%Hi_np1 - region%ice%Hi_prev) / region%ice%pc%dt_np1
 
       ! if so desired, modify the corrected ice thickness field based on user-defined settings
-      call alter_ice_thickness( region%mesh, region%ice, region%ice%Hi_prev, region%ice%pc%Hi_np1, region%refgeo_PD, region%time)
+      call alter_ice_thickness( region%mesh, region%ice, region%ice%Hi_prev, region%ice%Hb, region%ice%SL, region%ice%pc%Hi_np1, region%refgeo_PD, region%time)
 
       ! Adjust the predicted dHi_dt to compensate for thickness modifications
       ! This is just Robinson et al., 2020, Eq 31 above rearranged to retrieve

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -19,13 +19,15 @@ module ice_thickness_safeties
 
 contains
 
-  subroutine alter_ice_thickness( mesh, ice, Hi_old, Hi_new, refgeo, time)
+  subroutine alter_ice_thickness( mesh, ice, Hi_old,Hb,SL, Hi_new, refgeo, time)
     !< Modify the predicted ice thickness in some sneaky way
 
     ! In- and output variables:
     type(type_mesh),                        intent(in   ) :: mesh
     type(type_ice_model),                   intent(in   ) :: ice
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: Hi_old
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: Hb
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: SL
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(inout) :: Hi_new
     type(type_reference_geometry),          intent(in   ) :: refgeo
     real(dp),                               intent(in   ) :: time
@@ -46,8 +48,8 @@ contains
     Hi_save = Hi_new
 
     ! Calculate would-be effective thickness
-    call calc_effective_thickness( mesh, ice, Hi_new, Hi_eff_new, fraction_margin_new)
-
+    call calc_effective_thickness( mesh, Hi_new, Hb, SL, Hi_eff_new, fraction_margin_new)
+    
     ! == Mask conservation
     ! ====================
 

--- a/src/UFEMISM/ice_dynamics/utilities/subgrid_ice_margin.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/subgrid_ice_margin.f90
@@ -15,13 +15,14 @@ module subgrid_ice_margin
 
 contains
 
-  subroutine calc_effective_thickness( mesh, ice, Hi, Hi_eff, fraction_margin)
+  subroutine calc_effective_thickness( mesh, Hi, Hb, SL, Hi_eff, fraction_margin)
     !< Determine the ice-filled fraction and effective ice thickness of floating margin pixels
 
     ! In- and output variables
     type(type_mesh),      intent(in   )                 :: mesh
-    type(type_ice_model), intent(in   )                 :: ice
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in)  :: Hi
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in)  :: Hb
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in)  :: SL
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(out) :: Hi_eff
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(out) :: fraction_margin
 
@@ -40,9 +41,9 @@ contains
     call init_routine( routine_name)
 
     ! Collect Hi from all processes
-    call gather_to_all( Hi,     Hi_tot)
-    call gather_to_all( ice%Hb, Hb_tot)
-    call gather_to_all( ice%SL, SL_tot)
+    call gather_to_all( Hi, Hi_tot)
+    call gather_to_all( Hb, Hb_tot)
+    call gather_to_all( SL, SL_tot)
 
     ! == Margin mask
     ! ==============
@@ -69,7 +70,7 @@ contains
     mask_floating = .false.
 
     do vi = mesh%vi1, mesh%vi2
-      if (is_floating( Hi_tot( vi), ice%Hb( vi), ice%SL( vi))) then
+      if (is_floating( Hi_tot( vi), Hb( vi), SL( vi))) then
         mask_floating( vi) = .true.
       end if
     end do


### PR DESCRIPTION
Changed the calc_effective_thickness subroutine so that it no longer uses the type ice but instead takes in the three primary ice geometry fields (Hi, Hb and SL) and outputs Hi_eff and fraction_margin.  Also added Hb and SL as inputs in alter_ice_thickness.