### PR TITLE
Calving front flux

### DIFF
--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:24</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.6323</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.6321</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.632</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.6318</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:39</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.6323</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.6321</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.632</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.6318</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:18</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.6323</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.6321</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.632</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.6318</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:26</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>9.2535e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.0404e-05</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.00011207</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.00014998</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:40</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>9.2535e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.0404e-05</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.00011207</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.00014998</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:20</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>9.2535e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.0404e-05</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.00011207</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.00014998</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:28</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.22294</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.42479</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.74691</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.087</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:41</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.22294</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.42479</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.74691</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.087</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_fun_3.0000E+04_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:21</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.22294</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.42479</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.74691</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.087</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:29</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.0218</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0218</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.0217</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0217</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:42</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.0218</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0218</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.0217</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0217</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:22</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.0218</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0218</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.0217</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0217</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:30</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.3542e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0015207</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0030343</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0045392</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:43</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.3542e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0015207</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0030343</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0045392</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:22</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.3542e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0015207</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0030343</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0045392</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:32</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.21985</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.4874</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.9504</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>13.4051</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:43</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.21985</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.4874</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.9504</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>13.4051</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_x_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:23</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.21985</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.4874</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.9504</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>13.4051</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:33</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2827</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2826</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.2826</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2826</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:44</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2827</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2826</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.2826</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2826</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:24</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2827</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2826</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.2826</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2826</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:35</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.2019e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.002279</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0045468</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0068034</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:45</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.2019e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.002279</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0045468</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0068034</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:25</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.2019e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.002279</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0045468</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0068034</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:36</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.22041</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.4642</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.9057</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>13.339</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:46</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.22041</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.4642</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.9057</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>13.339</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_gradient_4.0000E+05-7.5000E+04_m_y_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:25</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.22041</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.4642</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.9057</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>13.339</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:37</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.5793</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.5793</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.5792</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.5791</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:47</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.5793</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.5793</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.5792</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.5791</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:26</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.5793</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.5793</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.5792</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.5791</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:38</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.1111e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0054681</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.010914</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.016339</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:47</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.1111e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0054681</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.010914</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.016339</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:27</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.1111e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0054681</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.010914</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.016339</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:39</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.18925</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.4783</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>6.9309</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>10.379</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:48</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.18925</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.4783</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>6.9309</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>10.379</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:28</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.18925</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.4783</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>6.9309</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>10.379</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:41</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>5.5983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.5983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.5982</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.5981</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:49</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>5.5983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.5983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.5982</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.5981</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:29</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>5.5983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.5983</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.5982</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.5981</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:42</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3457e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0049488</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0098842</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.014806</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:50</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3457e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0049488</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0098842</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.014806</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:29</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3457e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0049488</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0098842</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.014806</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:43</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.2381</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.015</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9948</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.974</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:50</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.2381</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.015</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9948</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.974</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_10_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:30</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.2381</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.015</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9948</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.974</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:44</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.9115</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.9115</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.9114</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.9113</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:51</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.9115</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.9115</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.9114</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.9113</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:31</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.9115</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.9115</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.9114</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.9113</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:45</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3079e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0020247</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.004044</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.006058</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:52</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3079e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0020247</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.004044</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.006058</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:32</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3079e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0020247</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.004044</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.006058</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:46</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23949</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.9606</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.8862</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.8113</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:53</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23949</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.9606</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.8862</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.8113</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:33</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23949</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.9606</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.8862</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.8113</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:47</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.8121</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8121</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.812</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8119</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:53</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.8121</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8121</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.812</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8119</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:34</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.8121</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8121</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.812</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8119</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:48</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3247e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0042416</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0084718</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.012691</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:54</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3247e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0042416</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0084718</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.012691</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:35</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3247e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0042416</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0084718</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.012691</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:49</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.2385</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.9866</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9378</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.8886</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:55</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.2385</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.9866</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9378</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.8886</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_4_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:36</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.2385</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.9866</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9378</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.8886</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:50</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.8928</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8927</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.8926</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8926</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:56</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.8928</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8927</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.8926</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8926</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:36</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.8928</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8927</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.8926</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.8926</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:51</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3289e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0046293</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0092462</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.013851</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:56</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3289e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0046293</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0092462</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.013851</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:37</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3289e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0046293</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0092462</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.013851</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:52</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23831</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0014</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9676</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.9332</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:57</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23831</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0014</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9676</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.9332</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_6_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:38</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23831</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0014</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9676</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.9332</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:53</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>7.5003</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.5003</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>7.5002</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.5002</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:58</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>7.5003</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.5003</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>7.5002</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.5002</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:39</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>7.5003</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.5003</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>7.5002</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.5002</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:54</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3373e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.00482</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.009627</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.014421</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:59</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3373e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.00482</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.009627</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.014421</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:40</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3373e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.00482</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.009627</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.014421</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:55</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23823</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0105</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9858</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.9605</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:26:59</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23823</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0105</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9858</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.9605</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_1.5000E+05_m_nit_Lloyd_8_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:41</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.23823</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.0105</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.9858</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>8.9605</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:56</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:27:00</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:42</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.1471</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:57</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0090051</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.017991</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.026958</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:27:01</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0090051</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.017991</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.026958</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:43</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0090051</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.017991</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.026958</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:58</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.31135</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.6359</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.2199</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.8075</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:27:01</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.31135</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.6359</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.2199</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.8075</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_2.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:43</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.31135</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.6359</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>5.2199</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>7.8075</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:23:59</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3869</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.3869</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.3869</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.3868</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:27:02</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3869</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.3869</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.3869</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.3868</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:44</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.3869</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.3869</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>2.3869</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.3868</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:24:00</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0021267</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0042505</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0063716</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:27:03</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0021267</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0042505</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0063716</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:45</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0021267</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.0042505</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0063716</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:24:01</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.42769</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2308</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>4.3518</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>6.4847</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:27:03</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.42769</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2308</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>4.3518</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>6.4847</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_3.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:46</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.42769</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.2308</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>4.3518</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>6.4847</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:24:02</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:27:04</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:47</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>1.0753</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:24:03</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0072914</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.014574</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.021848</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:27:05</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0072914</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.014574</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.021848</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:48</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>2.2737e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0072914</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.014574</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.021848</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:24:04</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.57588</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.0203</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.8555</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.716</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:27:06</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.57588</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.0203</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.8555</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.716</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_4.0000E+05_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:48</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.57588</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>2.0203</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.8555</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>5.716</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:24:05</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.4413</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.4412</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.4411</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.441</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:27:06</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.4413</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.4412</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.4411</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.441</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_Halfar</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:49</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>3.4413</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.4412</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>3.4411</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>3.441</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:24:07</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.6269e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0054374</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.010846</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.016226</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:27:07</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.6269e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0054374</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.010846</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.016226</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_linear</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:50</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>4.6269e-13</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.0054374</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>0.010846</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>0.016226</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic_8b4d7ba36a294f973cacd8b5719ba50fd7236f30.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>07-Apr-2026 13:24:08</date_and_time>
+    <git_hash_string>8b4d7ba36a294f973cacd8b5719ba50fd7236f30</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.1601</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.1438</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.2687</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>12.3847</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic_a94196133f8a6f6c73565a3877c09f3b9324691d.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>31-Mar-2026 16:27:08</date_and_time>
+    <git_hash_string>a94196133f8a6f6c73565a3877c09f3b9324691d</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.1601</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.1438</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.2687</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>12.3847</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
+++ b/automated_testing/scoreboard/scoreboard_files/ct_mass_conservation_mesh_vertices_to_grid_mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic_d015578e91220eab2415d9bbea5dadf3c900c922.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>mesh_Ant_uniform_7.5000E+04_m_nit_Lloyd_2_periodic</name>
+    <category>component_tests/mass_conservation/mesh_vertices_to_grid</category>
+    <date_and_time>08-Apr-2026 14:52:51</date_and_time>
+    <git_hash_string>d015578e91220eab2415d9bbea5dadf3c900c922</git_hash_string>
+    <cost_functions>
+        <name>rmse_explicit</name>
+        <definition>sqrt( mean( (dHi_dt_explicit - dHi_dt_ex).^2))</definition>
+        <value>0.1601</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_semiimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_semiimplicit - dHi_dt_ex).^2))</definition>
+        <value>4.1438</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_implicit</name>
+        <definition>sqrt( mean( (dHi_dt_implicit - dHi_dt_ex).^2))</definition>
+        <value>8.2687</value>
+    </cost_functions>
+    <cost_functions>
+        <name>rmse_overimplicit</name>
+        <definition>sqrt( mean( (dHi_dt_overimplicit - dHi_dt_ex).^2))</definition>
+        <value>12.3847</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_flowline_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_flowline_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_dHdt_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>31-Mar-2026 18:34:12</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>4.3855</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>828.0137</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>72.6631</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>18593</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>18593</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1308060</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_flowline_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_flowline_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_dHdt_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>08-Apr-2026 14:11:16</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>3.1644</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>811.8374</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>73.8058</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>11055</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>11055</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>721832</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_flowline_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_flowline_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_dHdt_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>07-Apr-2026 14:01:05</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>3.1644</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>811.8374</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>73.8058</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>11055</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>11055</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>721832</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_local_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_local_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_dHdt_local</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>31-Mar-2026 18:34:14</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>5.073</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>822.4263</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>74.9698</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>21399</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>21399</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1624627</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_local_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_local_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_dHdt_local</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>08-Apr-2026 14:11:18</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>2.7024</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>810.3534</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>74.5043</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>21265</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>21265</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1460404</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_local_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_dHdt_local_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_dHdt_local</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>07-Apr-2026 14:01:06</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>2.7024</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>810.3534</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>74.5043</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>21265</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>21265</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1460404</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_u_flowline_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_u_flowline_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_u_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>31-Mar-2026 18:34:15</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>5.1242</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>815.3737</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>76.5722</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>20999</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>20999</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1570972</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_u_flowline_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_u_flowline_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_u_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>08-Apr-2026 14:11:19</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>4.7929</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>801.7341</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>79.202</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>20842</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>20842</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1413853</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_u_flowline_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_H_u_flowline_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_H_u_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>07-Apr-2026 14:01:08</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>4.7929</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>801.7341</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>79.202</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>20842</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>20842</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1413853</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_dHdt_invfric_invBMB_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_dHdt_invfric_invBMB_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_dHdt_invfric_invBMB</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>31-Mar-2026 18:34:16</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.57332</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target [m]</definition>
+        <value>51.5106</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.6145</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_melt_rate</name>
+        <definition>95% of melt rates are within this range of its target [m/yr]</definition>
+        <value>3.9526</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>15544</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>15544</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1018737</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_dHdt_invfric_invBMB_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_dHdt_invfric_invBMB_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_dHdt_invfric_invBMB</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>08-Apr-2026 14:11:19</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.58784</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target [m]</definition>
+        <value>47.4221</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.50452</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_melt_rate</name>
+        <definition>95% of melt rates are within this range of its target [m/yr]</definition>
+        <value>5.1536</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>15542</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>15542</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1130344</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_dHdt_invfric_invBMB_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_II_dHdt_invfric_invBMB_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_II_dHdt_invfric_invBMB</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>07-Apr-2026 14:01:09</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.58784</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target [m]</definition>
+        <value>47.4221</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.50452</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_melt_rate</name>
+        <definition>95% of melt rates are within this range of its target [m/yr]</definition>
+        <value>5.1536</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>15542</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>15542</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1130344</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_flowline_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_flowline_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_dHdt_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>31-Mar-2026 18:00:15</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.035609</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>7.8603</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.026588</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>6876</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>6878</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>205982</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_flowline_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_flowline_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_dHdt_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>08-Apr-2026 13:43:06</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.04969</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>8.0841</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.059601</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>6923</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>6923</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>193758</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_flowline_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_flowline_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_dHdt_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>07-Apr-2026 13:36:21</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.04969</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>8.0841</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.059601</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>6923</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>6923</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>193758</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_local_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_local_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_dHdt_local</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>31-Mar-2026 18:00:17</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.17544</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>42.0573</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.14548</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>55315</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>55622</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>1306761</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_local_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_local_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_dHdt_local</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>08-Apr-2026 13:43:08</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.16445</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>44.9929</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.15101</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>12541</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>12753</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>340166</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_local_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_dHdt_local_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_dHdt_local</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>07-Apr-2026 13:36:23</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.16445</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>44.9929</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.15101</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>12541</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>12753</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>340166</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_u_flowline_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_u_flowline_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_u_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>31-Mar-2026 18:00:19</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.09678</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>30.3644</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.068248</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>39206</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>39232</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>936629</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_u_flowline_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_u_flowline_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_u_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>08-Apr-2026 13:43:09</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.10486</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>34.3711</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.087781</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>12361</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>12380</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>371222</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_u_flowline_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Berends2023_nudging_experiment_I_H_u_flowline_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>experiment_I_H_u_flowline</name>
+    <category>integrated_tests/idealised/Berends2023_nudging</category>
+    <date_and_time>07-Apr-2026 13:36:24</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>r95_till_friction_angle</name>
+        <definition>95% of till friction is within this fraction of its target</definition>
+        <value>0.10486</value>
+    </cost_functions>
+    <cost_functions>
+        <name>p95_ice_thickness</name>
+        <definition>95% of ice thickness is within this range of its target</definition>
+        <value>34.3711</value>
+    </cost_functions>
+    <cost_functions>
+        <name>r95_ice_velocity</name>
+        <definition>95% of ice velocity is within this fraction of its target</definition>
+        <value>0.087781</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>12361</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>12380</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>371222</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_10km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_10km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_10km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>31-Mar-2026 16:17:08</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>18.8854</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>1209</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_10km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_10km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_10km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>08-Apr-2026 14:19:17</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>18.731</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>1207</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_10km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_10km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_10km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>07-Apr-2026 12:56:40</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>18.731</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>1207</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_20km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_20km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_20km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>31-Mar-2026 16:17:07</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>22.603</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>760</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_20km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_20km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_20km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>08-Apr-2026 14:19:16</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>22.6084</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>765</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_20km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_20km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_20km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>07-Apr-2026 12:56:40</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>22.6084</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>765</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_40km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_40km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_40km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>31-Mar-2026 16:17:06</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>35.134</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>607</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_40km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_40km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_40km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>08-Apr-2026 14:19:15</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>35.1325</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>601</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_40km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_40km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_40km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>07-Apr-2026 12:56:38</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>35.1325</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>601</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_5km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_5km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_5km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>31-Mar-2026 16:17:09</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>13.3841</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>2648</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_5km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_5km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_5km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>08-Apr-2026 14:19:18</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>13.3833</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>2637</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_5km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_5km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_5km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>07-Apr-2026 12:56:41</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>13.3833</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>2637</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_10km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_10km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_10km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>31-Mar-2026 16:17:12</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>37.597</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27491</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_10km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_10km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_10km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>08-Apr-2026 14:19:21</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>37.5962</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27489</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_10km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_10km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_10km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>07-Apr-2026 12:56:44</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>37.5962</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27489</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_20km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_20km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_20km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>31-Mar-2026 16:17:10</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>50.4554</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27475</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_20km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_20km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_20km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>08-Apr-2026 14:19:20</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>50.4546</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27476</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_20km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_20km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_20km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>07-Apr-2026 12:56:43</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>50.4546</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27476</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_40km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_40km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_40km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>31-Mar-2026 16:17:10</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>45.7502</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27446</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_40km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_40km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_40km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>08-Apr-2026 14:19:19</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>45.7525</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27382</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_40km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_40km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_40km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>07-Apr-2026 12:56:42</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>45.7525</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27382</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_5km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_5km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_5km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>31-Mar-2026 16:17:13</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>28.47</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27494</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_5km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_5km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_5km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>08-Apr-2026 14:19:21</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>28.47</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27494</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_5km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_Hlf_dome_Halfar_static_5km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Halfar_static_5km</name>
+    <category>integrated_tests/idealised/Halfar_dome</category>
+    <date_and_time>07-Apr-2026 12:56:45</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi_analytical( :,end)).^2 ))</definition>
+        <value>28.47</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>27494</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>0</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIP_mod_MISMIP_mod_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIP_mod_MISMIP_mod_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>MISMIP_mod</name>
+    <category>integrated_tests/idealised/MISMIP_mod</category>
+    <date_and_time>31-Mar-2026 16:16:28</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>GL_hyst_east</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>756.0677</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_northeast</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>4272.8497</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_north</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>4611.531</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_northwest</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>12241.9612</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_west</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>11449.9121</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_southwest</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>5028.3411</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_south</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>7971.4747</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_southeast</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>2202.0596</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>6019</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>6143</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>563116</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIP_mod_MISMIP_mod_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIP_mod_MISMIP_mod_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>MISMIP_mod</name>
+    <category>integrated_tests/idealised/MISMIP_mod</category>
+    <date_and_time>08-Apr-2026 13:07:05</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>GL_hyst_east</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>9011.9531</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_northeast</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>9314.4478</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_north</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>4400.4997</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_northwest</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>506.2793</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_west</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>548.1282</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_southwest</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>385.2031</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_south</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>8885.2927</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_southeast</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>8148.4135</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>5772</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>5772</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>321917</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIP_mod_MISMIP_mod_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIP_mod_MISMIP_mod_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>MISMIP_mod</name>
+    <category>integrated_tests/idealised/MISMIP_mod</category>
+    <date_and_time>07-Apr-2026 13:19:13</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>GL_hyst_east</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>9011.9531</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_northeast</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>9314.4478</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_north</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>4400.4997</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_northwest</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>506.2793</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_west</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>548.1282</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_southwest</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>385.2031</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_south</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>8885.2927</value>
+    </cost_functions>
+    <cost_functions>
+        <name>GL_hyst_southeast</name>
+        <definition>abs( rGL_retreat(end) - rGL_spinup(end) )</definition>
+        <value>8148.4135</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>5772</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>5772</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>321917</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISMIPplus_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISMIPplus_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>MISMIPplus</name>
+    <category>integrated_tests/idealised/MISMIPplus</category>
+    <date_and_time>31-Mar-2026 17:04:22</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>err_x_GL_init</name>
+        <definition>abs( x_GL(1) - 450e3)</definition>
+        <value>828.6411</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_lo</name>
+        <definition>abs( min( 0, x_GL( end) - 350e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_hi</name>
+        <definition>abs( max( 0, x_GL( end) - 420e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>var_x_GL</name>
+        <definition>max( abs( x_GL_smooth - x_GL))</definition>
+        <value>887.7368</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>6786</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>6786</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>612685</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISMIPplus_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISMIPplus_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>MISMIPplus</name>
+    <category>integrated_tests/idealised/MISMIPplus</category>
+    <date_and_time>08-Apr-2026 13:56:39</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>err_x_GL_init</name>
+        <definition>abs( x_GL(1) - 450e3)</definition>
+        <value>799.123</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_lo</name>
+        <definition>abs( min( 0, x_GL( end) - 350e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_hi</name>
+        <definition>abs( max( 0, x_GL( end) - 420e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>var_x_GL</name>
+        <definition>max( abs( x_GL_smooth - x_GL))</definition>
+        <value>1116.3866</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>6792</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>6792</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>604063</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISMIPplus_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_MISMIPplus_MISMIPplus_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>MISMIPplus</name>
+    <category>integrated_tests/idealised/MISMIPplus</category>
+    <date_and_time>07-Apr-2026 13:31:33</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>err_x_GL_init</name>
+        <definition>abs( x_GL(1) - 450e3)</definition>
+        <value>799.123</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_lo</name>
+        <definition>abs( min( 0, x_GL( end) - 350e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>err_x_GL_final_hi</name>
+        <definition>abs( max( 0, x_GL( end) - 420e3))</definition>
+        <value>0</value>
+    </cost_functions>
+    <cost_functions>
+        <name>var_x_GL</name>
+        <definition>max( abs( x_GL_smooth - x_GL))</definition>
+        <value>1116.3866</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>6792</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>6792</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>604063</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_SSA_icestream_SSA_icestream_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_SSA_icestream_SSA_icestream_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>SSA_icestream</name>
+    <category>integrated_tests/idealised/SSA_icestream</category>
+    <date_and_time>31-Mar-2026 16:33:11</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>RMSE_32km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>384.8429</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_16km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>283.241</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_8km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>127.2302</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_4km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>85.3579</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>1</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>524</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>338870</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_SSA_icestream_SSA_icestream_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_SSA_icestream_SSA_icestream_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>SSA_icestream</name>
+    <category>integrated_tests/idealised/SSA_icestream</category>
+    <date_and_time>08-Apr-2026 13:38:37</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>RMSE_32km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>384.8429</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_16km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>283.241</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_8km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>127.2302</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_4km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>85.3579</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>1</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>524</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>338870</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_ideal_SSA_icestream_SSA_icestream_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_ideal_SSA_icestream_SSA_icestream_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>SSA_icestream</name>
+    <category>integrated_tests/idealised/SSA_icestream</category>
+    <date_and_time>07-Apr-2026 13:30:42</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>RMSE_32km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>384.8429</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_16km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>283.241</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_8km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>127.2302</value>
+    </cost_functions>
+    <cost_functions>
+        <name>RMSE_4km</name>
+        <definition>sqrt( mean( (u_surf - u_an).^2 ))</definition>
+        <value>85.3579</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>1</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>524</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>338870</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_realistic_Antarctica_initialisation_Ant_init_20kyr_invBMB_invfric_40km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_realistic_Antarctica_initialisation_Ant_init_20kyr_invBMB_invfric_40km_409263a96d5ec60ad211eccb949a5b053008b2d7.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Ant_init_20kyr_invBMB_invfric_40km</name>
+    <category>integrated_tests/realistic/Antarctica/initialisation</category>
+    <date_and_time>31-Mar-2026 18:15:53</date_and_time>
+    <git_hash_string>409263a96d5ec60ad211eccb949a5b053008b2d7</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi( :,1)).^2 ))</definition>
+        <value>77.4484</value>
+    </cost_functions>
+    <cost_functions>
+        <name>peak_volume_difference</name>
+        <definition>max( abs( ice_volume - ice_volume(1)))</definition>
+        <value>0.96092</value>
+    </cost_functions>
+    <cost_functions>
+        <name>final_volume_difference</name>
+        <definition>ice_volume( end) - ice_volume(1)</definition>
+        <value>0.21953</value>
+    </cost_functions>
+    <cost_functions>
+        <name>ice_volume_var</name>
+        <definition>max( ice_volume( last 5000 yr)) - min( ice_volume( last 5000 yr))</definition>
+        <value>0.0099299</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>30608</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>30937</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>2531695</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_realistic_Antarctica_initialisation_Ant_init_20kyr_invBMB_invfric_40km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_realistic_Antarctica_initialisation_Ant_init_20kyr_invBMB_invfric_40km_63b8df58dbdfec25334aa863246b2a7cdcd09326.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Ant_init_20kyr_invBMB_invfric_40km</name>
+    <category>integrated_tests/realistic/Antarctica/initialisation</category>
+    <date_and_time>08-Apr-2026 15:18:25</date_and_time>
+    <git_hash_string>63b8df58dbdfec25334aa863246b2a7cdcd09326</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi( :,1)).^2 ))</definition>
+        <value>76.1789</value>
+    </cost_functions>
+    <cost_functions>
+        <name>peak_volume_difference</name>
+        <definition>max( abs( ice_volume - ice_volume(1)))</definition>
+        <value>0.90936</value>
+    </cost_functions>
+    <cost_functions>
+        <name>final_volume_difference</name>
+        <definition>ice_volume( end) - ice_volume(1)</definition>
+        <value>0.18142</value>
+    </cost_functions>
+    <cost_functions>
+        <name>ice_volume_var</name>
+        <definition>max( ice_volume( last 5000 yr)) - min( ice_volume( last 5000 yr))</definition>
+        <value>0.017393</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>30858</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>31468</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>2410872</value>
+    </cost_functions>
+</single_run>

--- a/automated_testing/scoreboard/scoreboard_files/it_realistic_Antarctica_initialisation_Ant_init_20kyr_invBMB_invfric_40km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
+++ b/automated_testing/scoreboard/scoreboard_files/it_realistic_Antarctica_initialisation_Ant_init_20kyr_invBMB_invfric_40km_6cb72285a1425b506964c495c2db8151b0ce2d5a.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<single_run>
+    <name>Ant_init_20kyr_invBMB_invfric_40km</name>
+    <category>integrated_tests/realistic/Antarctica/initialisation</category>
+    <date_and_time>07-Apr-2026 14:28:16</date_and_time>
+    <git_hash_string>6cb72285a1425b506964c495c2db8151b0ce2d5a</git_hash_string>
+    <cost_functions>
+        <name>rmse</name>
+        <definition>sqrt( mean( (Hi( :,end) - Hi( :,1)).^2 ))</definition>
+        <value>75.8674</value>
+    </cost_functions>
+    <cost_functions>
+        <name>peak_volume_difference</name>
+        <definition>max( abs( ice_volume - ice_volume(1)))</definition>
+        <value>0.91281</value>
+    </cost_functions>
+    <cost_functions>
+        <name>final_volume_difference</name>
+        <definition>ice_volume( end) - ice_volume(1)</definition>
+        <value>0.19154</value>
+    </cost_functions>
+    <cost_functions>
+        <name>ice_volume_var</name>
+        <definition>max( ice_volume( last 5000 yr)) - min( ice_volume( last 5000 yr))</definition>
+        <value>0.013958</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_dt_ice</name>
+        <definition>total number of ice-dynamical time steps</definition>
+        <value>30883</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_visc_its</name>
+        <definition>total number of viscosity iterations</definition>
+        <value>31304</value>
+    </cost_functions>
+    <cost_functions>
+        <name>n_Axb_its</name>
+        <definition>total number of linear solver iterations</definition>
+        <value>2361199</value>
+    </cost_functions>
+</single_run>

--- a/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_explicit.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_explicit.f90
@@ -4,6 +4,7 @@ module conservation_of_mass_explicit
   use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine, crash
   use model_configuration, only: C
   use mesh_types, only: type_mesh
+  use ice_model_types, only: type_ice_model
   use CSR_sparse_matrix_type, only: type_sparse_matrix_CSR_dp
   use ice_geometry_basics, only: ice_surface_elevation, Hi_from_Hb_Hs_and_SL
   use mpi_distributed_memory, only: gather_to_all
@@ -19,7 +20,7 @@ module conservation_of_mass_explicit
 
 contains
 
-  subroutine calc_dHi_dt_explicit( mesh, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+  subroutine calc_dHi_dt_explicit( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
     fraction_margin, mask_noice, dt, dHi_dt, Hi_tplusdt, divQ, dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     !< Calculate ice thickness rates of change (dH/dt)
     !< Use a time-explicit discretisation scheme for the ice fluxes
@@ -47,6 +48,7 @@ contains
 
     ! In/output variables:
     type(type_mesh),                        intent(in   )           :: mesh                  ! [-]       The model mesh
+    type(type_ice_model),                   intent(inout)           :: ice                   ! [-]       The ice model
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: Hi                    ! [m]       Ice thickness at time t
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: Hb                    ! [m]       Bedrock elevation at time t
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: SL                    ! [m]       Water surface elevation at time t
@@ -76,7 +78,7 @@ contains
     call init_routine( routine_name)
 
     ! Calculate the ice flux divergence matrix M_divQ using an upwind scheme
-    call calc_ice_flux_divergence_matrix_upwind( mesh, u_vav_b, v_vav_b, fraction_margin, M_divQ)
+    call calc_ice_flux_divergence_matrix_upwind( mesh, ice, u_vav_b, v_vav_b, fraction_margin, M_divQ)
 
     ! Calculate the ice flux divergence div(Q)
     call multiply_CSR_matrix_with_vector_1D_wrapper( M_divQ, &

--- a/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_main.f90
@@ -12,6 +12,7 @@ module conservation_of_mass_main
   use conservation_of_mass_explicit, only: calc_dHi_dt_explicit, apply_ice_thickness_BC_explicit
   use conservation_of_mass_semiimplicit, only: calc_dHi_dt_semiimplicit
   use mpi_f08, only: MPI_ALLREDUCE, MPI_IN_PLACE, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD
+  use ice_thickness_safeties, only: calc_and_apply_spill_over_flux
 
   implicit none
 
@@ -78,6 +79,9 @@ contains
       call calc_dHi_dt_semiimplicit( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
         fraction_margin, mask_noice, dt, dHi_dt, Hi_tplusdt, divQ, dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     end select
+
+    ! Apply spill over from overfilled margin cells
+    call calc_and_apply_spill_over_flux( mesh, ice, Hi_tplusdt, dt)
 
     ! Limit Hi( t+dt) to zero; throw a warning if negative thickness are encountered
     found_negative_vals = .false.

--- a/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_main.f90
@@ -6,6 +6,7 @@ module conservation_of_mass_main
   use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine, crash, warning
   use model_configuration, only: C
   use mesh_types, only: type_mesh
+  use ice_model_types, only: type_ice_model
   use conservation_of_mass_utilities, only: calc_ice_flux_divergence_matrix_upwind, &
     apply_mask_noice_direct, calc_flux_limited_timestep
   use conservation_of_mass_explicit, only: calc_dHi_dt_explicit, apply_ice_thickness_BC_explicit
@@ -20,12 +21,13 @@ module conservation_of_mass_main
 
 contains
 
-  subroutine calc_dHi_dt( mesh, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+  subroutine calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
     fraction_margin, mask_noice, dt, dHi_dt, Hi_tplusdt, divQ, dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     !< Calculate ice thickness at time t+dt
 
     ! In/output variables:
     type(type_mesh),                        intent(in   )           :: mesh                  ! [-]       The model mesh
+    type(type_ice_model),                   intent(inout)           :: ice                   ! [-]       The ice model
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: Hi                    ! [m]       Ice thickness at time t
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: Hb                    ! [m]       Bedrock elevation at time t
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: SL                    ! [m]       Water surface elevation at time t
@@ -70,10 +72,10 @@ contains
       return
 
     case ('explicit')
-      call calc_dHi_dt_explicit( mesh, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+      call calc_dHi_dt_explicit( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
         fraction_margin, mask_noice, dt, dHi_dt, Hi_tplusdt, divQ, dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     case ('semi-implicit')
-      call calc_dHi_dt_semiimplicit( mesh, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+      call calc_dHi_dt_semiimplicit( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
         fraction_margin, mask_noice, dt, dHi_dt, Hi_tplusdt, divQ, dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     end select
 

--- a/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_semiimplicit.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_semiimplicit.f90
@@ -4,6 +4,7 @@ module conservation_of_mass_semiimplicit
   use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine, crash
   use model_configuration, only: C
   use mesh_types, only: type_mesh
+  use ice_model_types, only: type_ice_model
   use CSR_sparse_matrix_type, only: type_sparse_matrix_CSR_dp
   use CSR_matrix_basics, only: duplicate_matrix_CSR_dist, finalise_matrix_CSR_dist, &
      set_diagonal_to_one_and_rest_of_row_to_zero
@@ -20,7 +21,7 @@ module conservation_of_mass_semiimplicit
 
 contains
 
-  subroutine calc_dHi_dt_semiimplicit( mesh, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+  subroutine calc_dHi_dt_semiimplicit( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
     fraction_margin, mask_noice, dt, dHi_dt, Hi_tplusdt, divQ, dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     !< Calculate ice thickness rates of change (dH/dt)
     !< Use a semi-implicit time discretisation scheme for the ice fluxes
@@ -69,6 +70,7 @@ contains
 
     ! In/output variables:
     type(type_mesh),                        intent(in   )           :: mesh                  ! [-]       The model mesh
+    type(type_ice_model),                   intent(inout)           :: ice                   ! [-]       The ice model
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: Hi                    ! [m]       Ice thickness at time t
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: Hb                    ! [m]       Bedrock elevation at time t
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: SL                    ! [m]       Water surface elevation at time t
@@ -105,13 +107,13 @@ contains
     ! First calculate the explicit solution (used to estimate the time step,
     ! and to apply boundary conditions at the domain border)
     dt_ex = dt
-    call calc_dHi_dt_explicit( mesh, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB_ex, &
+    call calc_dHi_dt_explicit( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB_ex, &
       fraction_margin, mask_noice, dt_ex, dHi_dt_ex, Hi_tplusdt_ex, divQ_ex, &
       dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     dt_max = dt_ex
 
     ! Calculate the ice flux divergence matrix M_divQ using an upwind scheme
-    call calc_ice_flux_divergence_matrix_upwind( mesh, u_vav_b, v_vav_b, fraction_margin, M_divQ)
+    call calc_ice_flux_divergence_matrix_upwind( mesh, ice, u_vav_b, v_vav_b, fraction_margin, M_divQ)
 
     ! Calculate the ice flux divergence div(Q)
     call multiply_CSR_matrix_with_vector_1D_wrapper( M_divQ, &

--- a/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_utilities.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_utilities.f90
@@ -4,6 +4,7 @@ module conservation_of_mass_utilities
   use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine
   use model_configuration, only: C
   use mesh_types, only: type_mesh
+  use ice_model_types, only: type_ice_model
   use CSR_sparse_matrix_type, only: type_sparse_matrix_CSR_dp
   use CSR_matrix_basics, only: allocate_matrix_CSR_dist, add_entry_CSR_dist, finalise_matrix_CSR_dist
   use map_velocities_to_c_grid, only: map_velocities_from_b_to_c_2D
@@ -19,7 +20,7 @@ module conservation_of_mass_utilities
 
 contains
 
-  subroutine calc_ice_flux_divergence_matrix_upwind( mesh, u_vav_b, v_vav_b, fraction_margin, M_divQ)
+  subroutine calc_ice_flux_divergence_matrix_upwind( mesh, ice, u_vav_b, v_vav_b, fraction_margin, M_divQ)
     !< Calculate the ice flux divergence matrix M_divQ using an upwind scheme
 
     ! The vertically averaged ice flux divergence represents the net ice volume (which,
@@ -33,6 +34,7 @@ contains
 
     ! In/output variables:
     type(type_mesh),                        intent(in   ) :: mesh
+    type(type_ice_model),                   intent(inout) :: ice
     real(dp), dimension(mesh%ti1:mesh%ti1), intent(in   ) :: u_vav_b
     real(dp), dimension(mesh%ti1:mesh%ti1), intent(in   ) :: v_vav_b
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: fraction_margin
@@ -46,7 +48,6 @@ contains
     integer                                :: ncols, ncols_loc, nrows, nrows_loc, nnz_est_proc
     integer                                :: vi, ci, ei, vj
     real(dp)                               :: A_i, L_c
-    real(dp)                               :: u_perp
     real(dp), dimension(0:mesh%nC_mem)     :: cM_divQ
 
     ! Add routine to path
@@ -74,6 +75,8 @@ contains
     ! == Calculate coefficients
     ! =========================
 
+    ice%u_perp = 0._dp
+
     do vi = mesh%vi1, mesh%vi2
 
       ! Initialise
@@ -94,21 +97,21 @@ contains
         L_c = mesh%Cw( vi,ci)
 
         ! Calculate vertically averaged ice velocity component perpendicular to this shared Voronoi cell boundary section
-        u_perp = u_vav_c_tot( ei) * mesh%D_x( vi, ci)/mesh%D( vi, ci) + v_vav_c_tot( ei) * mesh%D_y( vi, ci)/mesh%D( vi, ci)
+        ice%u_perp( vi, ci) = u_vav_c_tot( ei) * mesh%D_x( vi, ci)/mesh%D( vi, ci) + v_vav_c_tot( ei) * mesh%D_y( vi, ci)/mesh%D( vi, ci)
 
         ! Calculate matrix coefficients
         ! =============================
 
         ! u_perp > 0: flow is exiting this vertex into vertex vj
         if (fraction_margin_tot( vi) >= 1._dp) then
-          cM_divQ( 0) = cM_divQ( 0) + L_c * max( 0._dp, u_perp) / A_i
+          cM_divQ( 0) = cM_divQ( 0) + L_c * max( 0._dp, ice%u_perp( vi, ci)) / A_i
         else
           ! if this vertex is not completely covering its assigned area, then don't let ice out of it yet.
         end if
 
         ! u_perp < 0: flow is entering this vertex from vertex vj
         if (fraction_margin_tot( vj) >= 1._dp) then
-          cM_divQ( ci) = L_c * MIN( 0._dp, u_perp) / A_i
+          cM_divQ( ci) = L_c * MIN( 0._dp, ice%u_perp( vi, ci)) / A_i
         else
           ! if that vertex is not completely covering its assigned area, then don't let ice out of it yet.
         end if

--- a/src/UFEMISM/ice_dynamics/ice_dynamics_main.f90
+++ b/src/UFEMISM/ice_dynamics/ice_dynamics_main.f90
@@ -671,6 +671,8 @@ contains
 
     call reallocate_bounds( ice%divQ   , mesh_new%vi1, mesh_new%vi2)  ! [m yr^-1] Horizontal ice flux divergence
     call reallocate_bounds( ice%R_shear, mesh_new%vi1, mesh_new%vi2)  ! [0-1]     uabs_base / uabs_surf (0 = pure vertical shear, viscous flow; 1 = pure sliding, plug flow)
+    call reallocate_bounds( ice%Qspill , mesh_new%vi1, mesh_new%vi2)  ! [m yr^-1] Horizontal ice flux due to spill over of filled cells
+    call reallocate_bounds( ice%u_perp, mesh_new%vi1, mesh_new%vi2, mesh_new%nC_mem)  ! [m yr^-1] Ice velocity perpendicular to edge
 
     ! == Basal hydrology ==
     ! =====================
@@ -1261,7 +1263,7 @@ contains
         BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b, BC_prescr_mask_bk, BC_prescr_u_bk, BC_prescr_v_bk)
 
       ! Calculate dH/dt around the calving front
-      call calc_dHi_dt( mesh, ice%Hi, ice%Hb, ice%SL, ice%u_vav_b, ice%v_vav_b, SMB_new, BMB_new, LMB_new, AMB_new, ice%fraction_margin, ice%mask_noice, C%dt_ice_min, &
+      call calc_dHi_dt( mesh, ice, ice%Hi, ice%Hb, ice%SL, ice%u_vav_b, ice%v_vav_b, SMB_new, BMB_new, LMB_new, AMB_new, ice%fraction_margin, ice%mask_noice, C%dt_ice_min, &
         ice%dHi_dt, Hi_tplusdt, divQ, ice%dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
 
       ! Update ice thickness and advance pseudo-time
@@ -1372,7 +1374,7 @@ contains
         BMB_dummy, region%name, n_visc_its, n_Axb_its)
 
       ! Calculate thinning rates for current geometry and velocity
-      call calc_dHi_dt( region%mesh, region%ice%Hi, region%ice%Hb, region%ice%SL, region%ice%u_vav_b, region%ice%v_vav_b, SMB_dummy, BMB_dummy, LMB_dummy, AMB_dummy, region%ice%fraction_margin, &
+      call calc_dHi_dt( region%mesh, region%ice, region%ice%Hi, region%ice%Hb, region%ice%SL, region%ice%u_vav_b, region%ice%v_vav_b, SMB_dummy, BMB_dummy, LMB_dummy, AMB_dummy, region%ice%fraction_margin, &
                         region%ice%mask_noice, t_step, dHi_dt_new, Hi_new, region%ice%divQ, dHi_dt_target_dummy)
 
       ! Set ice model ice thickness to relaxed field

--- a/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
+++ b/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
@@ -125,7 +125,7 @@ contains
       ! ====================
 
       ! Calculate thinning rates for current geometry and velocity
-      call calc_dHi_dt( region%mesh, region%ice%Hi, region%ice%Hb, region%ice%SL, region%ice%u_vav_b, region%ice%v_vav_b, SMB_loc, region%BMB%BMB, region%LMB%LMB, region%AMB%AMB, region%ice%fraction_margin, &
+      call calc_dHi_dt( region%mesh, region%ice, region%ice%Hi, region%ice%Hb, region%ice%SL, region%ice%u_vav_b, region%ice%v_vav_b, SMB_loc, region%BMB%BMB, region%LMB%LMB, region%AMB%AMB, region%ice%fraction_margin, &
                         region%ice%mask_noice, region%ice%pc%dt_np1, region%ice%pc%dHi_dt_Hi_n_u_n, Hi_dummy, region%ice%divQ, region%ice%dHi_dt_target)
 
       ! Making sure verticies in no ice mask have zero thinning rates
@@ -208,7 +208,7 @@ contains
       call calc_effective_thickness( region%mesh, region%ice%Hi, region%ice%Hb,region%ice%SL,region%ice%Hi_eff, region%ice%fraction_margin)
 
       ! Calculate thinning rates for the current ice thickness and predicted velocity
-      call calc_dHi_dt( region%mesh, region%ice%Hi, region%ice%Hb, region%ice%SL, region%ice%u_vav_b, region%ice%v_vav_b, SMB_loc, region%BMB%BMB, region%LMB%LMB, region%AMB%AMB, region%ice%fraction_margin, &
+      call calc_dHi_dt( region%mesh, region%ice, region%ice%Hi, region%ice%Hb, region%ice%SL, region%ice%u_vav_b, region%ice%v_vav_b, SMB_loc, region%BMB%BMB, region%LMB%LMB, region%AMB%AMB, region%ice%fraction_margin, &
                         region%ice%mask_noice, region%ice%pc%dt_np1, region%ice%pc%dHi_dt_Hi_star_np1_u_np1, Hi_dummy, region%ice%divQ, region%ice%dHi_dt_target)
 
       ! Making sure verticies in no ice mask have zero thinning rates

--- a/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
+++ b/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
@@ -14,7 +14,7 @@ module predictor_corrector_scheme
   use netcdf_io_main
   use time_step_criteria, only: calc_critical_timestep_adv
   use conservation_of_mass_main, only: calc_dHi_dt
-  use ice_thickness_safeties, only: alter_ice_thickness, calc_and_apply_spill_over_flux
+  use ice_thickness_safeties, only: alter_ice_thickness
   use ice_geometry_basics, only: ice_surface_elevation
   use masks_mod, only: determine_masks
   use subgrid_grounded_fractions_main, only: calc_grounded_fractions
@@ -139,9 +139,6 @@ contains
       region%ice%pc%Hi_star_np1 = region%ice%Hi_prev + region%ice%pc%dt_np1 * ((1._dp + region%ice%pc%zeta_t / 2._dp) * &
         region%ice%pc%dHi_dt_Hi_n_u_n - (region%ice%pc%zeta_t / 2._dp) * region%ice%pc%dHi_dt_Hi_nm1_u_nm1)
 
-      ! Apply spill over from overfilled margin cells
-      ! call calc_and_apply_spill_over_flux( region%mesh, region%ice, region%ice%pc%Hi_star_np1, region%ice%pc%dt_np1)
-
       ! if so desired, modify the predicted ice thickness field based on user-defined settings
       call alter_ice_thickness( region%mesh, region%ice, region%ice%Hi_prev, region%ice%Hb, region%ice%SL, region%ice%pc%Hi_star_np1, region%refgeo_PD, region%time)
       
@@ -227,9 +224,6 @@ contains
 
       ! Save "raw" thinning rates, as applied after the corrector step
       region%ice%dHi_dt_raw = (region%ice%pc%Hi_np1 - region%ice%Hi_prev) / region%ice%pc%dt_np1
-
-      ! Apply spill over from overfilled margin cells
-      call calc_and_apply_spill_over_flux( region%mesh, region%ice, region%ice%pc%Hi_star_np1, region%ice%pc%dt_np1)
 
       ! if so desired, modify the corrected ice thickness field based on user-defined settings
       call alter_ice_thickness( region%mesh, region%ice, region%ice%Hi_prev, region%ice%Hb, region%ice%SL, region%ice%pc%Hi_np1, region%refgeo_PD, region%time)

--- a/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
+++ b/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
@@ -14,7 +14,7 @@ module predictor_corrector_scheme
   use netcdf_io_main
   use time_step_criteria, only: calc_critical_timestep_adv
   use conservation_of_mass_main, only: calc_dHi_dt
-  use ice_thickness_safeties, only: alter_ice_thickness
+  use ice_thickness_safeties, only: alter_ice_thickness, calc_and_apply_spill_over_flux
   use ice_geometry_basics, only: ice_surface_elevation
   use masks_mod, only: determine_masks
   use subgrid_grounded_fractions_main, only: calc_grounded_fractions
@@ -139,6 +139,9 @@ contains
       region%ice%pc%Hi_star_np1 = region%ice%Hi_prev + region%ice%pc%dt_np1 * ((1._dp + region%ice%pc%zeta_t / 2._dp) * &
         region%ice%pc%dHi_dt_Hi_n_u_n - (region%ice%pc%zeta_t / 2._dp) * region%ice%pc%dHi_dt_Hi_nm1_u_nm1)
 
+      ! Apply spill over from overfilled margin cells
+      call calc_and_apply_spill_over_flux( region%mesh, region%ice, region%ice%pc%Hi_star_np1, region%ice%pc%dt_np1)
+
       ! if so desired, modify the predicted ice thickness field based on user-defined settings
       call alter_ice_thickness( region%mesh, region%ice, region%ice%Hi_prev, region%ice%Hb, region%ice%SL, region%ice%pc%Hi_star_np1, region%refgeo_PD, region%time)
       
@@ -224,6 +227,9 @@ contains
 
       ! Save "raw" thinning rates, as applied after the corrector step
       region%ice%dHi_dt_raw = (region%ice%pc%Hi_np1 - region%ice%Hi_prev) / region%ice%pc%dt_np1
+
+      ! Apply spill over from overfilled margin cells
+      call calc_and_apply_spill_over_flux( region%mesh, region%ice, region%ice%pc%Hi_star_np1, region%ice%pc%dt_np1)
 
       ! if so desired, modify the corrected ice thickness field based on user-defined settings
       call alter_ice_thickness( region%mesh, region%ice, region%ice%Hi_prev, region%ice%Hb, region%ice%SL, region%ice%pc%Hi_np1, region%refgeo_PD, region%time)

--- a/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
+++ b/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
@@ -140,7 +140,7 @@ contains
         region%ice%pc%dHi_dt_Hi_n_u_n - (region%ice%pc%zeta_t / 2._dp) * region%ice%pc%dHi_dt_Hi_nm1_u_nm1)
 
       ! Apply spill over from overfilled margin cells
-      call calc_and_apply_spill_over_flux( region%mesh, region%ice, region%ice%pc%Hi_star_np1, region%ice%pc%dt_np1)
+      ! call calc_and_apply_spill_over_flux( region%mesh, region%ice, region%ice%pc%Hi_star_np1, region%ice%pc%dt_np1)
 
       ! if so desired, modify the predicted ice thickness field based on user-defined settings
       call alter_ice_thickness( region%mesh, region%ice, region%ice%Hi_prev, region%ice%Hb, region%ice%SL, region%ice%pc%Hi_star_np1, region%refgeo_PD, region%time)

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
@@ -414,19 +414,35 @@ contains
         end if
 
         ! Floating calving front
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) THEN
-          scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+        !if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
+        !  scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+        !end if
+
+        ! Add Qspill
+        if (ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
+          scalars%cf_fl_flux = scalars%cf_fl_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp
         end if
 
         ! Land-terminating ice (grounded or floating)
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
-          scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+        !if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
+        !  scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+        !end if
+
+        ! Add Qspill
+        if (ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) then
+          scalars%cf_gr_flux = scalars%cf_gr_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp
         end if
 
         ! Marine-terminating ice (grounded or floating)
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
-          scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+        !if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
+        !  scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+        !end if
+
+        ! Add Qspill
+        if (ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
+          scalars%margin_ocean_flux = scalars%margin_ocean_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp
         end if
+
 
       end do ! do ci = 1, mesh%nC( vi)
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
@@ -409,23 +409,13 @@ contains
         end if
 
         ! Grounded marine front
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) THEN
+        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) THEN
           scalars%cf_gr_flux = scalars%cf_gr_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
-        ! Add spill over
-        if (ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) then
-          scalars%cf_gr_flux = scalars%cf_gr_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp ! [Gt/yr]
-        end if
-
         ! Floating calving front
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill(vi ) ==0._dp) THEN
+        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) THEN
           scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
-        end if
-
-        ! Add spill over
-        if (ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
-          scalars%cf_fl_flux = scalars%cf_fl_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp ! [Gt/yr]
         end if
 
         ! Land-terminating ice (grounded or floating)
@@ -434,15 +424,9 @@ contains
         end if
 
         ! Marine-terminating ice (grounded or floating)
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
+        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
           scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
-
-        ! Add spill over
-        if (ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
-          scalars%margin_ocean_flux = scalars%margin_ocean_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp ! [Gt/yr]
-        end if
-
 
       end do ! do ci = 1, mesh%nC( vi)
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
@@ -409,22 +409,22 @@ contains
         end if
 
         ! Grounded marine front
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) THEN
+        if (fraction_margin_tot( vi) > 0._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) THEN
           scalars%cf_gr_flux = scalars%cf_gr_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
         ! Floating calving front
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
+        if (fraction_margin_tot( vi) > 0._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
           scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
         ! Land-terminating ice (grounded or floating)
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
+        if (fraction_margin_tot( vi) > 0._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
           scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
         ! Marine-terminating ice (grounded or floating)
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
+        if (fraction_margin_tot( vi) > 0._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
           scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
@@ -414,35 +414,19 @@ contains
         end if
 
         ! Floating calving front
-        !if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
-        !  scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
-        !end if
-
-        ! Add Qspill
-        if (ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
-          scalars%cf_fl_flux = scalars%cf_fl_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp
+        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
+          scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
         ! Land-terminating ice (grounded or floating)
-        !if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
-        !  scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
-        !end if
-
-        ! Add Qspill
-        if (ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) then
-          scalars%cf_gr_flux = scalars%cf_gr_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp
+        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
+          scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
         ! Marine-terminating ice (grounded or floating)
-        !if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
-        !  scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
-        !end if
-
-        ! Add Qspill
-        if (ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
-          scalars%margin_ocean_flux = scalars%margin_ocean_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp
+        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
+          scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
-
 
       end do ! do ci = 1, mesh%nC( vi)
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
@@ -409,13 +409,23 @@ contains
         end if
 
         ! Grounded marine front
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) THEN
+        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) THEN
           scalars%cf_gr_flux = scalars%cf_gr_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
+        ! Add spill over
+        if (ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) then
+          scalars%cf_gr_flux = scalars%cf_gr_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp ! [Gt/yr]
+        end if
+
         ! Floating calving front
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) THEN
+        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill(vi ) ==0._dp) THEN
           scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+        end if
+
+        ! Add spill over
+        if (ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
+          scalars%cf_fl_flux = scalars%cf_fl_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp ! [Gt/yr]
         end if
 
         ! Land-terminating ice (grounded or floating)
@@ -424,9 +434,15 @@ contains
         end if
 
         ! Marine-terminating ice (grounded or floating)
-        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
+        if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
           scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
+
+        ! Add spill over
+        if (ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
+          scalars%margin_ocean_flux = scalars%margin_ocean_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp ! [Gt/yr]
+        end if
+
 
       end do ! do ci = 1, mesh%nC( vi)
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes.f90
@@ -349,24 +349,16 @@ contains
 
     ! Local variables:
     character(len=1024), parameter         :: routine_name = 'calc_ice_transitional_fluxes'
-    real(dp), dimension(mesh%ei1:mesh%ei2) :: u_vav_c, v_vav_c
-    real(dp), dimension(mesh%nE)           :: u_vav_c_tot, v_vav_c_tot
     real(dp), dimension(mesh%nV)           :: Hi_tot
     real(dp), dimension(mesh%nV)           :: fraction_margin_tot
     logical,  dimension(mesh%nV)           :: mask_floating_ice_tot
     logical,  dimension(mesh%nV)           :: mask_icefree_land_tot
     logical,  dimension(mesh%nV)           :: mask_icefree_ocean_tot
-    integer                                :: vi, ci, ei, vj, ierr
+    integer                                :: vi, ci, vj, ierr
     real(dp)                               :: A_i, L_c
-    real(dp)                               :: u_perp
 
     ! Add routine to path
     call init_routine( routine_name)
-
-    ! Calculate vertically averaged ice velocities on the triangle edges
-    call map_velocities_from_b_to_c_2D( mesh, ice%u_vav_b, ice%v_vav_b, u_vav_c, v_vav_c)
-    call gather_to_all( u_vav_c, u_vav_c_tot)
-    call gather_to_all( v_vav_c, v_vav_c_tot)
 
     ! Gather ice thickness from all processes
     call gather_to_all( ice%Hi, Hi_tot)
@@ -389,8 +381,7 @@ contains
       ! Loop over all connections of vertex vi
       do ci = 1, mesh%nC( vi)
 
-        ! Connection ci from vertex vi leads through edge ei to vertex vj
-        ei = mesh%VE( vi,ci)
+        ! Connection ci from vertex vi leads to vertex vj
         vj = mesh%C(  vi,ci)
 
         ! The Voronoi cell of vertex vi has area A_i
@@ -399,10 +390,6 @@ contains
         ! The shared Voronoi cell boundary section between the
         ! Voronoi cells of vertices vi and vj has length L_c
         L_c = mesh%Cw( vi,ci)
-
-        ! Calculate vertically averaged ice velocity component perpendicular
-        ! to this shared Voronoi cell boundary section
-        u_perp = u_vav_c_tot( ei) * mesh%D_x( vi, ci)/mesh%D( vi, ci) + v_vav_c_tot( ei) * mesh%D_y( vi, ci)/mesh%D( vi, ci)
 
         ! Calculate the flux: if u_perp > 0, that means that this mass is
         ! flowing out from our transitional vertex. If so, add it its (negative) total.
@@ -414,31 +401,31 @@ contains
 
         ! Grounding line (grounded side)
         if (ice%mask_grounded_ice( vi) .and. mask_floating_ice_tot( vj)) then
-          if (fraction_margin_tot( vi) >= 1._dp .and. u_perp > 0._dp) then
-            scalars%gl_flux = scalars%gl_flux - L_c * u_perp * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
-          elseif (fraction_margin_tot( vj) >= 1._dp .and. u_perp < 0._dp) then
-            scalars%gl_flux = scalars%gl_flux - L_c * u_perp * Hi_tot( vj) * 1.0E-09_dp ! [Gt/yr]
+          if (fraction_margin_tot( vi) >= 1._dp .and. ice%u_perp( vi, ci) > 0._dp) then
+            scalars%gl_flux = scalars%gl_flux - L_c * ice%u_perp( vi, ci) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          elseif (fraction_margin_tot( vj) >= 1._dp .and. ice%u_perp( vi, ci) < 0._dp) then
+            scalars%gl_flux = scalars%gl_flux - L_c * ice%u_perp( vi, ci) * Hi_tot( vj) * 1.0E-09_dp ! [Gt/yr]
           end if
         end if
 
         ! Grounded marine front
         if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) THEN
-          scalars%cf_gr_flux = scalars%cf_gr_flux - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          scalars%cf_gr_flux = scalars%cf_gr_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
         ! Floating calving front
         if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) THEN
-          scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
         ! Land-terminating ice (grounded or floating)
         if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
-          scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
         ! Marine-terminating ice (grounded or floating)
         if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
-          scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
       end do ! do ci = 1, mesh%nC( vi)
@@ -470,8 +457,6 @@ contains
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'calc_ISMIP_scalars'
 
-    real(dp), dimension(mesh%ei1:mesh%ei2) :: u_vav_c, v_vav_c
-    real(dp), dimension(mesh%nE)           :: u_vav_c_tot, v_vav_c_tot
     real(dp), dimension(mesh%nV)           :: Hi_tot, TAF_tot
     real(dp), dimension(mesh%nV)           :: fraction_margin_tot
     logical,  dimension(mesh%nV)           :: mask_floating_ice_tot
@@ -481,9 +466,8 @@ contains
     real(dp), dimension( :), allocatable   :: calving_and_front_melt_flux
     real(dp), dimension( :), allocatable   :: land_ice_area_fraction
     real(dp), dimension( :), allocatable   :: floating_ice_shelf_area_fraction
-    integer                                :: vi, ci, ei, vj, ierr
+    integer                                :: vi, ci, vj, ierr
     real(dp)                               :: A_i, L_c
-    real(dp)                               :: u_perp
 
     REAL(dp)                               :: land_ice_mass
     REAL(dp)                               :: mass_above_floatation
@@ -497,11 +481,6 @@ contains
 
     ! Add routine to path
     call init_routine( routine_name)
-
-    ! Calculate vertically averaged ice velocities on the triangle edges
-    call map_velocities_from_b_to_c_2D( mesh, ice%u_vav_b, ice%v_vav_b, u_vav_c, v_vav_c)
-    call gather_to_all( u_vav_c, u_vav_c_tot)
-    call gather_to_all( v_vav_c, v_vav_c_tot)
 
     ! Gather ice thickness from all processes
     call gather_to_all( ice%Hi, Hi_tot)
@@ -536,8 +515,7 @@ contains
       ! Loop over all connections of vertex vi
       do ci = 1, mesh%nC( vi)
 
-        ! Connection ci from vertex vi leads through edge ei to vertex vj
-        ei = mesh%VE( vi,ci)
+        ! Connection ci from vertex vi leads to vertex vj
         vj = mesh%C(  vi,ci)
 
         ! The Voronoi cell of vertex vi has area A_i
@@ -546,10 +524,6 @@ contains
         ! The shared Voronoi cell boundary section between the
         ! Voronoi cells of vertices vi and vj has length L_c
         L_c = mesh%Cw( vi,ci)
-
-        ! Calculate vertically averaged ice velocity component perpendicular
-        ! to this shared Voronoi cell boundary section
-        u_perp = u_vav_c_tot( ei) * mesh%D_x( vi, ci)/mesh%D( vi, ci) + v_vav_c_tot( ei) * mesh%D_y( vi, ci)/mesh%D( vi, ci)
 
         ! Calculate the flux: if u_perp > 0, that means that this mass is
         ! flowing out from our transitional vertex. If so, add it its (negative) total.
@@ -561,22 +535,22 @@ contains
 
         ! Grounded marine front
         if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) THEN
-          calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
         ! Floating calving front
         if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) THEN
-          calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         end if
 
         ! ! Land-terminating ice (grounded or floating)
         ! if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
-        !   calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+        !   calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         ! end if
 
         ! ! Marine-terminating ice (grounded or floating)
         ! if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
-        !   calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+        !   calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
         ! end if
 
       end do ! do ci = 1, mesh%nC( vi)
@@ -660,24 +634,16 @@ contains
 
       ! Local variables:
       character(len=1024), parameter         :: routine_name = 'calc_ice_margin_fluxes'
-      real(dp), dimension(mesh%ei1:mesh%ei2) :: u_vav_c, v_vav_c
-      real(dp), dimension(mesh%nE)           :: u_vav_c_tot, v_vav_c_tot
       real(dp), dimension(mesh%nV)           :: Hi_tot
       real(dp), dimension(mesh%nV)           :: fraction_margin_tot
       logical,  dimension(mesh%nV)           :: mask_floating_ice_tot
       logical,  dimension(mesh%nV)           :: mask_icefree_land_tot
       logical,  dimension(mesh%nV)           :: mask_icefree_ocean_tot
-      integer                                :: vi, ci, ei, vj, ierr
+      integer                                :: vi, ci, vj, ierr
       real(dp)                               :: A_i, L_c
-      real(dp)                               :: u_perp
 
       ! Add routine to path
       call init_routine( routine_name)
-
-      ! Calculate vertically averaged ice velocities on the triangle edges
-      call map_velocities_from_b_to_c_2D( mesh, ice%u_vav_b, ice%v_vav_b, u_vav_c, v_vav_c)
-      call gather_to_all( u_vav_c, u_vav_c_tot)
-      call gather_to_all( v_vav_c, v_vav_c_tot)
 
       ! Gather ice thickness from all processes
       call gather_to_all( ice%Hi, Hi_tot)
@@ -692,14 +658,12 @@ contains
       calving_flux                = 0._dp
       ! calving_and_front_melt_flux = 0._dp ! TODO: when front melt is computed
 
-
       do vi = mesh%vi1, mesh%vi2
 
         ! Loop over all connections of vertex vi
         do ci = 1, mesh%nC( vi)
 
-          ! Connection ci from vertex vi leads through edge ei to vertex vj
-          ei = mesh%VE( vi,ci)
+          ! Connection ci from vertex vi leads to vertex vj
           vj = mesh%C(  vi,ci)
 
           ! The Voronoi cell of vertex vi has area A_i
@@ -708,10 +672,6 @@ contains
           ! The shared Voronoi cell boundary section between the
           ! Voronoi cells of vertices vi and vj has length L_c
           L_c = mesh%Cw( vi,ci)
-
-          ! Calculate vertically averaged ice velocity component perpendicular
-          ! to this shared Voronoi cell boundary section
-          u_perp = u_vav_c_tot( ei) * mesh%D_x( vi, ci)/mesh%D( vi, ci) + v_vav_c_tot( ei) * mesh%D_y( vi, ci)/mesh%D( vi, ci)
 
           ! Calculate the flux: if u_perp > 0, that means that this mass is
           ! flowing out from our transitional vertex. If so, add it its (negative) total.
@@ -723,19 +683,19 @@ contains
 
           ! Floating calving front
           if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) THEN
-            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
             ! calving_and_front_melt_flux( vi) = calving_flux( vi) ! TODO: when front melt is computed
           end if
 
           ! Land-terminating ice (grounded or floating)
           if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
-            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
             ! calving_and_front_melt_flux( vi) = calving_flux( vi) ! TODO: when front melt is computed
           end if
 
           ! Marine-terminating ice (grounded or floating)
           if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
-            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
             ! calving_and_front_melt_flux( vi) = calving_flux( vi) ! TODO: when front melt is computed
           end if
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
@@ -425,18 +425,33 @@ contains
           end if
 
           ! Floating calving front
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) THEN
-            scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          !if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
+          !  scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          !end if
+
+          ! Add Qspill
+          if (ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
+            scalars%cf_fl_flux = scalars%cf_fl_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp
           end if
 
           ! Land-terminating ice (grounded or floating)
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
-            scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          !if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
+          !  scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          !end if
+
+          ! Add Qspill
+          if (ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) then
+            scalars%cf_gr_flux = scalars%cf_gr_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp
           end if
 
           ! Marine-terminating ice (grounded or floating)
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
-            scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          !if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
+          !  scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          !end if
+
+          ! Add Qspill
+          if (ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
+            scalars%margin_ocean_flux = scalars%margin_ocean_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp
           end if
 
         end do ! do ci = 1, mesh%nC( vi)

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
@@ -420,22 +420,22 @@ contains
           end if
 
           ! Grounded marine front
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) THEN
+          if (fraction_margin_tot( vi) > 0._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) THEN
             scalars%cf_gr_flux = scalars%cf_gr_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
           ! Floating calving front
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
+          if (fraction_margin_tot( vi) > 0._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
             scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
           ! Land-terminating ice (grounded or floating)
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
+          if (fraction_margin_tot( vi) > 0._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
             scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
           ! Marine-terminating ice (grounded or floating)
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
+          if (fraction_margin_tot( vi) > 0._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
             scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
@@ -420,23 +420,13 @@ contains
           end if
 
           ! Grounded marine front
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) THEN
+          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) THEN
             scalars%cf_gr_flux = scalars%cf_gr_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
-          ! Add spill over
-          if (ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) then
-            scalars%cf_gr_flux = scalars%cf_gr_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp ! [Gt/yr]
-          end if
-
           ! Floating calving front
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) THEN
+          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) THEN
             scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
-          end if
-
-          ! Add spill over
-          if (ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
-            scalars%cf_fl_flux = scalars%cf_fl_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp ! [Gt/yr]
           end if
 
           ! Land-terminating ice (grounded or floating)
@@ -445,13 +435,8 @@ contains
           end if
 
           ! Marine-terminating ice (grounded or floating)
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
+          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
             scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
-          end if
-
-          ! Add spill over
-          if (ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
-            scalars%margin_ocean_flux = scalars%margin_ocean_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp ! [Gt/yr]
           end if
 
         end do ! do ci = 1, mesh%nC( vi)

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
@@ -420,13 +420,23 @@ contains
           end if
 
           ! Grounded marine front
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) THEN
+          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) THEN
             scalars%cf_gr_flux = scalars%cf_gr_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
+          ! Add spill over
+          if (ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) then
+            scalars%cf_gr_flux = scalars%cf_gr_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp ! [Gt/yr]
+          end if
+
           ! Floating calving front
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) THEN
+          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) THEN
             scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          end if
+
+          ! Add spill over
+          if (ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
+            scalars%cf_fl_flux = scalars%cf_fl_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp ! [Gt/yr]
           end if
 
           ! Land-terminating ice (grounded or floating)
@@ -435,8 +445,13 @@ contains
           end if
 
           ! Marine-terminating ice (grounded or floating)
-          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
+          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
             scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          end if
+
+          ! Add spill over
+          if (ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
+            scalars%margin_ocean_flux = scalars%margin_ocean_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp ! [Gt/yr]
           end if
 
         end do ! do ci = 1, mesh%nC( vi)

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
@@ -359,24 +359,16 @@ contains
 
     ! Local variables:
     character(len=1024), parameter         :: routine_name = 'calc_ice_transitional_fluxes_ROI'
-    real(dp), dimension(mesh%ei1:mesh%ei2) :: u_vav_c, v_vav_c
-    real(dp), dimension(mesh%nE)           :: u_vav_c_tot, v_vav_c_tot
     real(dp), dimension(mesh%nV)           :: Hi_tot
     real(dp), dimension(mesh%nV)           :: fraction_margin_tot
     logical,  dimension(mesh%nV)           :: mask_floating_ice_tot
     logical,  dimension(mesh%nV)           :: mask_icefree_land_tot
     logical,  dimension(mesh%nV)           :: mask_icefree_ocean_tot
-    integer                                :: vi, ci, ei, vj, ierr
+    integer                                :: vi, ci, vj, ierr
     real(dp)                               :: A_i, L_c
-    real(dp)                               :: u_perp
 
     ! Add routine to path
     call init_routine( routine_name)
-
-    ! Calculate vertically averaged ice velocities on the triangle edges
-    call map_velocities_from_b_to_c_2D( mesh, ice%u_vav_b, ice%v_vav_b, u_vav_c, v_vav_c)
-    call gather_to_all( u_vav_c, u_vav_c_tot)
-    call gather_to_all( v_vav_c, v_vav_c_tot)
 
     ! Gather ice thickness from all processes
     call gather_to_all( ice%Hi, Hi_tot)
@@ -400,8 +392,7 @@ contains
         ! Loop over all connections of vertex vi
         do ci = 1, mesh%nC( vi)
 
-          ! Connection ci from vertex vi leads through edge ei to vertex vj
-          ei = mesh%VE( vi,ci)
+          ! Connection ci from vertex vi leads to vertex vj
           vj = mesh%C(  vi,ci)
 
           ! The Voronoi cell of vertex vi has area A_i
@@ -410,10 +401,6 @@ contains
           ! The shared Voronoi cell boundary section between the
           ! Voronoi cells of vertices vi and vj has length L_c
           L_c = mesh%Cw( vi,ci)
-
-          ! Calculate vertically averaged ice velocity component perpendicular
-          ! to this shared Voronoi cell boundary section
-          u_perp = u_vav_c_tot( ei) * mesh%D_x( vi, ci)/mesh%D( vi, ci) + v_vav_c_tot( ei) * mesh%D_y( vi, ci)/mesh%D( vi, ci)
 
           ! Calculate the flux: if u_perp > 0, that means that this mass is
           ! flowing out from our transitional vertex. If so, add it its (negative) total.
@@ -425,31 +412,31 @@ contains
 
           ! Grounding line (grounded side)
           if (ice%mask_grounded_ice( vi) .and. mask_floating_ice_tot( vj)) then
-            if (fraction_margin_tot( vi) >= 1._dp .and. u_perp > 0._dp) then
-              scalars%gl_flux = scalars%gl_flux - L_c * u_perp * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
-            elseif (fraction_margin_tot( vj) >= 1._dp .and. u_perp < 0._dp) then
-              scalars%gl_flux = scalars%gl_flux - L_c * u_perp * Hi_tot( vj) * 1.0E-09_dp ! [Gt/yr]
+            if (fraction_margin_tot( vi) >= 1._dp .and. ice%u_perp( vi, ci) > 0._dp) then
+              scalars%gl_flux = scalars%gl_flux - L_c * ice%u_perp( vi, ci) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            elseif (fraction_margin_tot( vj) >= 1._dp .and. ice%u_perp( vi, ci) < 0._dp) then
+              scalars%gl_flux = scalars%gl_flux - L_c * ice%u_perp( vi, ci) * Hi_tot( vj) * 1.0E-09_dp ! [Gt/yr]
             end if
           end if
 
           ! Grounded marine front
           if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) THEN
-            scalars%cf_gr_flux = scalars%cf_gr_flux - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            scalars%cf_gr_flux = scalars%cf_gr_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
           ! Floating calving front
           if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) THEN
-            scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
           ! Land-terminating ice (grounded or floating)
           if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
-            scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
           ! Marine-terminating ice (grounded or floating)
           if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
-            scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
         end do ! do ci = 1, mesh%nC( vi)
@@ -482,8 +469,6 @@ contains
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'calc_ISMIP_scalars_ROI'
 
-    real(dp), dimension(mesh%ei1:mesh%ei2) :: u_vav_c, v_vav_c
-    real(dp), dimension(mesh%nE)           :: u_vav_c_tot, v_vav_c_tot
     real(dp), dimension(mesh%nV)           :: Hi_tot, TAF_tot
     real(dp), dimension(mesh%nV)           :: fraction_margin_tot
     logical,  dimension(mesh%nV)           :: mask_floating_ice_tot
@@ -493,9 +478,8 @@ contains
     real(dp), dimension( :), allocatable   :: calving_and_front_melt_flux
     real(dp), dimension( :), allocatable   :: land_ice_area_fraction
     real(dp), dimension( :), allocatable   :: floating_ice_shelf_area_fraction
-    integer                                :: vi, ci, ei, vj, ierr
+    integer                                :: vi, ci, vj, ierr
     real(dp)                               :: A_i, L_c
-    real(dp)                               :: u_perp
 
     REAL(dp)                               :: land_ice_mass
     REAL(dp)                               :: mass_above_floatation
@@ -509,11 +493,6 @@ contains
 
     ! Add routine to path
     call init_routine( routine_name)
-
-    ! Calculate vertically averaged ice velocities on the triangle edges
-    call map_velocities_from_b_to_c_2D( mesh, ice%u_vav_b, ice%v_vav_b, u_vav_c, v_vav_c)
-    call gather_to_all( u_vav_c, u_vav_c_tot)
-    call gather_to_all( v_vav_c, v_vav_c_tot)
 
     ! Gather ice thickness from all processes
     call gather_to_all( ice%Hi, Hi_tot)
@@ -549,8 +528,7 @@ contains
         ! Loop over all connections of vertex vi
         do ci = 1, mesh%nC( vi)
 
-          ! Connection ci from vertex vi leads through edge ei to vertex vj
-          ei = mesh%VE( vi,ci)
+          ! Connection ci from vertex vi leads to vertex vj
           vj = mesh%C(  vi,ci)
 
           ! The Voronoi cell of vertex vi has area A_i
@@ -559,10 +537,6 @@ contains
           ! The shared Voronoi cell boundary section between the
           ! Voronoi cells of vertices vi and vj has length L_c
           L_c = mesh%Cw( vi,ci)
-
-          ! Calculate vertically averaged ice velocity component perpendicular
-          ! to this shared Voronoi cell boundary section
-          u_perp = u_vav_c_tot( ei) * mesh%D_x( vi, ci)/mesh%D( vi, ci) + v_vav_c_tot( ei) * mesh%D_y( vi, ci)/mesh%D( vi, ci)
 
           ! Calculate the flux: if u_perp > 0, that means that this mass is
           ! flowing out from our transitional vertex. If so, add it its (negative) total.
@@ -574,22 +548,22 @@ contains
 
           ! Grounded marine front
           if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) THEN
-            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
           ! Floating calving front
           if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) THEN
-            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
           ! ! Land-terminating ice (grounded or floating)
           ! if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
-          !   calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          !   calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           ! end if
 
           ! ! Marine-terminating ice (grounded or floating)
           ! if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
-          !   calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+          !   calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           ! end if
 
         end do ! do ci = 1, mesh%nC( vi)
@@ -675,24 +649,16 @@ contains
 
       ! Local variables:
       character(len=1024), parameter         :: routine_name = 'calc_ice_margin_fluxes_ROI'
-      real(dp), dimension(mesh%ei1:mesh%ei2) :: u_vav_c, v_vav_c
-      real(dp), dimension(mesh%nE)           :: u_vav_c_tot, v_vav_c_tot
       real(dp), dimension(mesh%nV)           :: Hi_tot
       real(dp), dimension(mesh%nV)           :: fraction_margin_tot
       logical,  dimension(mesh%nV)           :: mask_floating_ice_tot
       logical,  dimension(mesh%nV)           :: mask_icefree_land_tot
       logical,  dimension(mesh%nV)           :: mask_icefree_ocean_tot
-      integer                                :: vi, ci, ei, vj, ierr
+      integer                                :: vi, ci, vj, ierr
       real(dp)                               :: A_i, L_c
-      real(dp)                               :: u_perp
 
       ! Add routine to path
       call init_routine( routine_name)
-
-      ! Calculate vertically averaged ice velocities on the triangle edges
-      call map_velocities_from_b_to_c_2D( mesh, ice%u_vav_b, ice%v_vav_b, u_vav_c, v_vav_c)
-      call gather_to_all( u_vav_c, u_vav_c_tot)
-      call gather_to_all( v_vav_c, v_vav_c_tot)
 
       ! Gather ice thickness from all processes
       call gather_to_all( ice%Hi, Hi_tot)
@@ -714,8 +680,7 @@ contains
         ! Loop over all connections of vertex vi
         do ci = 1, mesh%nC( vi)
 
-          ! Connection ci from vertex vi leads through edge ei to vertex vj
-          ei = mesh%VE( vi,ci)
+          ! Connection ci from vertex vi leads to vertex vj
           vj = mesh%C(  vi,ci)
 
           ! The Voronoi cell of vertex vi has area A_i
@@ -724,10 +689,6 @@ contains
           ! The shared Voronoi cell boundary section between the
           ! Voronoi cells of vertices vi and vj has length L_c
           L_c = mesh%Cw( vi,ci)
-
-          ! Calculate vertically averaged ice velocity component perpendicular
-          ! to this shared Voronoi cell boundary section
-          u_perp = u_vav_c_tot( ei) * mesh%D_x( vi, ci)/mesh%D( vi, ci) + v_vav_c_tot( ei) * mesh%D_y( vi, ci)/mesh%D( vi, ci)
 
           ! Calculate the flux: if u_perp > 0, that means that this mass is
           ! flowing out from our transitional vertex. If so, add it its (negative) total.
@@ -739,19 +700,19 @@ contains
 
           ! Floating calving front
           if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) THEN
-            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
             ! calving_and_front_melt_flux( vi) = calving_flux( vi) ! TODO: when front melt is computed
           end if
 
           ! Land-terminating ice (grounded or floating)
           if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
-            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
             ! calving_and_front_melt_flux( vi) = calving_flux( vi) ! TODO: when front melt is computed
           end if
 
           ! Marine-terminating ice (grounded or floating)
           if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
-            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, u_perp) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
+            calving_flux( vi) = calving_flux( vi) - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
             ! calving_and_front_melt_flux( vi) = calving_flux( vi) ! TODO: when front melt is computed
           end if
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_mass_and_fluxes_ROI.f90
@@ -425,33 +425,18 @@ contains
           end if
 
           ! Floating calving front
-          !if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
-          !  scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
-          !end if
-
-          ! Add Qspill
-          if (ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
-            scalars%cf_fl_flux = scalars%cf_fl_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp
+          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_cf_fl( vi) .and. mask_icefree_ocean_tot( vj)) then
+            scalars%cf_fl_flux = scalars%cf_fl_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
           ! Land-terminating ice (grounded or floating)
-          !if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
-          !  scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
-          !end if
-
-          ! Add Qspill
-          if (ice%mask_cf_gr( vi) .and. mask_icefree_ocean_tot( vj)) then
-            scalars%cf_gr_flux = scalars%cf_gr_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp
+          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_land_tot( vj)) then
+            scalars%margin_land_flux = scalars%margin_land_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
           ! Marine-terminating ice (grounded or floating)
-          !if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj) .and. ice%Qspill( vi) == 0._dp) then
-          !  scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
-          !end if
-
-          ! Add Qspill
-          if (ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
-            scalars%margin_ocean_flux = scalars%margin_ocean_flux + ice%Qspill( vi) * A_i * 1.0E-09_dp
+          if (fraction_margin_tot( vi) >= 1._dp .and. ice%mask_margin( vi) .and. mask_icefree_ocean_tot( vj)) then
+            scalars%margin_ocean_flux = scalars%margin_ocean_flux - L_c * max( 0._dp, ice%u_perp( vi, ci)) * Hi_tot( vi) * 1.0E-09_dp ! [Gt/yr]
           end if
 
         end do ! do ci = 1, mesh%nC( vi)

--- a/src/UFEMISM/ice_dynamics/utilities/ice_model_memory.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_model_memory.f90
@@ -195,6 +195,8 @@ contains
 
     allocate( ice%divQ   ( mesh%vi1:mesh%vi2), source = 0._dp)
     allocate( ice%R_shear( mesh%vi1:mesh%vi2), source = 0._dp)
+    allocate( ice%Qspill ( mesh%vi1:mesh%vi2), source = 0._dp)
+    allocate( ice%u_perp ( mesh%vi1:mesh%vi2, mesh%nC_mem), source = 0._dp)
 
     ! == Basal hydrology ==
     ! =====================

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -427,24 +427,6 @@ contains
 
     end do
 
-    ! Q_max = maxval( ice%Qspill)
-    ! call MPI_ALLREDUCE( MPI_IN_PLACE, Q_max, 1, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_COMM_WORLD, ierr)
-    ! Q_min = minval( ice%Qspill)
-    ! call MPI_ALLREDUCE( MPI_IN_PLACE, Q_min, 1, MPI_DOUBLE_PRECISION, MPI_MIN, MPI_COMM_WORLD, ierr)
-    ! Q_dsttot = sum( Q_dst)*1e-9
-    ! call MPI_ALLREDUCE( MPI_IN_PLACE, Q_dsttot, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
-    ! Q_srctot = sum( Q_src)*1e-9
-    ! call MPI_ALLREDUCE( MPI_IN_PLACE, Q_srctot, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
-
-    ! if (par%primary) write (*,*) Q_max, Q_min, Q_dsttot, Q_srctot
-
-    ! Update masks
-
-    ! call determine_masks( mesh, Hi_new, ice%Hb, ice%SL, ice%mask, ice%mask_icefree_land, & 
-    !                       ice%mask_icefree_ocean, ice%mask_grounded_ice, ice%mask_floating_ice, &
-    !                       ice%mask_margin, ice%mask_gl_fl, ice%mask_gl_gr,ice%mask_cf_gr, &
-    !                       ice%mask_cf_fl, ice%mask_coastline)
-
   end subroutine calc_and_apply_spill_over_flux
 
 end module ice_thickness_safeties

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -293,41 +293,22 @@ contains
     real(dp),                               intent(in   ) :: dt
 
     ! Local variables:
-    character(len=1024), parameter         :: routine_name = 'calc_and_apply_spill_over_flux'
-    integer                                :: vi, ci, vj
-    real(dp)                               :: Q_excess
-    real(dp), dimension(mesh%nC_mem)       :: weight
-    real(dp)                               :: w_eps = 1e-12
-    logical, dimension(mesh%nV)            :: mask_icefree_ocean_tot
-    real(dp), dimension(mesh%nV)           :: Hi_tot
-    logical,  dimension(mesh%vi1:mesh%vi2) :: mask_margin
+    character(len=1024), parameter   :: routine_name = 'calc_and_apply_spill_over_flux'
+    integer                          :: vi, ci, vj
+    real(dp)                         :: Q_excess
+    real(dp), dimension(mesh%nC_mem) :: weight
+    real(dp)                         :: w_eps = 1e-12
+    logical, dimension(mesh%nV)      :: mask_icefree_ocean_tot
   
     call gather_to_all( ice%mask_icefree_ocean, mask_icefree_ocean_tot)
-    call gather_to_all( Hi_new, Hi_tot)
-
-    ! Initialise
+  
     ice%Qspill = 0._dp
   
-    ! == Margin mask
-    ! ==============
-
-    ! Initialise
-    mask_margin = .false.
-
-    do vi = mesh%vi1, mesh%vi2
-      do ci = 1, mesh%nC( vi)
-        vj = mesh%C( vi,ci)
-        if (Hi_tot( vi) > 0._dp .and. Hi_tot( vj) == 0._dp) then
-          mask_margin( vi) = .true.
-        end if
-      end do
-    end do
-
     ! Compute spill rate
     do vi = mesh%vi1, mesh%vi2
-
+  
       ! Only compute spill-over when ice thickness exceeds effective ice thickness
-      if (mask_margin( vi) .and. Hi_new( vi) > ice%Hi_eff( vi)) then
+      if (Hi_new( vi) > ice%Hi_eff( vi)) then
 
         ! Determine spill rate of excess volume toward ocean cells in m/yr
         ice%Qspill( vi) = - (Hi_new( vi) - ice%Hi_eff( vi)) / dt

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -342,27 +342,6 @@ contains
 
         Hi_ups = Hi_new_tot( vj)
 
-      elseif (ice%mask_cf_gr( vi)) then
-
-        ! Find connection with the strongest inflow into this cell
-        cm = minloc(ice%u_perp( vi, :), dim=1)
-
-        ! Skip if somehow there is no inflow at all
-        if (ice%u_perp( vi, cm) >= 0._dp) then
-          call warning('No inflow velocity found')
-          Hi_ups = ice%Hi_eff( vi)
-        end if
-        
-        ! Determine the surface of that cell
-        vj = mesh%C( vi, cm)
-
-        ! Skip if upstream cell is empty
-        if (Hi_new_tot( vj) == 0._dp) cycle
-
-        Hs_ups = Hi_new_tot( vj) + Hb_tot( vj)
-
-        Hi_ups = Hs_ups - ice%Hb( vi)
-
       else
 
         ! Default

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -406,15 +406,15 @@ contains
     if (par%primary) write (*,*) Q_max, Q_min, Q_dsttot, Q_srctot
 
     ! Update masks
-    call determine_masks( mesh, Hi_new, ice%Hb, ice%SL, ice%mask, ice%mask_icefree_land, & 
-                          ice%mask_icefree_ocean, ice%mask_grounded_ice, ice%mask_floating_ice, &
-                          ice%mask_margin, ice%mask_gl_fl, ice%mask_gl_gr,ice%mask_cf_gr, &
-                          ice%mask_cf_fl, ice%mask_coastline)
+    ! call determine_masks( mesh, Hi_new, ice%Hb, ice%SL, ice%mask, ice%mask_icefree_land, & 
+    !                       ice%mask_icefree_ocean, ice%mask_grounded_ice, ice%mask_floating_ice, &
+    !                       ice%mask_margin, ice%mask_gl_fl, ice%mask_gl_gr,ice%mask_cf_gr, &
+    !                       ice%mask_cf_fl, ice%mask_coastline)
 
-    call determine_masks( mesh, Hi_new, ice%Hb, ice%SL, ice%mask, ice%mask_icefree_land, & 
-                          ice%mask_icefree_ocean, ice%mask_grounded_ice, ice%mask_floating_ice, &
-                          ice%mask_margin, ice%mask_gl_fl, ice%mask_gl_gr,ice%mask_cf_gr, &
-                          ice%mask_cf_fl, ice%mask_coastline)
+    ! call determine_masks( mesh, Hi_new, ice%Hb, ice%SL, ice%mask, ice%mask_icefree_land, & 
+    !                       ice%mask_icefree_ocean, ice%mask_grounded_ice, ice%mask_floating_ice, &
+    !                       ice%mask_margin, ice%mask_gl_fl, ice%mask_gl_gr,ice%mask_cf_gr, &
+    !                       ice%mask_cf_fl, ice%mask_coastline)
 
   end subroutine calc_and_apply_spill_over_flux
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -323,28 +323,29 @@ contains
     do vi = mesh%vi1, mesh%vi2
   
       ! Determine upstream ice thickness
-      if (ice%mask_cf_fl( vi)) then
+      if (ice%mask_cf_fl( vi) .or. ice%mask_gr_fl( vi)) then
 
         ! Find connection with the strongest inflow into this cell
         cm = minloc(ice%u_perp( vi, :), dim=1)
 
-        ! Skip if somehow there is no inflow at all
+        ! If there is no inflow at all, for example during initialisation,
+        ! use effective thickness
         if (ice%u_perp( vi, cm) >= 0._dp) then
-          call warning('No inflow velocity found')
           Hi_ups = ice%Hi_eff( vi)
         end if
 
-        ! Determine the thickness of that cell
+        ! Find vertex index of strongest inflow cell
         vj = mesh%C( vi, cm)
 
         ! Skip if upstream cell is empty
         if (Hi_new_tot( vj) == 0._dp) cycle
 
+        ! Determine upstream thickness from strongest inflow cell
         Hi_ups = Hi_new_tot( vj)
 
       else
 
-        ! Default
+        ! Default: use effective ice thickness
         Hi_ups = ice%Hi_eff( vi)
 
       end if

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -2,7 +2,7 @@ module ice_thickness_safeties
   !< Different kinds of "safeties" to keep the ice sheet stable during nudging-based initialisation runs
 
   use precisions, only: dp
-  use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine, crash
+  use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine, crash, warning
   use model_configuration, only: C
   use parameters, only: ice_density, seawater_density
   use mesh_types, only: type_mesh
@@ -297,7 +297,7 @@ contains
 
     ! Local variables:
     character(len=1024), parameter                       :: routine_name = 'calc_and_apply_spill_over_flux'
-    integer                                              :: vi, ci, vj, cj, ierr
+    integer                                              :: vi, ci, vj, cj, cm, ierr
     real(dp)                                             :: Q_max, Q_min, Q_dsttot, Q_srctot
     real(dp), dimension(mesh%nC_mem)                     :: weight        ! [m2/y] Perpendicular outflow to ocean
     real(dp), dimension(mesh%vi1: mesh%vi2, mesh%nC_mem) :: relweight     ! [0-1] Relative outflow weight
@@ -306,6 +306,8 @@ contains
     real(dp), dimension(mesh%nV)                         :: Q_src_tot     ! [m3/y] Source spill flux
     real(dp)                                             :: w_eps = 1.e-2 ! [m2/y] Small value
     logical, dimension(mesh%nV)                          :: mask_icefree_ocean_tot
+    real(dp)                                             :: Hi_ups, Hs_ups ! [m] Upstream ice values
+    real(dp), dimension(mesh%nV)                         :: Hi_new_tot
 
     ! Initialise
     ice%Qspill = 0._dp
@@ -314,15 +316,43 @@ contains
     relweight  = 0._dp
 
     call gather_to_all( ice%mask_icefree_ocean, mask_icefree_ocean_tot)
+    call gather_to_all( Hi_new, Hi_new_tot)
 
     ! Compute spill flux source
     do vi = mesh%vi1, mesh%vi2
   
+      ! Determine upstream ice thickness
+      if (ice%mask_cf_fl( vi)) then
+
+        ! Find connection with the strongest inflow into this cell
+        cm = minloc(ice%u_perp( vi, :), dim=1)
+
+        ! Skip if somehow there is no inflow at all
+        if (ice%u_perp( vi, cm) >= 0._dp) then
+          call warning('No inflow velocity found')
+          Hi_ups = ice%Hi_eff( vi)
+        end if
+
+        ! Determine the thickness of that cell
+        vj = mesh%C( vi, cm)
+
+        ! Skip if upstream cell is empty
+        if (Hi_new_tot( vj) == 0._dp) cycle
+
+        Hi_ups = Hi_new_tot( vj)
+
+      else
+
+        ! Default
+        Hi_ups = ice%Hi_eff( vi)
+
+      end if
+
       ! Only compute spill-over when ice thickness exceeds effective ice thickness
-      if ((ice%mask_cf_gr( vi) .or. ice%mask_cf_fl( vi)) .and. Hi_new( vi) > ice%Hi_eff( vi)) then
+      if ((ice%mask_cf_gr( vi) .or. ice%mask_cf_fl( vi)) .and. Hi_new( vi) > Hi_ups) then
 
         ! Determine source flux of spill-over ice in m^3/yr
-        Q_src( vi) = - (Hi_new( vi) - ice%Hi_eff( vi)) * mesh%A( vi) / dt
+        Q_src( vi) = - (Hi_new( vi) - Hi_ups) * mesh%A( vi) / dt
 
         weight = 0._dp
   
@@ -353,6 +383,7 @@ contains
 
     end do
 
+    ! Only apply distribution during corrector step
     call gather_to_all( relweight, relweight_tot)
     call gather_to_all( Q_src, Q_src_tot)
 
@@ -387,7 +418,7 @@ contains
     do vi = mesh%vi1, mesh%vi2
 
       ! Combine source and destination and convert to thickness rate in m/yr
-      ice%Qspill( vi) = (Q_src( vi) + Q_dst( vi)) / mesh%A( vi)
+      ice%Qspill( vi) = ice%Qspill( vi) + (Q_src( vi) + Q_dst( vi)) / mesh%A( vi)
 
       ! Update ice thickness
       Hi_new( vi) = Hi_new( vi) + ice%Qspill( vi) * dt
@@ -406,10 +437,6 @@ contains
     if (par%primary) write (*,*) Q_max, Q_min, Q_dsttot, Q_srctot
 
     ! Update masks
-    ! call determine_masks( mesh, Hi_new, ice%Hb, ice%SL, ice%mask, ice%mask_icefree_land, & 
-    !                       ice%mask_icefree_ocean, ice%mask_grounded_ice, ice%mask_floating_ice, &
-    !                       ice%mask_margin, ice%mask_gl_fl, ice%mask_gl_gr,ice%mask_cf_gr, &
-    !                       ice%mask_cf_fl, ice%mask_coastline)
 
     ! call determine_masks( mesh, Hi_new, ice%Hb, ice%SL, ice%mask, ice%mask_icefree_land, & 
     !                       ice%mask_icefree_ocean, ice%mask_grounded_ice, ice%mask_floating_ice, &

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -11,8 +11,9 @@ module ice_thickness_safeties
   use subgrid_ice_margin, only: calc_effective_thickness
   use ice_geometry_basics, only: is_floating
   use mpi_distributed_memory, only: gather_to_all
-  use mpi_basic, only: sync
+  use mpi_basic, only: par, sync
   use masks_mod, only: determine_masks
+  use mpi_f08, only: MPI_ALLREDUCE, MPI_IN_PLACE, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_MIN, MPI_SUM, MPI_COMM_WORLD
 
   implicit none
 
@@ -296,7 +297,8 @@ contains
 
     ! Local variables:
     character(len=1024), parameter                       :: routine_name = 'calc_and_apply_spill_over_flux'
-    integer                                              :: vi, ci, vj, cj
+    integer                                              :: vi, ci, vj, cj, ierr
+    real(dp)                                             :: Q_max, Q_min, Q_dsttot, Q_srctot
     real(dp), dimension(mesh%nC_mem)                     :: weight        ! [m2/y] Perpendicular outflow to ocean
     real(dp), dimension(mesh%vi1: mesh%vi2, mesh%nC_mem) :: relweight     ! [0-1] Relative outflow weight
     real(dp), dimension(mesh%nV, mesh%nC_mem)            :: relweight_tot ! [0-1] Relative outflow weight
@@ -307,6 +309,7 @@ contains
 
     ! Initialise
     ice%Qspill = 0._dp
+    Q_src      = 0._dp
     Q_dst      = 0._dp
     relweight  = 0._dp
 
@@ -368,7 +371,7 @@ contains
   
             if (mesh%C( vj, cj) == vi) then
             ! Yes, this connection is a match, receive fraction of Q_src
-              if (Q_src_tot( vj) < 0._dp .and. relweight_tot( vj, cj) > 1.e-6_dp) then
+              if (Q_src_tot( vj) < -1.e-2_dp .and. relweight_tot( vj, cj) > 1.e-6_dp) then
                 Q_dst( vi) = Q_dst( vi) - Q_src_tot( vj) * relweight_tot( vj, cj)
               end if  
 
@@ -390,6 +393,17 @@ contains
       Hi_new( vi) = Hi_new( vi) + ice%Qspill( vi) * dt
 
     end do
+
+    Q_max = maxval( ice%Qspill)
+    call MPI_ALLREDUCE( MPI_IN_PLACE, Q_max, 1, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_COMM_WORLD, ierr)
+    Q_min = minval( ice%Qspill)
+    call MPI_ALLREDUCE( MPI_IN_PLACE, Q_min, 1, MPI_DOUBLE_PRECISION, MPI_MIN, MPI_COMM_WORLD, ierr)
+    Q_dsttot = sum( Q_dst)*1e-9
+    call MPI_ALLREDUCE( MPI_IN_PLACE, Q_dsttot, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
+    Q_srctot = sum( Q_src)*1e-9
+    call MPI_ALLREDUCE( MPI_IN_PLACE, Q_srctot, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
+
+    if (par%primary) write (*,*) Q_max, Q_min, Q_dsttot, Q_srctot
 
     ! Update masks
     call determine_masks( mesh, Hi_new, ice%Hb, ice%SL, ice%mask, ice%mask_icefree_land, & 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -323,7 +323,7 @@ contains
     do vi = mesh%vi1, mesh%vi2
   
       ! Determine upstream ice thickness
-      if (ice%mask_cf_fl( vi) .or. ice%mask_gr_fl( vi)) then
+      if (ice%mask_cf_fl( vi) .or. ice%mask_cf_gr( vi)) then
 
         ! Find connection with the strongest inflow into this cell
         cm = minloc(ice%u_perp( vi, :), dim=1)

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -10,12 +10,13 @@ module ice_thickness_safeties
   use reference_geometry_types, only: type_reference_geometry
   use subgrid_ice_margin, only: calc_effective_thickness
   use ice_geometry_basics, only: is_floating
+  use mpi_distributed_memory, only: gather_to_all
 
   implicit none
 
   private
 
-  public :: alter_ice_thickness
+  public :: alter_ice_thickness, calc_and_apply_spill_over_flux
 
 contains
 
@@ -282,5 +283,75 @@ contains
     call finalise_routine( routine_name)
 
   end subroutine alter_ice_thickness
+
+  subroutine calc_and_apply_spill_over_flux( mesh, ice, Hi_new, dt)
+
+    ! In/output variables:
+    type(type_mesh),                        intent(in   ) :: mesh
+    type(type_ice_model),                   intent(inout) :: ice
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(inout) :: Hi_new
+    real(dp),                               intent(in   ) :: dt
+
+    ! Local variables:
+    character(len=1024), parameter   :: routine_name = 'calc_and_apply_spill_over_flux'
+    integer                          :: vi, ci, vj
+    real(dp)                         :: Q_excess
+    real(dp), dimension(mesh%nC_mem) :: weight
+    real(dp)                         :: w_eps = 1e-12
+    logical, dimension(mesh%nV)      :: mask_icefree_ocean_tot
+  
+    call gather_to_all( ice%mask_icefree_ocean, mask_icefree_ocean_tot)
+  
+    ice%Qspill = 0._dp
+  
+    ! Compute spill rate
+    do vi = mesh%vi1, mesh%vi2
+  
+      ! Only compute spill-over when ice thickness exceeds effective ice thickness
+      if (Hi_new( vi) > ice%Hi_eff( vi)) then
+
+        ! Determine spill rate of excess volume toward ocean cells in m/yr
+        ice%Qspill( vi) = - (Hi_new( vi) - ice%Hi_eff( vi)) / dt
+  
+        weight = 0._dp
+
+        ! Determine weights of surrounding ocean cells
+        do ci = 1, mesh%nC( vi)
+          vj = mesh%C( vi,ci)
+    
+          if (mask_icefree_ocean_tot( vj)) then
+            ! Define weight by outflow perpendicular velocity into ocean cells.
+            ! Add small value to avoid division by 0 if no outflow velocity enters
+            ! any ocean cell. In that case, weights will be equally distributed
+            ! over all neighbouring ocean cells.
+            weight( ci) = max(0._dp, ice%u_perp( vi, ci)) + w_eps
+          end if
+        end do
+    
+        ! Determine spill rate into surrounding cells in m/y
+        do ci = 1, mesh%nC( vi)
+          vj = mesh%C( vi, ci)
+
+          if (sum(weight) > 0._dp) then
+            ! Add to Qspill to allow for accumulation from multiple margin cells
+            ice%Qspill( vj) = ice%Qspill( vj) & 
+                            - ice%Qspill( vi) * mesh%A( vi) / mesh%A( vj) &
+                            * weight( ci) / sum(weight)   
+          end if
+
+        end do
+
+      end if
+
+    end do
+
+    ! Apply spill rates
+    do vi = mesh%vi1, mesh%vi2
+
+      Hi_new( vi) = Hi_new( vi) + ice%Qspill( vi) * dt
+
+    end do
+
+  end subroutine calc_and_apply_spill_over_flux
 
 end module ice_thickness_safeties

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -307,7 +307,7 @@ contains
     real(dp)                                             :: w_eps = 1.e-2 ! [m2/y] Small value
     logical, dimension(mesh%nV)                          :: mask_icefree_ocean_tot
     real(dp)                                             :: Hi_ups, Hs_ups ! [m] Upstream ice values
-    real(dp), dimension(mesh%nV)                         :: Hi_new_tot
+    real(dp), dimension(mesh%nV)                         :: Hi_new_tot, Hb_tot
 
     ! Initialise
     ice%Qspill = 0._dp
@@ -317,6 +317,7 @@ contains
 
     call gather_to_all( ice%mask_icefree_ocean, mask_icefree_ocean_tot)
     call gather_to_all( Hi_new, Hi_new_tot)
+    call gather_to_all( ice%Hb, Hb_tot)
 
     ! Compute spill flux source
     do vi = mesh%vi1, mesh%vi2
@@ -340,6 +341,27 @@ contains
         if (Hi_new_tot( vj) == 0._dp) cycle
 
         Hi_ups = Hi_new_tot( vj)
+
+      elseif (ice%mask_cf_gr( vi)) then
+
+        ! Find connection with the strongest inflow into this cell
+        cm = minloc(ice%u_perp( vi, :), dim=1)
+
+        ! Skip if somehow there is no inflow at all
+        if (ice%u_perp( vi, cm) >= 0._dp) then
+          call warning('No inflow velocity found')
+          Hi_ups = ice%Hi_eff( vi)
+        end if
+        
+        ! Determine the surface of that cell
+        vj = mesh%C( vi, cm)
+
+        ! Skip if upstream cell is empty
+        if (Hi_new_tot( vj) == 0._dp) cycle
+
+        Hs_ups = Hi_new_tot( vj) + Hb_tot( vj)
+
+        Hi_ups = Hs_ups - ice%Hb( vi)
 
       else
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -418,23 +418,23 @@ contains
     do vi = mesh%vi1, mesh%vi2
 
       ! Combine source and destination and convert to thickness rate in m/yr
-      ice%Qspill( vi) = ice%Qspill( vi) + (Q_src( vi) + Q_dst( vi)) / mesh%A( vi)
+      ice%Qspill( vi) = (Q_src( vi) + Q_dst( vi)) / mesh%A( vi)
 
       ! Update ice thickness
       Hi_new( vi) = Hi_new( vi) + ice%Qspill( vi) * dt
 
     end do
 
-    Q_max = maxval( ice%Qspill)
-    call MPI_ALLREDUCE( MPI_IN_PLACE, Q_max, 1, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_COMM_WORLD, ierr)
-    Q_min = minval( ice%Qspill)
-    call MPI_ALLREDUCE( MPI_IN_PLACE, Q_min, 1, MPI_DOUBLE_PRECISION, MPI_MIN, MPI_COMM_WORLD, ierr)
-    Q_dsttot = sum( Q_dst)*1e-9
-    call MPI_ALLREDUCE( MPI_IN_PLACE, Q_dsttot, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
-    Q_srctot = sum( Q_src)*1e-9
-    call MPI_ALLREDUCE( MPI_IN_PLACE, Q_srctot, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
+    ! Q_max = maxval( ice%Qspill)
+    ! call MPI_ALLREDUCE( MPI_IN_PLACE, Q_max, 1, MPI_DOUBLE_PRECISION, MPI_MAX, MPI_COMM_WORLD, ierr)
+    ! Q_min = minval( ice%Qspill)
+    ! call MPI_ALLREDUCE( MPI_IN_PLACE, Q_min, 1, MPI_DOUBLE_PRECISION, MPI_MIN, MPI_COMM_WORLD, ierr)
+    ! Q_dsttot = sum( Q_dst)*1e-9
+    ! call MPI_ALLREDUCE( MPI_IN_PLACE, Q_dsttot, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
+    ! Q_srctot = sum( Q_src)*1e-9
+    ! call MPI_ALLREDUCE( MPI_IN_PLACE, Q_srctot, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, ierr)
 
-    if (par%primary) write (*,*) Q_max, Q_min, Q_dsttot, Q_srctot
+    ! if (par%primary) write (*,*) Q_max, Q_min, Q_dsttot, Q_srctot
 
     ! Update masks
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -293,22 +293,41 @@ contains
     real(dp),                               intent(in   ) :: dt
 
     ! Local variables:
-    character(len=1024), parameter   :: routine_name = 'calc_and_apply_spill_over_flux'
-    integer                          :: vi, ci, vj
-    real(dp)                         :: Q_excess
-    real(dp), dimension(mesh%nC_mem) :: weight
-    real(dp)                         :: w_eps = 1e-12
-    logical, dimension(mesh%nV)      :: mask_icefree_ocean_tot
+    character(len=1024), parameter         :: routine_name = 'calc_and_apply_spill_over_flux'
+    integer                                :: vi, ci, vj
+    real(dp)                               :: Q_excess
+    real(dp), dimension(mesh%nC_mem)       :: weight
+    real(dp)                               :: w_eps = 1e-12
+    logical, dimension(mesh%nV)            :: mask_icefree_ocean_tot
+    real(dp), dimension(mesh%nV)           :: Hi_tot
+    logical,  dimension(mesh%vi1:mesh%vi2) :: mask_margin
   
     call gather_to_all( ice%mask_icefree_ocean, mask_icefree_ocean_tot)
-  
+    call gather_to_all( Hi_new, Hi_tot)
+
+    ! Initialise
     ice%Qspill = 0._dp
   
+    ! == Margin mask
+    ! ==============
+
+    ! Initialise
+    mask_margin = .false.
+
+    do vi = mesh%vi1, mesh%vi2
+      do ci = 1, mesh%nC( vi)
+        vj = mesh%C( vi,ci)
+        if (Hi_tot( vi) > 0._dp .and. Hi_tot( vj) == 0._dp) then
+          mask_margin( vi) = .true.
+        end if
+      end do
+    end do
+
     ! Compute spill rate
     do vi = mesh%vi1, mesh%vi2
-  
+
       ! Only compute spill-over when ice thickness exceeds effective ice thickness
-      if (Hi_new( vi) > ice%Hi_eff( vi)) then
+      if (mask_margin( vi) .and. Hi_new( vi) > ice%Hi_eff( vi)) then
 
         ! Determine spill rate of excess volume toward ocean cells in m/yr
         ice%Qspill( vi) = - (Hi_new( vi) - ice%Hi_eff( vi)) / dt

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -335,7 +335,7 @@ contains
             ! Add small value to avoid division by 0 if no outflow velocity enters
             ! any ocean cell. In that case, weights will be equally distributed
             ! over all neighbouring ocean cells.
-            weight( ci) = 1._dp !max(0._dp, ice%u_perp( vi, ci)) + w_eps
+            weight( ci) = max(0._dp, ice%u_perp( vi, ci)) + w_eps
           end if
         end do
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -12,6 +12,7 @@ module ice_thickness_safeties
   use ice_geometry_basics, only: is_floating
   use mpi_distributed_memory, only: gather_to_all
   use mpi_basic, only: sync
+  use masks_mod, only: determine_masks
 
   implicit none
 
@@ -301,26 +302,26 @@ contains
     real(dp), dimension(mesh%nV, mesh%nC_mem)            :: relweight_tot ! [0-1] Relative outflow weight
     real(dp), dimension(mesh%vi1: mesh%vi2)              :: Q_src, Q_dst  ! [m3/y] Source and sink spill fluxes
     real(dp), dimension(mesh%nV)                         :: Q_src_tot     ! [m3/y] Source spill flux
-    real(dp)                                             :: w_eps = 1e-12_dp ! [m2/y] Small value
+    real(dp)                                             :: w_eps = 1.e-2 ! [m2/y] Small value
     logical, dimension(mesh%nV)                          :: mask_icefree_ocean_tot
 
-    call gather_to_all( ice%mask_icefree_ocean, mask_icefree_ocean_tot)
- 
     ! Initialise
-    Q_src( :)        = 0._dp
-    Q_dst( :)        = 0._dp
-    relweight( :, :) = 0._dp
+    ice%Qspill = 0._dp
+    Q_dst      = 0._dp
+    relweight  = 0._dp
+
+    call gather_to_all( ice%mask_icefree_ocean, mask_icefree_ocean_tot)
 
     ! Compute spill flux source
     do vi = mesh%vi1, mesh%vi2
   
       ! Only compute spill-over when ice thickness exceeds effective ice thickness
-      if (Hi_new( vi) > ice%Hi_eff( vi)) then
+      if ((ice%mask_cf_gr( vi) .or. ice%mask_cf_fl( vi)) .and. Hi_new( vi) > ice%Hi_eff( vi)) then
 
         ! Determine source flux of spill-over ice in m^3/yr
         Q_src( vi) = - (Hi_new( vi) - ice%Hi_eff( vi)) * mesh%A( vi) / dt
 
-        weight( :) = 0._dp
+        weight = 0._dp
   
         ! Determine weights of surrounding ocean cells
         do ci = 1, mesh%nC( vi)
@@ -336,7 +337,7 @@ contains
         end do
 
         ! Set spill source to zero if no surrounding ocean cells available
-        if (sum(weight) == 0._dp) then
+        if (sum(weight) < w_eps) then
           Q_src( vi) = 0._dp
         else
           ! Define the relative weight of Q_src to Q_dst of the downstream ocean cells
@@ -346,6 +347,7 @@ contains
         end if
 
       end if
+
     end do
 
     call gather_to_all( relweight, relweight_tot)
@@ -357,20 +359,20 @@ contains
       ! Skip if not an ocean cell
       if (.not. mask_icefree_ocean_tot( vi)) cycle
 
-      do ci = 1, mesh%nC( vi)
-        !Neighbouring cell which potentially has nonzero Q_src
-        vj = mesh%C( vi, ci)
-
-        ! Connections of neighbouring cell
-        do cj = 1, mesh%nC( vj)
-
-          if (mesh%C( vj, cj) == vi) then
-          ! Yes, this connection is a match, receive fraction of Q_src
-            Q_dst( vi) = Q_dst( vi) - Q_src( vj) * relweight( vj, cj)
-
-          end if
-
-        end do
+        do ci = 1, mesh%nC( vi)
+          !Neighbouring cell which potentially has nonzero Q_src
+          vj = mesh%C( vi, ci)
+  
+          ! Connections of neighbouring cell
+          do cj = 1, mesh%nC( vj)
+  
+            if (mesh%C( vj, cj) == vi) then
+            ! Yes, this connection is a match, receive fraction of Q_src
+              Q_dst( vi) = Q_dst( vi) - Q_src_tot( vj) * relweight_tot( vj, cj)
+  
+            end if
+  
+          end do
 
       end do
 
@@ -379,16 +381,19 @@ contains
     ! Apply spill rates
     do vi = mesh%vi1, mesh%vi2
 
-      ! Convert spill source flux to thinning rate in m/yr
-      ice%Qspill( vi) = Q_src( vi) / mesh%A( vi)
-
-      ! Add destination flux as thickening rate in m/yr
-      ice%Qspill( vi) = ice%Qspill( vi) + Q_dst( vi) / mesh%A( vi)
+      ! Combine source and destination and convert to thickness rate in m/yr
+      ice%Qspill( vi) = (Q_src( vi) + Q_dst( vi)) / mesh%A( vi)
 
       ! Update ice thickness
       Hi_new( vi) = Hi_new( vi) + ice%Qspill( vi) * dt
 
     end do
+
+    ! Update masks
+    call determine_masks( mesh, Hi_new, ice%Hb, ice%SL, ice%mask, ice%mask_icefree_land, & 
+                          ice%mask_icefree_ocean, ice%mask_grounded_ice, ice%mask_floating_ice, &
+                          ice%mask_margin, ice%mask_gl_fl, ice%mask_gl_gr,ice%mask_cf_gr, &
+                          ice%mask_cf_fl, ice%mask_coastline)
 
   end subroutine calc_and_apply_spill_over_flux
 

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -11,6 +11,7 @@ module ice_thickness_safeties
   use subgrid_ice_margin, only: calc_effective_thickness
   use ice_geometry_basics, only: is_floating
   use mpi_distributed_memory, only: gather_to_all
+  use mpi_basic, only: sync
 
   implicit none
 
@@ -293,31 +294,37 @@ contains
     real(dp),                               intent(in   ) :: dt
 
     ! Local variables:
-    character(len=1024), parameter   :: routine_name = 'calc_and_apply_spill_over_flux'
-    integer                          :: vi, ci, vj
-    real(dp)                         :: Q_excess
-    real(dp), dimension(mesh%nC_mem) :: weight
-    real(dp)                         :: w_eps = 1e-12
-    logical, dimension(mesh%nV)      :: mask_icefree_ocean_tot
-  
+    character(len=1024), parameter                       :: routine_name = 'calc_and_apply_spill_over_flux'
+    integer                                              :: vi, ci, vj, cj
+    real(dp), dimension(mesh%nC_mem)                     :: weight        ! [m2/y] Perpendicular outflow to ocean
+    real(dp), dimension(mesh%vi1: mesh%vi2, mesh%nC_mem) :: relweight     ! [0-1] Relative outflow weight
+    real(dp), dimension(mesh%nV, mesh%nC_mem)            :: relweight_tot ! [0-1] Relative outflow weight
+    real(dp), dimension(mesh%vi1: mesh%vi2)              :: Q_src, Q_dst  ! [m3/y] Source and sink spill fluxes
+    real(dp), dimension(mesh%nV)                         :: Q_src_tot     ! [m3/y] Source spill flux
+    real(dp)                                             :: w_eps = 1e-12_dp ! [m2/y] Small value
+    logical, dimension(mesh%nV)                          :: mask_icefree_ocean_tot
+
     call gather_to_all( ice%mask_icefree_ocean, mask_icefree_ocean_tot)
-  
-    ice%Qspill = 0._dp
-  
-    ! Compute spill rate
+ 
+    ! Initialise
+    Q_src( :)        = 0._dp
+    Q_dst( :)        = 0._dp
+    relweight( :, :) = 0._dp
+
+    ! Compute spill flux source
     do vi = mesh%vi1, mesh%vi2
   
       ! Only compute spill-over when ice thickness exceeds effective ice thickness
       if (Hi_new( vi) > ice%Hi_eff( vi)) then
 
-        ! Determine spill rate of excess volume toward ocean cells in m/yr
-        ice%Qspill( vi) = - (Hi_new( vi) - ice%Hi_eff( vi)) / dt
-  
-        weight = 0._dp
+        ! Determine source flux of spill-over ice in m^3/yr
+        Q_src( vi) = - (Hi_new( vi) - ice%Hi_eff( vi)) * mesh%A( vi) / dt
 
+        weight( :) = 0._dp
+  
         ! Determine weights of surrounding ocean cells
         do ci = 1, mesh%nC( vi)
-          vj = mesh%C( vi,ci)
+          vj = mesh%C( vi, ci)
     
           if (mask_icefree_ocean_tot( vj)) then
             ! Define weight by outflow perpendicular velocity into ocean cells.
@@ -327,27 +334,58 @@ contains
             weight( ci) = max(0._dp, ice%u_perp( vi, ci)) + w_eps
           end if
         end do
-    
-        ! Determine spill rate into surrounding cells in m/y
-        do ci = 1, mesh%nC( vi)
-          vj = mesh%C( vi, ci)
 
-          if (sum(weight) > 0._dp) then
-            ! Add to Qspill to allow for accumulation from multiple margin cells
-            ice%Qspill( vj) = ice%Qspill( vj) & 
-                            - ice%Qspill( vi) * mesh%A( vi) / mesh%A( vj) &
-                            * weight( ci) / sum(weight)   
+        ! Set spill source to zero if no surrounding ocean cells available
+        if (sum(weight) == 0._dp) then
+          Q_src( vi) = 0._dp
+        else
+          ! Define the relative weight of Q_src to Q_dst of the downstream ocean cells
+          do ci = 1, mesh%nC( vi)
+            relweight( vi, ci) = weight( ci) / sum(weight)
+          end do
+        end if
+
+      end if
+    end do
+
+    call gather_to_all( relweight, relweight_tot)
+    call gather_to_all( Q_src, Q_src_tot)
+
+    ! Compute spill flux destination
+    do vi = mesh%vi1, mesh%vi2
+
+      ! Skip if not an ocean cell
+      if (.not. mask_icefree_ocean_tot( vi)) cycle
+
+      do ci = 1, mesh%nC( vi)
+        !Neighbouring cell which potentially has nonzero Q_src
+        vj = mesh%C( vi, ci)
+
+        ! Connections of neighbouring cell
+        do cj = 1, mesh%nC( vj)
+
+          if (mesh%C( vj, cj) == vi) then
+          ! Yes, this connection is a match, receive fraction of Q_src
+            Q_dst( vi) = Q_dst( vi) - Q_src( vj) * relweight( vj, cj)
+
           end if
 
         end do
 
-      end if
+      end do
 
     end do
 
     ! Apply spill rates
     do vi = mesh%vi1, mesh%vi2
 
+      ! Convert spill source flux to thinning rate in m/yr
+      ice%Qspill( vi) = Q_src( vi) / mesh%A( vi)
+
+      ! Add destination flux as thickening rate in m/yr
+      ice%Qspill( vi) = ice%Qspill( vi) + Q_dst( vi) / mesh%A( vi)
+
+      ! Update ice thickness
       Hi_new( vi) = Hi_new( vi) + ice%Qspill( vi) * dt
 
     end do

--- a/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/ice_thickness_safeties.f90
@@ -332,7 +332,7 @@ contains
             ! Add small value to avoid division by 0 if no outflow velocity enters
             ! any ocean cell. In that case, weights will be equally distributed
             ! over all neighbouring ocean cells.
-            weight( ci) = max(0._dp, ice%u_perp( vi, ci)) + w_eps
+            weight( ci) = 1._dp !max(0._dp, ice%u_perp( vi, ci)) + w_eps
           end if
         end do
 
@@ -368,8 +368,10 @@ contains
   
             if (mesh%C( vj, cj) == vi) then
             ! Yes, this connection is a match, receive fraction of Q_src
-              Q_dst( vi) = Q_dst( vi) - Q_src_tot( vj) * relweight_tot( vj, cj)
-  
+              if (Q_src_tot( vj) < 0._dp .and. relweight_tot( vj, cj) > 1.e-6_dp) then
+                Q_dst( vi) = Q_dst( vi) - Q_src_tot( vj) * relweight_tot( vj, cj)
+              end if  
+
             end if
   
           end do
@@ -390,6 +392,11 @@ contains
     end do
 
     ! Update masks
+    call determine_masks( mesh, Hi_new, ice%Hb, ice%SL, ice%mask, ice%mask_icefree_land, & 
+                          ice%mask_icefree_ocean, ice%mask_grounded_ice, ice%mask_floating_ice, &
+                          ice%mask_margin, ice%mask_gl_fl, ice%mask_gl_gr,ice%mask_cf_gr, &
+                          ice%mask_cf_fl, ice%mask_coastline)
+
     call determine_masks( mesh, Hi_new, ice%Hb, ice%SL, ice%mask, ice%mask_icefree_land, & 
                           ice%mask_icefree_ocean, ice%mask_grounded_ice, ice%mask_floating_ice, &
                           ice%mask_margin, ice%mask_gl_fl, ice%mask_gl_gr,ice%mask_cf_gr, &

--- a/src/UFEMISM/io/main_regional_output/grid_output_files.f90
+++ b/src/UFEMISM/io/main_regional_output/grid_output_files.f90
@@ -591,6 +591,9 @@ contains
       case ('R_shear')
         call map_from_mesh_vertices_to_xy_grid_2D( region%mesh, grid, C%output_dir, region%ice%R_shear, d_grid_vec_partial_2D)
         call write_to_field_multopt_grid_dp_2D( grid, filename, ncid, 'R_shear', d_grid_vec_partial_2D)
+      case ('Qspill')
+        call map_from_mesh_vertices_to_xy_grid_2D( region%mesh, grid, C%output_dir, region%ice%Qspill, d_grid_vec_partial_2D)
+        call write_to_field_multopt_grid_dp_2D( grid, filename, ncid, 'Qspill', d_grid_vec_partial_2D)
 
     ! == Ice P/C time stepping ==
     ! ===========================
@@ -1544,6 +1547,8 @@ contains
         call add_field_grid_dp_2D( filename, ncid, 'divQ', precision = C%output_precision, do_compress = C%do_compress_output, long_name = 'Horizontal ice flux divergence', units = 'm yr^-1')
       case ('R_shear')
         call add_field_grid_dp_2D( filename, ncid, 'R_shear', precision = C%output_precision, do_compress = C%do_compress_output, long_name = 'Slide/shear ratio', units = '0-1')
+      case ('Qspill')
+        call add_field_grid_dp_2D( filename, ncid, 'Qspill', precision = C%output_precision, do_compress = C%do_compress_output, long_name = 'Horizontal spill over flux', units = 'm yr^-1')
 
     ! == Ice P/C time stepping ==
     ! ===========================

--- a/src/UFEMISM/io/main_regional_output/mesh_output_files.f90
+++ b/src/UFEMISM/io/main_regional_output/mesh_output_files.f90
@@ -485,6 +485,8 @@ contains
         call write_to_field_multopt_mesh_dp_2D( region%mesh, filename, ncid, 'divQ', region%ice%divQ)
       case ('R_shear')
         call write_to_field_multopt_mesh_dp_2D( region%mesh, filename, ncid, 'R_shear', region%ice%R_shear)
+      case ('Qspill')
+        call write_to_field_multopt_mesh_dp_2D( region%mesh, filename, ncid, 'Qspill', region%ice%Qspill)
 
     ! == Ice P/C time stepping ==
     ! ===========================
@@ -1218,6 +1220,8 @@ contains
         call add_field_mesh_dp_2D( filename, ncid, 'divQ', precision = C%output_precision, do_compress = C%do_compress_output, long_name = 'Horizontal ice flux divergence', units = 'm yr^-1')
       case ('R_shear')
         call add_field_mesh_dp_2D( filename, ncid, 'R_shear', precision = C%output_precision, do_compress = C%do_compress_output, long_name = 'Slide/shear ratio', units = '0-1')
+      case ('Qspill')
+        call add_field_mesh_dp_2D( filename, ncid, 'Qspill', precision = C%output_precision, do_compress = C%do_compress_output, long_name = 'Horizontal spill over flux', units = 'm yr^-1')
 
     ! == Ice P/C time stepping ==
     ! ===========================

--- a/src/UFEMISM/types/ice_model_types.f90
+++ b/src/UFEMISM/types/ice_model_types.f90
@@ -472,6 +472,8 @@ MODULE ice_model_types
 
     REAL(dp), DIMENSION(:    ), ALLOCATABLE :: divQ                        ! [m yr^-1] Horizontal ice flux divergence
     REAL(dp), DIMENSION(:    ), ALLOCATABLE :: R_shear                     ! [0-1]     uabs_base / uabs_surf (0 = pure vertical shear, viscous flow; 1 = pure sliding, plug flow)
+    real(dp), dimension(:    ), allocatable :: Qspill                      ! [m yr^-1] Horizontal ice flux due to spill over of filled cells
+    real(dp), dimension(:,:  ), allocatable :: u_perp                      ! [m yr^-1] Perpendicular ice velocity to to edge. 
 
   ! == Basal hydrology ==
   ! =====================

--- a/src/UFEMISM/validation/component_tests/ct_mass_conservation.f90
+++ b/src/UFEMISM/validation/component_tests/ct_mass_conservation.f90
@@ -7,6 +7,7 @@ module ct_mass_conservation
   use mpi_basic, only: par
   use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine
   use mesh_types, only: type_mesh
+  use ice_model_types, only: type_ice_model
   use netcdf_io_main, only: open_existing_netcdf_file_for_reading, setup_mesh_from_file, &
     close_netcdf_file, create_new_netcdf_file_for_writing, setup_mesh_in_netcdf_file, &
     add_field_mesh_dp_2D_notime, write_to_field_multopt_mesh_dp_2D_notime
@@ -15,6 +16,7 @@ module ct_mass_conservation
   use Halfar_SIA_solution, only: Halfar
   use conservation_of_mass_main, only: calc_dHi_dt
   use parameters, only: pi
+  use ice_model_memory, only: allocate_ice_model
 
   implicit none
 
@@ -100,6 +102,7 @@ contains
     character(len=1024), parameter      :: routine_name = 'run_mass_cons_test_on_mesh'
     integer                             :: ncid
     type(type_mesh)                     :: mesh
+    type(type_ice_model)                :: ice
     real(dp), dimension(:), allocatable :: Hi, u_vav_b, v_vav_b, dHi_dt_ex
     character(len=1024)                 :: ice_sheet_name
 
@@ -119,6 +122,7 @@ contains
     call assert( test_mesh_is_self_consistent( mesh), 'mesh is not self-consistent')
 
     ! Run all the mapping tests with different test ice sheets
+    call allocate_ice_model( mesh, ice)
 
     allocate( Hi       (mesh%vi1:mesh%vi2), source = 0._dp)
     allocate( u_vav_b  (mesh%ti1:mesh%ti2), source = 0._dp)
@@ -128,17 +132,17 @@ contains
     call setup_test_ice_sheet_linear( mesh, Hi, u_vav_b, v_vav_b, dHi_dt_ex)
     ice_sheet_name = 'linear'
     call run_mass_cons_test_on_mesh_with_ice_sheet( foldername_mass_cons, test_mesh_filename, &
-      mesh, Hi, u_vav_b, v_vav_b, dHi_dt_ex, ice_sheet_name)
+      mesh, ice, Hi, u_vav_b, v_vav_b, dHi_dt_ex, ice_sheet_name)
 
     call setup_test_ice_sheet_periodic( mesh, Hi, u_vav_b, v_vav_b, dHi_dt_ex)
     ice_sheet_name = 'periodic'
     call run_mass_cons_test_on_mesh_with_ice_sheet( foldername_mass_cons, test_mesh_filename, &
-      mesh, Hi, u_vav_b, v_vav_b, dHi_dt_ex, ice_sheet_name)
+      mesh, ice, Hi, u_vav_b, v_vav_b, dHi_dt_ex, ice_sheet_name)
 
     call setup_test_ice_sheet_Halfar( mesh, Hi, u_vav_b, v_vav_b, dHi_dt_ex)
     ice_sheet_name = 'Halfar'
     call run_mass_cons_test_on_mesh_with_ice_sheet( foldername_mass_cons, test_mesh_filename, &
-      mesh, Hi, u_vav_b, v_vav_b, dHi_dt_ex, ice_sheet_name)
+      mesh, ice, Hi, u_vav_b, v_vav_b, dHi_dt_ex, ice_sheet_name)
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)
@@ -147,12 +151,13 @@ contains
 
   !> Run the mass conservation test on a particular mesh and a particular ice sheet
   subroutine run_mass_cons_test_on_mesh_with_ice_sheet( foldername_mass_cons, test_mesh_filename, &
-    mesh, Hi, u_vav_b, v_vav_b, dHi_dt_ex, ice_sheet_name)
+    mesh, ice, Hi, u_vav_b, v_vav_b, dHi_dt_ex, ice_sheet_name)
 
     ! In/output variables:
     character(len=*),                        intent(in   ) :: foldername_mass_cons
     character(len=*),                        intent(in   ) :: test_mesh_filename
     type(type_mesh),                         intent(in   ) :: mesh
+    type(type_ice_model),                    intent(inout) :: ice
     real(dp), dimension(mesh%vi1:mesh%vi2),  intent(in   ) :: Hi
     real(dp), dimension(mesh%ti1:mesh%ti2),  intent(in   ) :: u_vav_b, v_vav_b
     real(dp), dimension(mesh%vi1:mesh%vi2),  intent(in   ) :: dHi_dt_ex
@@ -193,25 +198,25 @@ contains
 
     ! Explicit
     C%choice_ice_integration_method = 'explicit'
-    call calc_dHi_dt( mesh, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+    call calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
       fraction_margin, mask_noice, dt, dHi_dt_expl, Hi_tplusdt, divQ, dHi_dt_target)
 
     ! Semi-implicit
     C%choice_ice_integration_method = 'semi-implicit'
     C%dHi_semiimplicit_fs = 0.5_dp
-    call calc_dHi_dt( mesh, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+    call calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
       fraction_margin, mask_noice, dt, dHi_dt_semiimpl, Hi_tplusdt, divQ, dHi_dt_target)
 
     ! Implicit
     C%choice_ice_integration_method = 'semi-implicit'
     C%dHi_semiimplicit_fs = 1._dp
-    call calc_dHi_dt( mesh, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+    call calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
       fraction_margin, mask_noice, dt, dHi_dt_impl, Hi_tplusdt, divQ, dHi_dt_target)
 
     ! Over-implicit
     C%choice_ice_integration_method = 'semi-implicit'
     C%dHi_semiimplicit_fs = 1.5_dp
-    call calc_dHi_dt( mesh, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+    call calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
       fraction_margin, mask_noice, dt, dHi_dt_overimpl, Hi_tplusdt, divQ, dHi_dt_target)
 
     ! Write results to output

--- a/src/UPSY/io/netcdf_input/netcdf_read_field_from_mesh_file.f90
+++ b/src/UPSY/io/netcdf_input/netcdf_read_field_from_mesh_file.f90
@@ -283,7 +283,7 @@ contains
     call check_mesh_dimensions( filename, ncid)
 
     ! Inquire mesh dimensions
-    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nTri)
+    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nTri, id_dim, dim_length = nTri)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -521,7 +521,7 @@ contains
     call check_mesh_dimensions( filename, ncid)
 
     ! Inquire mesh dimensions
-    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nTri)
+    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nTri, id_dim, dim_length = nTri)
 
     ! Set up the vertical coordinate zeta from the file
     call setup_zeta_from_file( filename, ncid, nzeta_loc, zeta_loc)

--- a/src/UPSY/io/netcdf_input/netcdf_read_field_from_mesh_file.f90
+++ b/src/UPSY/io/netcdf_input/netcdf_read_field_from_mesh_file.f90
@@ -35,12 +35,11 @@ contains
     ! Local variables:
     character(len=1024), parameter        :: routine_name = 'read_field_from_mesh_file_int_2D'
     integer                               :: ncid
-    type(type_mesh)                       :: mesh_loc
-    integer                               :: id_var
+    integer                               :: id_var, id_dim
     character(len=1024)                   :: var_name
     integer , dimension(:  ), allocatable :: d_mesh
     integer , dimension(:,:), allocatable :: d_mesh_with_time
-    integer                               :: ti
+    integer                               :: ti, nV
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -51,8 +50,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -62,18 +64,18 @@ contains
     call check_mesh_field_int_2D( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nV))
+    if (par%primary) allocate( d_mesh( nV))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, 1))
+      if (par%primary) allocate( d_mesh_with_time( nV, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ mesh_loc%nV, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ nV, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,1)
       ! Clean up after yourself
@@ -109,12 +111,11 @@ contains
     ! Local variables:
     character(len=1024), parameter        :: routine_name = 'read_field_from_mesh_file_int_2D_b'
     integer                               :: ncid
-    type(type_mesh)                       :: mesh_loc
-    integer                               :: id_var
+    integer                               :: id_var, id_dim
     character(len=1024)                   :: var_name
     integer , dimension(:  ), allocatable :: d_mesh
     integer , dimension(:,:), allocatable :: d_mesh_with_time
-    integer                               :: ti
+    integer                               :: ti, nTri
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -125,8 +126,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nTri, id_dim, dim_length = nTri)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -136,18 +140,18 @@ contains
     call check_mesh_field_int_2D_b( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nTri))
+    if (par%primary) allocate( d_mesh( nTri))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nTri, 1))
+      if (par%primary) allocate( d_mesh_with_time( nTri, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ mesh_loc%nTri, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ nTri, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,1)
       ! Clean up after yourself
@@ -183,12 +187,11 @@ contains
     ! Local variables:
     character(len=1024), parameter        :: routine_name = 'read_field_from_mesh_file_dp_2D'
     integer                               :: ncid
-    type(type_mesh)                       :: mesh_loc
-    integer                               :: id_var
+    integer                               :: id_var, id_dim
     character(len=1024)                   :: var_name
     real(dp), dimension(:  ), allocatable :: d_mesh
     real(dp), dimension(:,:), allocatable :: d_mesh_with_time
-    integer                               :: ti
+    integer                               :: vi, nV
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -199,8 +202,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -210,18 +216,18 @@ contains
     call check_mesh_field_dp_2D( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nV))
+    if (par%primary) allocate( d_mesh( nV))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, 1))
+      if (par%primary) allocate( d_mesh_with_time( nV, 1))
       ! Find out which timeframe to read
-      call find_timeframe( filename, ncid, time_to_read, ti)
+      call find_timeframe( filename, ncid, time_to_read, vi)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ mesh_loc%nV, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, vi /), count = (/ nV, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,1)
       ! Clean up after yourself
@@ -258,11 +264,11 @@ contains
     character(len=1024), parameter        :: routine_name = 'read_field_from_mesh_file_dp_2D_b'
     integer                               :: ncid
     type(type_mesh)                       :: mesh_loc
-    integer                               :: id_var
+    integer                               :: id_var, id_dim
     character(len=1024)                   :: var_name
     real(dp), dimension(:  ), allocatable :: d_mesh
     real(dp), dimension(:,:), allocatable :: d_mesh_with_time
-    integer                               :: ti
+    integer                               :: ti, nTri
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -273,8 +279,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nTri)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -284,18 +293,18 @@ contains
     call check_mesh_field_dp_2D_b( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nTri))
+    if (par%primary) allocate( d_mesh( nTri))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nTri, 1))
+      if (par%primary) allocate( d_mesh_with_time( nTri, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ mesh_loc%nTri, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ nTri, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,1)
       ! Clean up after yourself
@@ -331,12 +340,11 @@ contains
     ! Local variables:
     character(len=1024), parameter          :: routine_name = 'read_field_from_mesh_file_dp_2D_monthly'
     integer                                 :: ncid
-    type(type_mesh)                         :: mesh_loc
-    integer                                 :: id_var
+    integer                                 :: id_var, id_dim
     character(len=1024)                     :: var_name
     real(dp), dimension(:,:  ), allocatable :: d_mesh
     real(dp), dimension(:,:,:), allocatable :: d_mesh_with_time
-    integer                                 :: ti
+    integer                                 :: vi, nV
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -347,8 +355,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -361,18 +372,18 @@ contains
     call check_mesh_field_dp_2D_monthly( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nV, 12))
+    if (par%primary) allocate( d_mesh( nV, 12))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, 12, 1))
+      if (par%primary) allocate( d_mesh_with_time( nV, 12, 1))
       ! Find out which timeframe to read
-      call find_timeframe( filename, ncid, time_to_read, ti)
+      call find_timeframe( filename, ncid, time_to_read, vi)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ mesh_loc%nV, 12, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, vi /), count = (/ nV, 12, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,:,1)
       ! Clean up after yourself
@@ -408,14 +419,13 @@ contains
     ! Local variables:
     character(len=1024), parameter          :: routine_name = 'read_field_from_mesh_file_dp_3D'
     integer                                 :: ncid
-    type(type_mesh)                         :: mesh_loc
     integer                                 :: nzeta_loc
     real(dp), dimension(:), allocatable     :: zeta_loc
-    integer                                 :: id_var
+    integer                                 :: id_var, id_dim
     character(len=1024)                     :: var_name
     real(dp), dimension(:,:  ), allocatable :: d_mesh
     real(dp), dimension(:,:,:), allocatable :: d_mesh_with_time
-    integer                                 :: ti
+    integer                                 :: vi, nV
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -426,8 +436,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
 
     ! Set up the vertical coordinate zeta from the file
     call setup_zeta_from_file( filename, ncid, nzeta_loc, zeta_loc)
@@ -440,18 +453,18 @@ contains
     call check_mesh_field_dp_3D( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nV, nzeta_loc))
+    if (par%primary) allocate( d_mesh( nV, nzeta_loc))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, nzeta_loc, 1))
+      if (par%primary) allocate( d_mesh_with_time( nV, nzeta_loc, 1))
       ! Find out which timeframe to read
-      call find_timeframe( filename, ncid, time_to_read, ti)
+      call find_timeframe( filename, ncid, time_to_read, vi)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ mesh_loc%nV, nzeta_loc, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, vi /), count = (/ nV, nzeta_loc, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,:,1)
       ! Clean up after yourself
@@ -487,14 +500,13 @@ contains
     ! Local variables:
     character(len=1024), parameter          :: routine_name = 'read_field_from_mesh_file_dp_3D_b'
     integer                                 :: ncid
-    type(type_mesh)                         :: mesh_loc
     integer                                 :: nzeta_loc
     real(dp), dimension(:), allocatable     :: zeta_loc
-    integer                                 :: id_var
+    integer                                 :: id_var, id_dim
     character(len=1024)                     :: var_name
     real(dp), dimension(:,:  ), allocatable :: d_mesh
     real(dp), dimension(:,:,:), allocatable :: d_mesh_with_time
-    integer                                 :: ti
+    integer                                 :: ti, nTri
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -505,8 +517,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nTri)
 
     ! Set up the vertical coordinate zeta from the file
     call setup_zeta_from_file( filename, ncid, nzeta_loc, zeta_loc)
@@ -519,18 +534,18 @@ contains
     call check_mesh_field_dp_3D_b( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nTri, nzeta_loc))
+    if (par%primary) allocate( d_mesh( nTri, nzeta_loc))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nTri, nzeta_loc, 1))
+      if (par%primary) allocate( d_mesh_with_time( nTri, nzeta_loc, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ mesh_loc%nTri, nzeta_loc, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ nTri, nzeta_loc, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,:,1)
       ! Clean up after yourself
@@ -566,14 +581,13 @@ contains
     ! Local variables:
     character(len=1024), parameter          :: routine_name = 'read_field_from_mesh_file_dp_3D_ocean'
     integer                                 :: ncid
-    type(type_mesh)                         :: mesh_loc
     integer                                 :: ndepth_loc
     real(dp), dimension(:), allocatable     :: depth_loc
-    integer                                 :: id_var
+    integer                                 :: id_var, id_dim
     character(len=1024)                     :: var_name
     real(dp), dimension(:,:  ), allocatable :: d_mesh
     real(dp), dimension(:,:,:), allocatable :: d_mesh_with_time
-    integer                                 :: ti
+    integer                                 :: vi, nV
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -584,8 +598,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
 
     ! Set up the vertical coordinate depth from the file
     call setup_depth_from_file( filename, ncid, ndepth_loc, depth_loc)
@@ -598,18 +615,18 @@ contains
     call check_mesh_field_dp_3D_ocean( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nV, ndepth_loc))
+    if (par%primary) allocate( d_mesh( nV, ndepth_loc))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, ndepth_loc, 1))
+      if (par%primary) allocate( d_mesh_with_time( nV, ndepth_loc, 1))
       ! Find out which timeframe to read
-      call find_timeframe( filename, ncid, time_to_read, ti)
+      call find_timeframe( filename, ncid, time_to_read, vi)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ mesh_loc%nV, ndepth_loc, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, vi /), count = (/ nV, ndepth_loc, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,:,1)
       ! Clean up after yourself

--- a/src/UPSY/io/netcdf_input/netcdf_read_field_from_mesh_file.f90
+++ b/src/UPSY/io/netcdf_input/netcdf_read_field_from_mesh_file.f90
@@ -35,11 +35,12 @@ contains
     ! Local variables:
     character(len=1024), parameter        :: routine_name = 'read_field_from_mesh_file_int_2D'
     integer                               :: ncid
-    integer                               :: id_var, id_dim
+    type(type_mesh)                       :: mesh_loc
+    integer                               :: id_var
     character(len=1024)                   :: var_name
     integer , dimension(:  ), allocatable :: d_mesh
     integer , dimension(:,:), allocatable :: d_mesh_with_time
-    integer                               :: ti, nV
+    integer                               :: ti
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -50,11 +51,8 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Check mesh dimensions and variables for validity
-    call check_mesh_dimensions( filename, ncid)
-
-    ! Inquire mesh dimensions
-    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
+    ! Set up the mesh from the file
+    call setup_mesh_from_file( filename, ncid, mesh_loc)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -64,18 +62,18 @@ contains
     call check_mesh_field_int_2D( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( nV))
+    if (par%primary) allocate( d_mesh( mesh_loc%nV))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( nV, 1))
+      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ nV, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ mesh_loc%nV, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,1)
       ! Clean up after yourself
@@ -111,11 +109,12 @@ contains
     ! Local variables:
     character(len=1024), parameter        :: routine_name = 'read_field_from_mesh_file_int_2D_b'
     integer                               :: ncid
-    integer                               :: id_var, id_dim
+    type(type_mesh)                       :: mesh_loc
+    integer                               :: id_var
     character(len=1024)                   :: var_name
     integer , dimension(:  ), allocatable :: d_mesh
     integer , dimension(:,:), allocatable :: d_mesh_with_time
-    integer                               :: ti, nTri
+    integer                               :: ti
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -126,11 +125,8 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Check mesh dimensions and variables for validity
-    call check_mesh_dimensions( filename, ncid)
-
-    ! Inquire mesh dimensions
-    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nTri, id_dim, dim_length = nTri)
+    ! Set up the mesh from the file
+    call setup_mesh_from_file( filename, ncid, mesh_loc)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -140,18 +136,18 @@ contains
     call check_mesh_field_int_2D_b( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( nTri))
+    if (par%primary) allocate( d_mesh( mesh_loc%nTri))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( nTri, 1))
+      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nTri, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ nTri, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ mesh_loc%nTri, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,1)
       ! Clean up after yourself
@@ -187,11 +183,12 @@ contains
     ! Local variables:
     character(len=1024), parameter        :: routine_name = 'read_field_from_mesh_file_dp_2D'
     integer                               :: ncid
-    integer                               :: id_var, id_dim
+    type(type_mesh)                       :: mesh_loc
+    integer                               :: id_var
     character(len=1024)                   :: var_name
     real(dp), dimension(:  ), allocatable :: d_mesh
     real(dp), dimension(:,:), allocatable :: d_mesh_with_time
-    integer                               :: vi, nV
+    integer                               :: ti
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -202,11 +199,8 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Check mesh dimensions and variables for validity
-    call check_mesh_dimensions( filename, ncid)
-
-    ! Inquire mesh dimensions
-    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
+    ! Set up the mesh from the file
+    call setup_mesh_from_file( filename, ncid, mesh_loc)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -216,18 +210,18 @@ contains
     call check_mesh_field_dp_2D( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( nV))
+    if (par%primary) allocate( d_mesh( mesh_loc%nV))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( nV, 1))
+      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, 1))
       ! Find out which timeframe to read
-      call find_timeframe( filename, ncid, time_to_read, vi)
+      call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, vi /), count = (/ nV, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ mesh_loc%nV, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,1)
       ! Clean up after yourself
@@ -264,11 +258,11 @@ contains
     character(len=1024), parameter        :: routine_name = 'read_field_from_mesh_file_dp_2D_b'
     integer                               :: ncid
     type(type_mesh)                       :: mesh_loc
-    integer                               :: id_var, id_dim
+    integer                               :: id_var
     character(len=1024)                   :: var_name
     real(dp), dimension(:  ), allocatable :: d_mesh
     real(dp), dimension(:,:), allocatable :: d_mesh_with_time
-    integer                               :: ti, nTri
+    integer                               :: ti
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -279,11 +273,8 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Check mesh dimensions and variables for validity
-    call check_mesh_dimensions( filename, ncid)
-
-    ! Inquire mesh dimensions
-    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nTri, id_dim, dim_length = nTri)
+    ! Set up the mesh from the file
+    call setup_mesh_from_file( filename, ncid, mesh_loc)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -293,18 +284,18 @@ contains
     call check_mesh_field_dp_2D_b( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( nTri))
+    if (par%primary) allocate( d_mesh( mesh_loc%nTri))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( nTri, 1))
+      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nTri, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ nTri, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ mesh_loc%nTri, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,1)
       ! Clean up after yourself
@@ -340,11 +331,12 @@ contains
     ! Local variables:
     character(len=1024), parameter          :: routine_name = 'read_field_from_mesh_file_dp_2D_monthly'
     integer                                 :: ncid
-    integer                                 :: id_var, id_dim
+    type(type_mesh)                         :: mesh_loc
+    integer                                 :: id_var
     character(len=1024)                     :: var_name
     real(dp), dimension(:,:  ), allocatable :: d_mesh
     real(dp), dimension(:,:,:), allocatable :: d_mesh_with_time
-    integer                                 :: vi, nV
+    integer                                 :: ti
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -355,11 +347,8 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Check mesh dimensions and variables for validity
-    call check_mesh_dimensions( filename, ncid)
-
-    ! Inquire mesh dimensions
-    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
+    ! Set up the mesh from the file
+    call setup_mesh_from_file( filename, ncid, mesh_loc)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -372,18 +361,18 @@ contains
     call check_mesh_field_dp_2D_monthly( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( nV, 12))
+    if (par%primary) allocate( d_mesh( mesh_loc%nV, 12))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( nV, 12, 1))
+      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, 12, 1))
       ! Find out which timeframe to read
-      call find_timeframe( filename, ncid, time_to_read, vi)
+      call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, vi /), count = (/ nV, 12, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ mesh_loc%nV, 12, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,:,1)
       ! Clean up after yourself
@@ -419,13 +408,14 @@ contains
     ! Local variables:
     character(len=1024), parameter          :: routine_name = 'read_field_from_mesh_file_dp_3D'
     integer                                 :: ncid
+    type(type_mesh)                         :: mesh_loc
     integer                                 :: nzeta_loc
     real(dp), dimension(:), allocatable     :: zeta_loc
-    integer                                 :: id_var, id_dim
+    integer                                 :: id_var
     character(len=1024)                     :: var_name
     real(dp), dimension(:,:  ), allocatable :: d_mesh
     real(dp), dimension(:,:,:), allocatable :: d_mesh_with_time
-    integer                                 :: vi, nV
+    integer                                 :: ti
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -436,11 +426,8 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Check mesh dimensions and variables for validity
-    call check_mesh_dimensions( filename, ncid)
-
-    ! Inquire mesh dimensions
-    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
+    ! Set up the mesh from the file
+    call setup_mesh_from_file( filename, ncid, mesh_loc)
 
     ! Set up the vertical coordinate zeta from the file
     call setup_zeta_from_file( filename, ncid, nzeta_loc, zeta_loc)
@@ -453,18 +440,18 @@ contains
     call check_mesh_field_dp_3D( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( nV, nzeta_loc))
+    if (par%primary) allocate( d_mesh( mesh_loc%nV, nzeta_loc))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( nV, nzeta_loc, 1))
+      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, nzeta_loc, 1))
       ! Find out which timeframe to read
-      call find_timeframe( filename, ncid, time_to_read, vi)
+      call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, vi /), count = (/ nV, nzeta_loc, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ mesh_loc%nV, nzeta_loc, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,:,1)
       ! Clean up after yourself
@@ -500,13 +487,14 @@ contains
     ! Local variables:
     character(len=1024), parameter          :: routine_name = 'read_field_from_mesh_file_dp_3D_b'
     integer                                 :: ncid
+    type(type_mesh)                         :: mesh_loc
     integer                                 :: nzeta_loc
     real(dp), dimension(:), allocatable     :: zeta_loc
-    integer                                 :: id_var, id_dim
+    integer                                 :: id_var
     character(len=1024)                     :: var_name
     real(dp), dimension(:,:  ), allocatable :: d_mesh
     real(dp), dimension(:,:,:), allocatable :: d_mesh_with_time
-    integer                                 :: ti, nTri
+    integer                                 :: ti
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -517,11 +505,8 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Check mesh dimensions and variables for validity
-    call check_mesh_dimensions( filename, ncid)
-
-    ! Inquire mesh dimensions
-    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nTri, id_dim, dim_length = nTri)
+    ! Set up the mesh from the file
+    call setup_mesh_from_file( filename, ncid, mesh_loc)
 
     ! Set up the vertical coordinate zeta from the file
     call setup_zeta_from_file( filename, ncid, nzeta_loc, zeta_loc)
@@ -534,18 +519,18 @@ contains
     call check_mesh_field_dp_3D_b( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( nTri, nzeta_loc))
+    if (par%primary) allocate( d_mesh( mesh_loc%nTri, nzeta_loc))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( nTri, nzeta_loc, 1))
+      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nTri, nzeta_loc, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ nTri, nzeta_loc, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ mesh_loc%nTri, nzeta_loc, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,:,1)
       ! Clean up after yourself
@@ -581,13 +566,14 @@ contains
     ! Local variables:
     character(len=1024), parameter          :: routine_name = 'read_field_from_mesh_file_dp_3D_ocean'
     integer                                 :: ncid
+    type(type_mesh)                         :: mesh_loc
     integer                                 :: ndepth_loc
     real(dp), dimension(:), allocatable     :: depth_loc
-    integer                                 :: id_var, id_dim
+    integer                                 :: id_var
     character(len=1024)                     :: var_name
     real(dp), dimension(:,:  ), allocatable :: d_mesh
     real(dp), dimension(:,:,:), allocatable :: d_mesh_with_time
-    integer                                 :: vi, nV
+    integer                                 :: ti
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -598,11 +584,8 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Check mesh dimensions and variables for validity
-    call check_mesh_dimensions( filename, ncid)
-
-    ! Inquire mesh dimensions
-    call inquire_dim_multopt( filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
+    ! Set up the mesh from the file
+    call setup_mesh_from_file( filename, ncid, mesh_loc)
 
     ! Set up the vertical coordinate depth from the file
     call setup_depth_from_file( filename, ncid, ndepth_loc, depth_loc)
@@ -615,18 +598,18 @@ contains
     call check_mesh_field_dp_3D_ocean( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( nV, ndepth_loc))
+    if (par%primary) allocate( d_mesh( mesh_loc%nV, ndepth_loc))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( nV, ndepth_loc, 1))
+      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, ndepth_loc, 1))
       ! Find out which timeframe to read
-      call find_timeframe( filename, ncid, time_to_read, vi)
+      call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, vi /), count = (/ nV, ndepth_loc, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ mesh_loc%nV, ndepth_loc, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,:,1)
       ! Clean up after yourself

--- a/tools/python/upsy/colormaps.py
+++ b/tools/python/upsy/colormaps.py
@@ -78,7 +78,7 @@ def get_cmap(varname):
     elif varname in ['Hi', 'Hi_eff']:
         cmap = copy(plt.get_cmap('cmo.ice'))
         #norm = mpl.colors.Normalize(vmin=0,vmax=3000,clip=True)
-        norm = mpl.colors.LogNorm(vmin=.1,vmax=3000,clip=True)
+        norm = mpl.colors.LogNorm(vmin=100,vmax=1000,clip=True)
 
     elif varname == 'dHi':
         colors1 = plt.get_cmap('afmhot')(np.linspace(0,1,128))
@@ -169,15 +169,15 @@ def get_cmap(varname):
 
     elif varname == 'divQ':
         cmap = copy(plt.get_cmap('cmo.diff'))
-        norm = mpl.colors.Normalize(vmin=-10,vmax=10,clip=True)
+        norm = mpl.colors.Normalize(vmin=-30,vmax=30,clip=True)
 
     elif varname == 'Qspill':
-        cmap = copy(plt.get_cmap('cmo.diff'))
-        norm = mpl.colors.Normalize(vmin=-1,vmax=1,clip=True)
+        cmap = copy(plt.get_cmap('cmo.diff_r'))
+        norm = mpl.colors.Normalize(vmin=-30,vmax=30,clip=True)
 
     elif varname == 'fraction_margin':
         cmap = copy(plt.get_cmap('cmo.ice'))
-        norm = mpl.colors.Normalize(vmin=0,vmax=1.2,clip=True)
+        norm = mpl.colors.Normalize(vmin=0,vmax=1.1,clip=True)
 
     elif varname == 'dHi_eff':
         cmap = copy(plt.get_cmap('cmo.balance'))

--- a/tools/python/upsy/colormaps.py
+++ b/tools/python/upsy/colormaps.py
@@ -168,11 +168,11 @@ def get_cmap(varname):
 
     elif varname == 'divQ':
         cmap = copy(plt.get_cmap('cmo.diff'))
-        norm = mpl.colors.Normalize(vmin=-10,vmax=10,clip=True)
+        norm = mpl.colors.Normalize(vmin=-100,vmax=100,clip=True)
 
     elif varname == 'Qspill':
-        cmap = copy(plt.get_cmap('cmo.diff'))
-        norm = mpl.colors.Normalize(vmin=-1,vmax=1,clip=True)
+        cmap = copy(plt.get_cmap('cmo.diff_r'))
+        norm = mpl.colors.Normalize(vmin=-100,vmax=100,clip=True)
 
     elif varname == 'fraction_margin':
         cmap = copy(plt.get_cmap('cmo.ice'))

--- a/tools/python/upsy/colormaps.py
+++ b/tools/python/upsy/colormaps.py
@@ -170,6 +170,10 @@ def get_cmap(varname):
         cmap = copy(plt.get_cmap('cmo.diff'))
         norm = mpl.colors.Normalize(vmin=-10,vmax=10,clip=True)
 
+    elif varname == 'Qspill':
+        cmap = copy(plt.get_cmap('cmo.diff'))
+        norm = mpl.colors.Normalize(vmin=-1,vmax=1,clip=True)
+
     elif varname == 'fraction_margin':
         cmap = copy(plt.get_cmap('cmo.ice'))
         norm = mpl.colors.Normalize(vmin=0,vmax=1.2,clip=True)

--- a/tools/python/upsy/colormaps.py
+++ b/tools/python/upsy/colormaps.py
@@ -168,11 +168,11 @@ def get_cmap(varname):
 
     elif varname == 'divQ':
         cmap = copy(plt.get_cmap('cmo.diff'))
-        norm = mpl.colors.Normalize(vmin=-100,vmax=100,clip=True)
+        norm = mpl.colors.Normalize(vmin=-10,vmax=10,clip=True)
 
     elif varname == 'Qspill':
-        cmap = copy(plt.get_cmap('cmo.diff_r'))
-        norm = mpl.colors.Normalize(vmin=-100,vmax=100,clip=True)
+        cmap = copy(plt.get_cmap('cmo.diff'))
+        norm = mpl.colors.Normalize(vmin=-1,vmax=1,clip=True)
 
     elif varname == 'fraction_margin':
         cmap = copy(plt.get_cmap('cmo.ice'))

--- a/tools/python/upsy/colormaps.py
+++ b/tools/python/upsy/colormaps.py
@@ -75,7 +75,7 @@ def get_cmap(varname):
         cmap = mpl.colors.LinearSegmentedColormap.from_list('my_colormap', colors,68)
         norm = mpl.colors.SymLogNorm(linthresh, vmin=vmin, vmax=vmax, linscale=linscale)
         
-    elif varname == 'Hi':
+    elif varname in ['Hi', 'Hi_eff']:
         cmap = copy(plt.get_cmap('cmo.ice'))
         norm = mpl.colors.Normalize(vmin=0,vmax=3000,clip=True)
 
@@ -164,11 +164,15 @@ def get_cmap(varname):
 
     elif varname == 'dHi_dt':
         cmap = copy(plt.get_cmap('cmo.balance_r'))
-        norm = mpl.colors.Normalize(vmin=-1,vmax=1,clip=True)
+        norm = mpl.colors.Normalize(vmin=-10,vmax=10,clip=True)
 
     elif varname == 'divQ':
         cmap = copy(plt.get_cmap('cmo.diff'))
-        norm = mpl.colors.Normalize(vmin=-1,vmax=1,clip=True)
+        norm = mpl.colors.Normalize(vmin=-10,vmax=10,clip=True)
+
+    elif varname == 'fraction_margin':
+        cmap = copy(plt.get_cmap('cmo.ice'))
+        norm = mpl.colors.Normalize(vmin=0,vmax=1.2,clip=True)
 
     else:
         print(f'ERROR: no colormap available yet for {varname}, add one to colormaps.py')

--- a/tools/python/upsy/colormaps.py
+++ b/tools/python/upsy/colormaps.py
@@ -77,7 +77,8 @@ def get_cmap(varname):
         
     elif varname in ['Hi', 'Hi_eff']:
         cmap = copy(plt.get_cmap('cmo.ice'))
-        norm = mpl.colors.Normalize(vmin=0,vmax=3000,clip=True)
+        #norm = mpl.colors.Normalize(vmin=0,vmax=3000,clip=True)
+        norm = mpl.colors.LogNorm(vmin=.1,vmax=3000,clip=True)
 
     elif varname == 'dHi':
         colors1 = plt.get_cmap('afmhot')(np.linspace(0,1,128))
@@ -177,6 +178,10 @@ def get_cmap(varname):
     elif varname == 'fraction_margin':
         cmap = copy(plt.get_cmap('cmo.ice'))
         norm = mpl.colors.Normalize(vmin=0,vmax=1.2,clip=True)
+
+    elif varname == 'dHi_eff':
+        cmap = copy(plt.get_cmap('cmo.balance'))
+        norm = mpl.colors.SymLogNorm(.01, vmin=-100, vmax=100, linscale=.01)
 
     else:
         print(f'ERROR: no colormap available yet for {varname}, add one to colormaps.py')

--- a/tools/python/upsy/figure.py
+++ b/tools/python/upsy/figure.py
@@ -385,6 +385,10 @@ class Field(object):
             else:
                 print(f"ERROR: no valid BMB or melt variable in Timeframe")
                 return
+        elif self.varname == 'dHi_eff':
+            Hi = self.Timeframe.ds['Hi']
+            Hi_eff = self.Timeframe.ds['Hi_eff']
+            self.data = Hi-Hi_eff
         else:
             # Regular case: read variable if available in output
             try:


### PR DESCRIPTION
Made some improvements on the representation of the partially filled cells. Most importantly: implemented a 'Qspill' that spills ice from margin cells into downstream ocean cells when the ice thickness of the margin cell exceeds that of the upstream cell. Equivalent but not identical to the effective ice thickness.

Didn't implement this yet, but a similar procedure can be implemented when margin cells empty, draining ice from upstream cells. This should allow for rate-based calving laws.

Improvements with these changes:
- No more bump at the calving front (MISOMIP, Thwaites)
- Much smoother grounding line and calving fluxes and effective thickness at calving front
- Reasonable values for inverted BMB
- Less persistent pinning of Pine Island, and overall somewhat reduced thickness biases in a pan-Antarctic initialisation

Also, I skipped the repeated 'setup_mesh_from_file' for each individual input variable, which greatly slowed down the initialisation (and probably clogged memory). This still needs to be implemented for thermodynamics though, which now by definition does a remap. Not sure whether that's by design or not.