### PR TITLE
Fix ROI/ISMIP scalar file memory issues

### DIFF
--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
@@ -68,7 +68,7 @@ contains
     call calc_icesheet_integrated_fluxes( mesh, ice, SMB, BMB, LMB, scalars)
 
     ! ISMIP quantities
-    if (C%do_create_ISMIP_output) then
+    if (C%do_create_ismip_output) then
       call calc_ISMIP_scalars( mesh, ice, SMB, BMB, scalars)
     end if
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
@@ -69,7 +69,7 @@ contains
     call calc_icesheet_integrated_fluxes_ROI( mesh, ice, SMB, BMB, LMB, scalars, i_ROI)
 
     ! ISMIP quantities
-    if (C%do_create_ISMIP_output) then
+    if (C%do_create_ismip_output) then
       call calc_ISMIP_scalars_ROI( mesh, ice, SMB, BMB, scalars, i_ROI)
     end if
 

--- a/src/UFEMISM/io/main_regional_output/grid_output_files.f90
+++ b/src/UFEMISM/io/main_regional_output/grid_output_files.f90
@@ -1864,7 +1864,7 @@ contains
       call init_routine( routine_name)
 
       ! if no NetCDF output should be created, do nothing
-      if (.not. C%do_create_ismip_output) then
+      if (.not. C%do_create_ismip_output .OR. .not. C%do_create_netcdf_output) then
         call finalise_routine( routine_name)
         return
       end if
@@ -1936,7 +1936,7 @@ contains
       call init_routine( routine_name)
 
       ! if no NetCDF output should be created, do nothing
-      if (.not. C%do_create_ismip_output) then
+      if (.not. C%do_create_ismip_output .OR. .not. C%do_create_netcdf_output) then
         call finalise_routine( routine_name)
         return
       end if
@@ -2002,7 +2002,7 @@ contains
     call init_routine( routine_name)
 
     ! if no NetCDF output should be created, do nothing
-    if (.not. C%do_create_ismip_output) then
+    if (.not. C%do_create_ismip_output .OR. .not. C%do_create_netcdf_output) then
       call finalise_routine( routine_name)
       return
     end if
@@ -2072,7 +2072,7 @@ contains
     call init_routine( routine_name)
 
     ! if no NetCDF output should be created, do nothing
-    if (.not. C%do_create_ismip_output) then
+    if (.not. C%do_create_ismip_output .OR. .not. C%do_create_netcdf_output) then
       call finalise_routine( routine_name)
       return
     end if

--- a/src/UFEMISM/io/main_regional_output/grid_output_files.f90
+++ b/src/UFEMISM/io/main_regional_output/grid_output_files.f90
@@ -1864,7 +1864,7 @@ contains
       call init_routine( routine_name)
 
       ! if no NetCDF output should be created, do nothing
-      if (.not. C%do_create_ISMIP_output) then
+      if (.not. C%do_create_ismip_output) then
         call finalise_routine( routine_name)
         return
       end if
@@ -1936,7 +1936,7 @@ contains
       call init_routine( routine_name)
 
       ! if no NetCDF output should be created, do nothing
-      if (.not. C%do_create_ISMIP_output) then
+      if (.not. C%do_create_ismip_output) then
         call finalise_routine( routine_name)
         return
       end if
@@ -2002,7 +2002,7 @@ contains
     call init_routine( routine_name)
 
     ! if no NetCDF output should be created, do nothing
-    if (.not. C%do_create_ISMIP_output) then
+    if (.not. C%do_create_ismip_output) then
       call finalise_routine( routine_name)
       return
     end if
@@ -2072,7 +2072,7 @@ contains
     call init_routine( routine_name)
 
     ! if no NetCDF output should be created, do nothing
-    if (.not. C%do_create_ISMIP_output) then
+    if (.not. C%do_create_ismip_output) then
       call finalise_routine( routine_name)
       return
     end if

--- a/src/UFEMISM/io/main_regional_output/scalar_output_files.f90
+++ b/src/UFEMISM/io/main_regional_output/scalar_output_files.f90
@@ -510,7 +510,7 @@ contains
       call init_routine( routine_name)
 
       ! if no NetCDF output should be created, do nothing
-      if (.not. C%do_create_ismip_output) then
+      if (.not. C%do_create_ismip_output .OR. .not. C%do_create_netcdf_output) then
         call finalise_routine( routine_name)
         return
       end if
@@ -572,7 +572,7 @@ contains
       call init_routine( routine_name)
 
       ! if no NetCDF output should be created, do nothing
-      if (.not. C%do_create_netcdf_output) then
+      if (.not. C%do_create_ismip_output .OR. .not. C%do_create_netcdf_output) then
         call finalise_routine( routine_name)
         return
       end if

--- a/src/UFEMISM/io/main_regional_output/scalar_output_files.f90
+++ b/src/UFEMISM/io/main_regional_output/scalar_output_files.f90
@@ -301,6 +301,11 @@ contains
     ! Add routine to path
     call init_routine( routine_name)
 
+    if (.not. C%do_create_netcdf_output) then
+      call finalise_routine( routine_name)
+      return
+    end if
+
     ! Only the primary does this
     if (par%primary) then
 
@@ -674,6 +679,11 @@ contains
 
     ! Add routine to path
     call init_routine( routine_name)
+
+    if (.not. C%do_create_ismip_output .OR. .not. C%do_create_netcdf_output) then
+      call finalise_routine( routine_name)
+      return
+    end if
 
     ! Only the primary does this
     if (par%primary) then

--- a/src/UFEMISM/io/main_regional_output/scalar_output_files.f90
+++ b/src/UFEMISM/io/main_regional_output/scalar_output_files.f90
@@ -510,7 +510,7 @@ contains
       call init_routine( routine_name)
 
       ! if no NetCDF output should be created, do nothing
-      if (.not. C%do_create_ISMIP_output) then
+      if (.not. C%do_create_ismip_output) then
         call finalise_routine( routine_name)
         return
       end if

--- a/src/UFEMISM/io/main_regional_output/scalar_output_files_ROI.f90
+++ b/src/UFEMISM/io/main_regional_output/scalar_output_files_ROI.f90
@@ -525,7 +525,7 @@ contains
     call init_routine( routine_name)
 
     ! if no NetCDF output should be created, do nothing
-    if (.not. C%do_create_ismip_output) then
+    if (.not. C%do_create_ismip_output .OR. .not. C%do_create_netcdf_output) then
       call finalise_routine( routine_name)
       return
     end if
@@ -591,7 +591,7 @@ contains
     call init_routine( routine_name)
 
     ! if no NetCDF output should be created, do nothing
-    if (.not. C%do_create_ismip_output) then
+    if (.not. C%do_create_ismip_output .OR. .not. C%do_create_netcdf_output) then
       call finalise_routine( routine_name)
       return
     end if

--- a/src/UFEMISM/io/main_regional_output/scalar_output_files_ROI.f90
+++ b/src/UFEMISM/io/main_regional_output/scalar_output_files_ROI.f90
@@ -525,7 +525,7 @@ contains
     call init_routine( routine_name)
 
     ! if no NetCDF output should be created, do nothing
-    if (.not. C%do_create_ISMIP_output) then
+    if (.not. C%do_create_ismip_output) then
       call finalise_routine( routine_name)
       return
     end if
@@ -591,7 +591,7 @@ contains
     call init_routine( routine_name)
 
     ! if no NetCDF output should be created, do nothing
-    if (.not. C%do_create_ISMIP_output) then
+    if (.not. C%do_create_ismip_output) then
       call finalise_routine( routine_name)
       return
     end if

--- a/src/UFEMISM/io/main_regional_output/scalar_output_files_ROI.f90
+++ b/src/UFEMISM/io/main_regional_output/scalar_output_files_ROI.f90
@@ -301,7 +301,7 @@ contains
     type(type_model_region), intent(inout) :: region
 
     ! Local variables:
-    character(len=1024), parameter :: routine_name = 'buffer_scalar_output'
+    character(len=1024), parameter :: routine_name = 'buffer_scalar_output_ROI'
     integer                        :: n, i_ROI
 
     ! Add routine to path

--- a/src/UFEMISM/io/main_regional_output/scalar_output_files_ROI.f90
+++ b/src/UFEMISM/io/main_regional_output/scalar_output_files_ROI.f90
@@ -307,6 +307,11 @@ contains
     ! Add routine to path
     call init_routine( routine_name)
 
+    if (.not. C%do_create_netcdf_output) then
+      call finalise_routine( routine_name)
+      return
+    end if
+
     ! Only the primary does this
     if (par%primary) then
 
@@ -694,6 +699,11 @@ contains
 
     ! Add routine to path
     call init_routine( routine_name)
+
+    if (.not. C%do_create_ismip_output .OR. .not. C%do_create_netcdf_output) then
+      call finalise_routine( routine_name)
+      return
+    end if
 
     ! Only the primary does this
     if (par%primary) then

--- a/src/UFEMISM/main/UFEMISM_main_model.f90
+++ b/src/UFEMISM/main/UFEMISM_main_model.f90
@@ -9,7 +9,7 @@ MODULE UFEMISM_main_model
   use UPSY_main, only: UPSY
   USE precisions                                             , ONLY: dp
   USE mpi_basic                                              , ONLY: par, sync
-  use call_stack_and_comp_time_tracking, only: crash, init_routine, finalise_routine
+  use call_stack_and_comp_time_tracking, only: crash, init_routine, finalise_routine, warning
   USE model_configuration                                    , ONLY: C
   USE parameters
   USE region_types                                           , ONLY: type_model_region
@@ -650,6 +650,9 @@ CONTAINS
        lambda_M = region%mesh%lambda_M, phi_M = region%mesh%phi_M, beta_stereo = region%mesh%beta_stereo)
 
     ! Create the main regional output files
+    if (C%do_create_ismip_output .AND. .not. C%do_create_netcdf_output) then
+       if (par%primary) call warning('NetCDF creation was set to False, but ISMIP creation was set to True. No ISMIP files will be created!')
+    end if
     CALL create_main_regional_output_file_mesh( region)
     CALL create_main_regional_output_file_grid( region)
     CALL create_ISMIP_regional_output_file_grid( region)

--- a/src/UFEMISM/main/UFEMISM_main_model.f90
+++ b/src/UFEMISM/main/UFEMISM_main_model.f90
@@ -226,7 +226,9 @@ CONTAINS
 
     ! Buffer scalar output data
     call buffer_scalar_output( region)
-    call buffer_ISMIP_scalar_output( region)
+    if (C%do_create_ismip_output) then
+      call buffer_ISMIP_scalar_output( region)
+    end if
 
     if (region%nROI > 0) then
       call buffer_scalar_output_ROI( region)


### PR DESCRIPTION
Added extra checks to make sure that no functions try to access (or create) files/scalars that were not created because their flags were disabled. Tested with all combinations of ROI/no-ROI, saving usual NetCDF files and also ISMIP files. Added one warning that ISMIP files won't be saved anyways if NC-file saving is set to false, even if the ISMIP flag is set to True.

Hopefully this fixes all remaining issues raised in #529 