### PR TITLE
Climate snapshot plus anomalies

### DIFF
--- a/src/UFEMISM/climate/climate_main.f90
+++ b/src/UFEMISM/climate/climate_main.f90
@@ -22,6 +22,7 @@ MODULE climate_main
   USE climate_realistic                                      , ONLY: initialise_climate_model_realistic, run_climate_model_realistic, remap_climate_realistic
   USE climate_snapshot_plus_uniform_deltaT                   , ONLY: initialise_climate_model_snapshot_plus_uniform_deltaT, run_climate_model_snapshot_plus_uniform_deltaT, remap_climate_snapshot_plus_uniform_deltaT
   USE climate_snapshot_plus_transient_deltaT                 , ONLY: initialise_climate_model_snapshot_plus_transient_deltaT, run_climate_model_snapshot_plus_transient_deltaT, remap_climate_snapshot_plus_transient_deltaT
+  USE climate_snapshot_plus_anomalies                        , ONLY: initialise_climate_model_snp_p_anml, run_climate_model_snp_p_anml, remap_climate_snp_p_anml
   USE reallocate_mod                                         , ONLY: reallocate_bounds
   use netcdf_io_main
   use climate_matrix                                         , only: run_climate_model_matrix, initialise_climate_matrix, remap_climate_matrix_model
@@ -104,7 +105,7 @@ CONTAINS
     CASE ('snapshot_plus_transient_deltaT')
       CALL run_climate_model_snapshot_plus_transient_deltaT( mesh, ice, climate, time)
     CASE ('snapshot_plus_anomalies')
-      CALL run_climate_model_snp_p_anml( mesh, ice, climate, forcing, time)  
+      CALL run_climate_model_snp_p_anml( mesh, ice, climate, time)  
     CASE ('matrix')
       call run_climate_model_matrix( mesh, grid, ice, SMB, climate, region_name, time, forcing)
     case ('SMB_snapshot_plus_anomalies')
@@ -194,7 +195,7 @@ CONTAINS
     case ('snapshot_plus_transient_deltaT')
       call initialise_climate_model_snapshot_plus_transient_deltaT( mesh, ice, climate, region_name, C%start_time_of_run)
     CASE ('snapshot_plus_anomalies')
-      CALL initialise_climate_model_snp_p_anml( mesh, ice, climate, region_name, forcing, C%start_time_of_run)    
+      CALL initialise_climate_model_snp_p_anml( mesh, ice, climate, region_name)    
     case ('matrix')
       if (par%primary)  write(*,"(A)") '   Initialising climate matrix model...'
       call initialise_climate_matrix( mesh, grid, ice, climate, region_name, forcing)

--- a/src/UFEMISM/climate/climate_main.f90
+++ b/src/UFEMISM/climate/climate_main.f90
@@ -103,6 +103,8 @@ CONTAINS
       CALL run_climate_model_snapshot_plus_uniform_deltaT( mesh, ice, climate, time)
     CASE ('snapshot_plus_transient_deltaT')
       CALL run_climate_model_snapshot_plus_transient_deltaT( mesh, ice, climate, time)
+    CASE ('snapshot_plus_anomalies')
+      CALL run_climate_model_snp_p_anml( mesh, ice, climate, forcing, time)  
     CASE ('matrix')
       call run_climate_model_matrix( mesh, grid, ice, SMB, climate, region_name, time, forcing)
     case ('SMB_snapshot_plus_anomalies')
@@ -191,6 +193,8 @@ CONTAINS
       call initialise_climate_model_snapshot_plus_uniform_deltaT( mesh, ice, climate, region_name)
     case ('snapshot_plus_transient_deltaT')
       call initialise_climate_model_snapshot_plus_transient_deltaT( mesh, ice, climate, region_name, C%start_time_of_run)
+    CASE ('snapshot_plus_anomalies')
+      CALL initialise_climate_model_snp_p_anml( mesh, ice, climate, region_name, forcing, C%start_time_of_run)    
     case ('matrix')
       if (par%primary)  write(*,"(A)") '   Initialising climate matrix model...'
       call initialise_climate_matrix( mesh, grid, ice, climate, region_name, forcing)
@@ -246,6 +250,7 @@ CONTAINS
     case ('realistic', &
           'snapshot_plus_uniform_deltaT', &
           'snapshot_plus_transient_deltaT', &
+          'snapshot_plus_anomalies', &
           'matrix')
       call write_to_restart_file_climate_model_region( mesh, climate, region_name, time)
     end select
@@ -343,6 +348,7 @@ CONTAINS
     case ('realistic', &
           'snapshot_plus_uniform_deltaT', &
           'snapshot_plus_transient_deltaT', &
+          'snapshot_plus_anomalies', &
           'matrix')
       call create_restart_file_climate_model_region( mesh, climate, region_name)
     end select
@@ -462,6 +468,8 @@ CONTAINS
       call remap_climate_snapshot_plus_uniform_deltaT(mesh_old, mesh_new, ice, climate, region_name)
     ELSEIF (choice_climate_model == 'snapshot_plus_transient_deltaT')  THEN
       call remap_climate_snapshot_plus_transient_deltaT(mesh_old, mesh_new, ice, climate, region_name, time)
+    ELSEIF (choice_climate_model == 'snapshot_plus_anomalies')  THEN
+      call remap_climate_snp_p_anml(mesh_old, mesh_new, ice, climate, region_name, time)  
     ELSEIF (choice_climate_model == 'matrix') THEN
       call remap_climate_matrix_model( mesh_new, climate, region_name, grid, ice, forcing)
     ELSE

--- a/src/UFEMISM/climate/climate_model_utilities.f90
+++ b/src/UFEMISM/climate/climate_model_utilities.f90
@@ -31,7 +31,6 @@ module climate_model_utilities
   public :: apply_precipitation_CC_correction
   public :: apply_geometry_downscaling_corrections
   public :: fill_in_transient_dT_snapshot_fields
-  public :: update_climate_timeframes
 
   contains
 
@@ -492,7 +491,7 @@ module climate_model_utilities
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    IF     ((C%choice_climate_model_realistic == 'snapshot_plus_uniform_deltaT') .AND. (snapshot%do_lapse_rates)) THEN
+    IF     (snapshot%do_lapse_rates) THEN
 
       allocate( T_inv     (mesh%vi1:mesh%vi2, 12))
       allocate( T_inv_ref (mesh%vi1:mesh%vi2, 12))
@@ -559,70 +558,5 @@ module climate_model_utilities
 
 end subroutine fill_in_transient_dT_snapshot_fields
 
-subroutine update_climate_timeframes(mesh, climate, time)
 
-    ! In/output variables:
-    type(type_mesh),                  intent(in   ) :: mesh
-    type(type_climate_model),         intent(inout) :: climate
-    real(dp),                         intent(in   ) :: time
-
-    ! Local variables:
-    character(len=1024), parameter      :: routine_name = 'update_climate_timeframes'
-    integer                             :: ncid, id_dim_time, nt, id_var_time, ierr
-    real(dp), dimension(:), allocatable :: time_from_file
-    integer                             :: ti0, ti1
-
-    ! Add routine to path
-    call init_routine( routine_name)
-
-    ! Read time variable from the file
-    call open_existing_netcdf_file_for_reading( climate%snapshot_p_anml%filename_climate_anomalies, ncid)
-    call check_time( climate%snapshot_p_anml%filename_climate_anomalies, ncid)
-    call inquire_dim_multopt( climate%snapshot_p_anml%filename_climate_anomalies, ncid, field_name_options_time, id_dim_time, dim_length = nt)
-    call inquire_var_multopt( climate%snapshot_p_anml%filename_climate_anomalies, ncid, field_name_options_time, id_var_time)
-    allocate( time_from_file( nt))
-    call read_var_primary( climate%snapshot_p_anml%filename_climate_anomalies, ncid, id_var_time, time_from_file)
-    call MPI_BCAST( time_from_file(:), nt, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call close_netcdf_file( ncid)
-
-    ! Find the two timeframes
-    if (time < time_from_file( 1)) then
-      if (par%primary) call warning('model time before start of anomaly file; using first timeframe')
-      ti0 = 1
-      ti1 = 2
-    elseif (time > time_from_file( size( time_from_file,1))) then
-      if (par%primary) call warning('model time beyond end of anomaly file; using last timeframe')
-      ti0 = size( time_from_file,1) - 1
-      ti1 = size( time_from_file,1)
-    else
-      ti0 = 1
-      ti1 = 2
-      do while (time_from_file( ti1) < time .and. ti1 < size( time_from_file,1))
-        ti0 = ti1
-        ti1 = ti1 + 1
-      end do
-    end if
-
-    climate%snapshot_p_anml%anomaly_t0 = time_from_file( ti0)
-    climate%snapshot_p_anml%anomaly_t1 = time_from_file( ti1)
-
-    ! Read the two timeframes
-    call read_field_from_file_2D_monthly( climate%snapshot_p_anml%filename_climate_anomalies, 'T2m_anomaly', &
-      mesh, C%output_dir, climate%snapshot_p_anml%T2m_anomaly_0, &
-      time_to_read = climate%snapshot_p_anml%anomaly_t0)
-    call read_field_from_file_2D_monthly( climate%snapshot_p_anml%filename_climate_anomalies, 'T2m_anomaly', &
-      mesh, C%output_dir, climate%snapshot_p_anml%T2m_anomaly_1, &
-      time_to_read = climate%snapshot_p_anml%anomaly_t1)
-    call read_field_from_file_2D_monthly( climate%snapshot_p_anml%filename_climate_anomalies, 'Precip_anomaly', &
-      mesh, C%output_dir, climate%snapshot_p_anml%Precip_anomaly_0, &
-      time_to_read = climate%snapshot_p_anml%anomaly_t0)
-    call read_field_from_file_2D_monthly( climate%snapshot_p_anml%filename_climate_anomalies, 'Precip_anomaly', &
-      mesh, C%output_dir, climate%snapshot_p_anml%Precip_anomaly_1, &
-      time_to_read = climate%snapshot_p_anml%anomaly_t1)
-
-    ! Finalise routine path
-    call finalise_routine( routine_name)
-
-  end subroutine update_climate_timeframes
-
-end module
+end module climate_model_utilities

--- a/src/UFEMISM/climate/climate_model_utilities.f90
+++ b/src/UFEMISM/climate/climate_model_utilities.f90
@@ -31,6 +31,7 @@ module climate_model_utilities
   public :: apply_precipitation_CC_correction
   public :: apply_geometry_downscaling_corrections
   public :: fill_in_transient_dT_snapshot_fields
+  public :: update_climate_timeframes
 
   contains
 
@@ -557,5 +558,71 @@ module climate_model_utilities
     CALL finalise_routine( routine_name)
 
 end subroutine fill_in_transient_dT_snapshot_fields
+
+subroutine update_climate_timeframes(mesh, climate, time)
+
+    ! In/output variables:
+    type(type_mesh),                  intent(in   ) :: mesh
+    type(type_climate_model),         intent(inout) :: climate
+    real(dp),                         intent(in   ) :: time
+
+    ! Local variables:
+    character(len=1024), parameter      :: routine_name = 'update_climate_timeframes'
+    integer                             :: ncid, id_dim_time, nt, id_var_time, ierr
+    real(dp), dimension(:), allocatable :: time_from_file
+    integer                             :: ti0, ti1
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    ! Read time variable from the file
+    call open_existing_netcdf_file_for_reading( filename, ncid)
+    call check_time( filename, ncid)
+    call inquire_dim_multopt( filename, ncid, field_name_options_time, id_dim_time, dim_length = nt)
+    call inquire_var_multopt( filename, ncid, field_name_options_time, id_var_time)
+    allocate( time_from_file( nt))
+    call read_var_primary( filename, ncid, id_var_time, time_from_file)
+    call MPI_BCAST( time_from_file(:), nt, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call close_netcdf_file( ncid)
+
+    ! Find the two timeframes
+    if (time < time_from_file( 1)) then
+      if (par%primary) call warning('model time before start of anomaly file; using first timeframe')
+      ti0 = 1
+      ti1 = 2
+    elseif (time > time_from_file( size( time_from_file,1))) then
+      if (par%primary) call warning('model time beyond end of anomaly file; using last timeframe')
+      ti0 = size( time_from_file,1) - 1
+      ti1 = size( time_from_file,1)
+    else
+      ti0 = 1
+      ti1 = 2
+      do while (time_from_file( ti1) < time .and. ti1 < size( time_from_file,1))
+        ti0 = ti1
+        ti1 = ti1 + 1
+      end do
+    end if
+
+    climate%snapshot_p_anml%anomaly_t0 = time_from_file( ti0)
+    climate%snapshot_p_anml%anomaly_t1 = time_from_file( ti1)
+
+    ! Read the two timeframes
+    call read_field_from_file_2D( filename, 'T2m_anomaly', &
+      mesh, C%output_dir, climate%snapshot_p_anml%T2m_anomaly_0, &
+      time_to_read = climate%snapshot_p_anml%anomaly_t0)
+    call read_field_from_file_2D( filename, 'T2m_anomaly', &
+      mesh, C%output_dir, climate%snapshot_p_anml%T2m_anomaly_1, &
+      time_to_read = climate%snapshot_p_anml%anomaly_t1)
+    call read_field_from_file_2D( filename, 'Precip_anomaly', &
+      mesh, C%output_dir, climate%snapshot_p_anml%Precip_anomaly_0, &
+      time_to_read = climate%snapshot_p_anml%anomaly_t0)
+    call read_field_from_file_2D( filename, 'Precip_anomaly', &
+      mesh, C%output_dir, climate%snapshot_p_anml%Precip_anomaly_1, &
+      time_to_read = climate%snapshot_p_anml%anomaly_t1)
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine update_climate_timeframes
 
 end module

--- a/src/UFEMISM/climate/climate_model_utilities.f90
+++ b/src/UFEMISM/climate/climate_model_utilities.f90
@@ -5,7 +5,7 @@ module climate_model_utilities
   use call_stack_and_comp_time_tracking                  , only: crash, init_routine, finalise_routine, warning
   use model_configuration                                    , only: C
   use parameters
-  use mpi_f08, only: MPI_ALLREDUCE, MPI_IN_PLACE, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, MPI_INTEGER
+  use mpi_f08, only: MPI_ALLREDUCE, MPI_IN_PLACE, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_COMM_WORLD, MPI_INTEGER, MPI_BCAST
   use mesh_types                                             , only: type_mesh
   use ice_model_types                                        , only: type_ice_model
   use grid_types                                             , only: type_grid
@@ -576,12 +576,12 @@ subroutine update_climate_timeframes(mesh, climate, time)
     call init_routine( routine_name)
 
     ! Read time variable from the file
-    call open_existing_netcdf_file_for_reading( filename, ncid)
-    call check_time( filename, ncid)
-    call inquire_dim_multopt( filename, ncid, field_name_options_time, id_dim_time, dim_length = nt)
-    call inquire_var_multopt( filename, ncid, field_name_options_time, id_var_time)
+    call open_existing_netcdf_file_for_reading( climate%snapshot_p_anml%filename_climate_anomalies, ncid)
+    call check_time( climate%snapshot_p_anml%filename_climate_anomalies, ncid)
+    call inquire_dim_multopt( climate%snapshot_p_anml%filename_climate_anomalies, ncid, field_name_options_time, id_dim_time, dim_length = nt)
+    call inquire_var_multopt( climate%snapshot_p_anml%filename_climate_anomalies, ncid, field_name_options_time, id_var_time)
     allocate( time_from_file( nt))
-    call read_var_primary( filename, ncid, id_var_time, time_from_file)
+    call read_var_primary( climate%snapshot_p_anml%filename_climate_anomalies, ncid, id_var_time, time_from_file)
     call MPI_BCAST( time_from_file(:), nt, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
     call close_netcdf_file( ncid)
 
@@ -607,16 +607,16 @@ subroutine update_climate_timeframes(mesh, climate, time)
     climate%snapshot_p_anml%anomaly_t1 = time_from_file( ti1)
 
     ! Read the two timeframes
-    call read_field_from_file_2D_monthly( filename, 'T2m_anomaly', &
+    call read_field_from_file_2D_monthly( climate%snapshot_p_anml%filename_climate_anomalies, 'T2m_anomaly', &
       mesh, C%output_dir, climate%snapshot_p_anml%T2m_anomaly_0, &
       time_to_read = climate%snapshot_p_anml%anomaly_t0)
-    call read_field_from_file_2D_monthly( filename, 'T2m_anomaly', &
+    call read_field_from_file_2D_monthly( climate%snapshot_p_anml%filename_climate_anomalies, 'T2m_anomaly', &
       mesh, C%output_dir, climate%snapshot_p_anml%T2m_anomaly_1, &
       time_to_read = climate%snapshot_p_anml%anomaly_t1)
-    call read_field_from_file_2D_monthly( filename, 'Precip_anomaly', &
+    call read_field_from_file_2D_monthly( climate%snapshot_p_anml%filename_climate_anomalies, 'Precip_anomaly', &
       mesh, C%output_dir, climate%snapshot_p_anml%Precip_anomaly_0, &
       time_to_read = climate%snapshot_p_anml%anomaly_t0)
-    call read_field_from_file_2D_monthly( filename, 'Precip_anomaly', &
+    call read_field_from_file_2D_monthly( climate%snapshot_p_anml%filename_climate_anomalies, 'Precip_anomaly', &
       mesh, C%output_dir, climate%snapshot_p_anml%Precip_anomaly_1, &
       time_to_read = climate%snapshot_p_anml%anomaly_t1)
 

--- a/src/UFEMISM/climate/climate_model_utilities.f90
+++ b/src/UFEMISM/climate/climate_model_utilities.f90
@@ -607,16 +607,16 @@ subroutine update_climate_timeframes(mesh, climate, time)
     climate%snapshot_p_anml%anomaly_t1 = time_from_file( ti1)
 
     ! Read the two timeframes
-    call read_field_from_file_2D( filename, 'T2m_anomaly', &
+    call read_field_from_file_2D_monthly( filename, 'T2m_anomaly', &
       mesh, C%output_dir, climate%snapshot_p_anml%T2m_anomaly_0, &
       time_to_read = climate%snapshot_p_anml%anomaly_t0)
-    call read_field_from_file_2D( filename, 'T2m_anomaly', &
+    call read_field_from_file_2D_monthly( filename, 'T2m_anomaly', &
       mesh, C%output_dir, climate%snapshot_p_anml%T2m_anomaly_1, &
       time_to_read = climate%snapshot_p_anml%anomaly_t1)
-    call read_field_from_file_2D( filename, 'Precip_anomaly', &
+    call read_field_from_file_2D_monthly( filename, 'Precip_anomaly', &
       mesh, C%output_dir, climate%snapshot_p_anml%Precip_anomaly_0, &
       time_to_read = climate%snapshot_p_anml%anomaly_t0)
-    call read_field_from_file_2D( filename, 'Precip_anomaly', &
+    call read_field_from_file_2D_monthly( filename, 'Precip_anomaly', &
       mesh, C%output_dir, climate%snapshot_p_anml%Precip_anomaly_1, &
       time_to_read = climate%snapshot_p_anml%anomaly_t1)
 

--- a/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
+++ b/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
@@ -7,6 +7,7 @@ MODULE climate_snapshot_plus_anomalies
 
   USE precisions                                             , ONLY: dp
   USE mpi_basic                                              , ONLY: par, sync
+  use mpi_f08                                                , only: MPI_DOUBLE_PRECISION, MPI_COMM_WORLD, MPI_BCAST
   USE call_stack_and_comp_time_tracking                  , ONLY: crash, init_routine, finalise_routine, warning
   USE model_configuration                                    , ONLY: C
   USE parameters
@@ -20,7 +21,7 @@ MODULE climate_snapshot_plus_anomalies
   USE netcdf_basic
   use reallocate_mod                                         , only: reallocate_bounds
   use mpi_distributed_memory                                 , only: distribute_from_primary
-  use climate_model_utilities                                , only: update_climate_timeframes, get_insolation_at_time
+  use climate_model_utilities                                , only: get_insolation_at_time, apply_geometry_downscaling_corrections
   use series_utilities
 
   IMPLICIT NONE
@@ -64,31 +65,11 @@ CONTAINS
     end if
 
     ! Interpolate between the two timeframes to find the applied anomaly
-    w0 = (climate%snapshot_p_anml%anomaly_t1 - time) / (climate%snapshot_p_anml%anomaly_t1 - climate%snapshot_p_anml%anomaly_t0)
-    w1 = 1._dp - w0
-
-    do m = 1,12
-    do vi = mesh%vi1, mesh%vi2
-
-      climate%snapshot_p_anml%T2m_anomaly( vi, m)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi, m)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi, m)
-      climate%snapshot_p_anml%Precip_anomaly( vi, m) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi, m) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi, m)
-      
-
-      ! Add anomaly to snapshot to find the applied temperature and precipitation
-      climate%snapshot_p_anml%T2m( vi,m)    = climate%snapshot_p_anml%snapshot_baseline%T2m( vi,m)    + climate%snapshot_p_anml%T2m_anomaly( vi, m)
-      climate%snapshot_p_anml%Precip( vi,m) = climate%snapshot_p_anml%snapshot_baseline%Precip( vi,m) + climate%snapshot_p_anml%Precip_anomaly( vi, m)
-      
-
-      ! Copy T2m to climate model
-      climate%T2m( vi,m)    = climate%snapshot_p_anml%T2m( vi,m)
-      climate%Precip( vi,m) = climate%snapshot_p_anml%Precip( vi,m)
-
-    end do
-    end do
+    call interpolate_between_climate_anomaly_timeframes(mesh, climate, time)
 
     ! Update temperature and precipitation fields based on the mismatch between
     ! the ice sheet surface elevation in the forcing climate and the model's ice sheet surface elevation
-    call apply_geometry_downscaling_corrections(mesh, ice, climate)
+    call apply_geometry_downscaling_corrections(mesh, ice, climate, climate%snapshot_p_anml%snapshot_baseline, 0.0_dp)
 
     ! if needed for IMAU-ITM or climate matrix, we need to update insolation
     IF (climate%snapshot%has_insolation) THEN
@@ -198,30 +179,10 @@ CONTAINS
     climate%snapshot_p_anml%anomaly_t1 = C%start_time_of_run - 100._dp
     call update_climate_timeframes( mesh, climate, C%start_time_of_run)
 
-    ! Calculate climate%snapshot_p_anml%T2m_anomaly
     ! Interpolate between the two timeframes to find the applied anomaly
-    w0 = (climate%snapshot_p_anml%anomaly_t1 - C%start_time_of_run) / (climate%snapshot_p_anml%anomaly_t1 - climate%snapshot_p_anml%anomaly_t0)
-    w1 = 1._dp - w0
+    call interpolate_between_climate_anomaly_timeframes(mesh, climate, C%start_time_of_run)
 
-    do m = 1,12
-    do vi = mesh%vi1, mesh%vi2
-
-      ! Note that the baseline and the applied temperature and precip are monthly, but the anomaly is annual
-      climate%snapshot_p_anml%T2m_anomaly( vi,m)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi,m)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi,m)
-      climate%snapshot_p_anml%Precip_anomaly( vi,m) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi,m) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi,m)
-
-      ! Add anomaly to snapshots to find the applied temperature and precipitation
-      climate%snapshot_p_anml%T2m( vi,m)    = climate%snapshot_p_anml%snapshot_baseline%T2m( vi,m)    + climate%snapshot_p_anml%T2m_anomaly( vi,m)
-      climate%snapshot_p_anml%Precip( vi,m) = climate%snapshot_p_anml%snapshot_baseline%Precip( vi,m) + climate%snapshot_p_anml%Precip_anomaly( vi,m)
-
-      ! Copy to climate model
-      climate%T2m( vi,m)    = climate%snapshot_p_anml%T2m( vi,m)
-      climate%Precip( vi,m) = climate%snapshot_p_anml%Precip( vi,m)
-
-    end do
-    end do
-
-    call apply_geometry_downscaling_corrections( mesh, ice, climate)
+    call apply_geometry_downscaling_corrections( mesh, ice, climate, climate%snapshot_p_anml%snapshot_baseline, 0.0_dp)
 
     ! Initialises the insolation (if needed)
     IF (climate%snapshot_p_anml%snapshot_baseline%has_insolation) THEN
@@ -308,13 +269,110 @@ CONTAINS
     ! Update anomaly timeframes
     call update_climate_timeframes( mesh_new, climate, time)
 
-    ! Calculate climate%snapshot_p_anml%T2m_anomaly
     ! Interpolate between the two timeframes to find the applied anomaly
+    call interpolate_between_climate_anomaly_timeframes(mesh_new, climate, time)
+    
+    call apply_geometry_downscaling_corrections( mesh_new, ice, climate, climate%snapshot_p_anml%snapshot_baseline, 0.0_dp)
+    
+
+    IF (climate%snapshot_p_anml%snapshot_baseline%has_insolation .eqv. .TRUE.) THEN
+      call remap_insolation( climate%snapshot_p_anml%snapshot_baseline, mesh_new)
+    END IF
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  END SUBROUTINE remap_climate_snp_p_anml
+
+  subroutine update_climate_timeframes(mesh, climate, time)
+
+    ! In/output variables:
+    type(type_mesh),                  intent(in   ) :: mesh
+    type(type_climate_model),         intent(inout) :: climate
+    real(dp),                         intent(in   ) :: time
+
+    ! Local variables:
+    character(len=1024), parameter      :: routine_name = 'update_climate_timeframes'
+    integer                             :: ncid, id_dim_time, nt, id_var_time, ierr
+    real(dp), dimension(:), allocatable :: time_from_file
+    integer                             :: ti0, ti1
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    ! Read time variable from the file
+    call open_existing_netcdf_file_for_reading( climate%snapshot_p_anml%filename_climate_anomalies, ncid)
+    call check_time( climate%snapshot_p_anml%filename_climate_anomalies, ncid)
+    call inquire_dim_multopt( climate%snapshot_p_anml%filename_climate_anomalies, ncid, field_name_options_time, id_dim_time, dim_length = nt)
+    call inquire_var_multopt( climate%snapshot_p_anml%filename_climate_anomalies, ncid, field_name_options_time, id_var_time)
+    allocate( time_from_file( nt))
+    call read_var_primary( climate%snapshot_p_anml%filename_climate_anomalies, ncid, id_var_time, time_from_file)
+    call MPI_BCAST( time_from_file(:), nt, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call close_netcdf_file( ncid)
+
+    ! Find the two timeframes
+    if (time < time_from_file( 1)) then
+      if (par%primary) call warning('model time before start of anomaly file; using first timeframe')
+      ti0 = 1
+      ti1 = 2
+    elseif (time > time_from_file( size( time_from_file,1))) then
+      if (par%primary) call warning('model time beyond end of anomaly file; using last timeframe')
+      ti0 = size( time_from_file,1) - 1
+      ti1 = size( time_from_file,1)
+    else
+      ti0 = 1
+      ti1 = 2
+      do while (time_from_file( ti1) < time .and. ti1 < size( time_from_file,1))
+        ti0 = ti1
+        ti1 = ti1 + 1
+      end do
+    end if
+
+    climate%snapshot_p_anml%anomaly_t0 = time_from_file( ti0)
+    climate%snapshot_p_anml%anomaly_t1 = time_from_file( ti1)
+
+    ! Read the two timeframes
+    call read_field_from_file_2D_monthly( climate%snapshot_p_anml%filename_climate_anomalies, 'T2m_anomaly', &
+      mesh, C%output_dir, climate%snapshot_p_anml%T2m_anomaly_0, &
+      time_to_read = climate%snapshot_p_anml%anomaly_t0)
+    call read_field_from_file_2D_monthly( climate%snapshot_p_anml%filename_climate_anomalies, 'T2m_anomaly', &
+      mesh, C%output_dir, climate%snapshot_p_anml%T2m_anomaly_1, &
+      time_to_read = climate%snapshot_p_anml%anomaly_t1)
+    call read_field_from_file_2D_monthly( climate%snapshot_p_anml%filename_climate_anomalies, 'Precip_anomaly', &
+      mesh, C%output_dir, climate%snapshot_p_anml%Precip_anomaly_0, &
+      time_to_read = climate%snapshot_p_anml%anomaly_t0)
+    call read_field_from_file_2D_monthly( climate%snapshot_p_anml%filename_climate_anomalies, 'Precip_anomaly', &
+      mesh, C%output_dir, climate%snapshot_p_anml%Precip_anomaly_1, &
+      time_to_read = climate%snapshot_p_anml%anomaly_t1)
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine update_climate_timeframes
+
+  subroutine interpolate_between_climate_anomaly_timeframes(mesh, climate, time)
+  ! Calculates anomalies by interpolating between the two 
+  ! timeframes to find the applied anomaly, then applies it to the climate variables
+
+
+    ! In/output variables:
+    type(type_mesh),                  intent(in   ) :: mesh
+    type(type_climate_model),         intent(inout) :: climate
+    real(dp),                         intent(in   ) :: time
+
+    ! Local variables:
+    character(len=1024), parameter      :: routine_name = 'interpolate_between_climate_anomaly_timeframes'
+    real(dp)                            :: w0, w1
+    integer                             :: vi, m
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
     w0 = (climate%snapshot_p_anml%anomaly_t1 - time) / (climate%snapshot_p_anml%anomaly_t1 - climate%snapshot_p_anml%anomaly_t0)
     w1 = 1._dp - w0
 
     do m = 1,12
-    do vi = mesh_new%vi1, mesh_new%vi2
+    do vi = mesh%vi1, mesh%vi2
 
       ! Note that the baseline and the applied temperature and precip are monthly, but the anomaly is annual
       climate%snapshot_p_anml%T2m_anomaly( vi,m)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi,m)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi,m)
@@ -331,73 +389,10 @@ CONTAINS
     end do
     end do
 
-    call apply_geometry_downscaling_corrections( mesh_new, ice, climate)
-    
-
-    IF (climate%snapshot_p_anml%snapshot_baseline%has_insolation .eqv. .TRUE.) THEN
-      call remap_insolation( climate%snapshot_p_anml%snapshot_baseline, mesh_new)
-    END IF
-
     ! Finalise routine path
     call finalise_routine( routine_name)
 
-  END SUBROUTINE remap_climate_snp_p_anml
-
-  SUBROUTINE apply_geometry_downscaling_corrections( mesh, ice, climate)
-    ! Applies the lapse rate corrections for temperature and precipitation
-    ! to correct for the mismatch between T and P at the forcing's ice surface elevation and the model's ice surface elevation
-
-    IMPLICIT NONE
-
-    TYPE(type_mesh),                       INTENT(IN)    :: mesh
-    TYPE(type_ice_model),                  INTENT(IN)    :: ice
-    TYPE(type_climate_model),              INTENT(INOUT) :: climate
-
-    ! Local Variables
-    CHARACTER(LEN=256), PARAMETER                        :: routine_name = 'apply_geometry_downscaling_corrections'
-    INTEGER                                              :: vi, m
-    REAL(dp)                                             :: deltaH, deltaT, deltaP
-    REAL(dp), DIMENSION(:,:), ALLOCATABLE                :: T_inv, T_inv_ref
-
-    ! Add routine to path
-    CALL init_routine( routine_name)
-
-    IF     (climate%snapshot_p_anml%snapshot_baseline%do_lapse_rates .eqv. .TRUE.) THEN
-
-      allocate( T_inv     (mesh%vi1:mesh%vi2, 12))
-      allocate( T_inv_ref (mesh%vi1:mesh%vi2, 12))
-
-
-      do vi = mesh%vi1, mesh%vi2
-
-        ! we only apply corrections where it is not open ocean
-        if (ice%mask_icefree_ocean( vi) .eqv. .FALSE.) then
-          deltaT  = (ice%Hs( vi) - climate%snapshot_p_anml%snapshot_baseline%Hs( vi)) * (-1._dp * abs(climate%snapshot_p_anml%snapshot_baseline%lapse_rate_temp))
-          do m = 1, 12
-            ! Do corrections - based on Eq. 11 of Albrecht et al. (2020; TC) for PISM
-            climate%T2m( vi, m)    = climate%T2m( vi, m)    + deltaT
-
-
-            ! Calculate inversion-layer temperatures
-            T_inv_ref( vi, m) = 88.9_dp + 0.67_dp *  climate%T2m( vi, m)
-            T_inv(     vi, m) = 88.9_dp + 0.67_dp * (climate%T2m( vi, m) - climate%snapshot_p_anml%snapshot_baseline%lapse_rate_temp * (ice%Hs( vi) - climate%snapshot_p_anml%snapshot_baseline%Hs( vi)))
-            ! Correct precipitation based on a simple Clausius-Clapeyron method (Jouzel & Merlivat, 1984; Huybrechts, 2002)
-            ! Same as implemented in IMAU-ICE
-            climate%Precip( vi, m) = climate%Precip( vi, m) * (T_inv_ref( vi, m) / T_inv( vi, m))**2 * EXP(22.47_dp * (T0 / T_inv_ref( vi, m) - T0 / T_inv( vi, m)))
-
-          end do ! m
-        end if
-      end do ! vi
-
-      deallocate(T_inv)
-      deallocate(T_inv_ref)
-
-    END IF
-
-    ! Finalise routine path
-    CALL finalise_routine( routine_name)
-
-  END SUBROUTINE apply_geometry_downscaling_corrections
+  end subroutine interpolate_between_climate_anomaly_timeframes
 
 
 END MODULE climate_snapshot_plus_anomalies

--- a/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
+++ b/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
@@ -128,15 +128,23 @@ CONTAINS
     ALLOCATE( climate%snapshot_p_anml%snapshot_baseline%Hs(     mesh%vi1:mesh%vi2))
     ALLOCATE( climate%snapshot_p_anml%snapshot_baseline%T2m(    mesh%vi1:mesh%vi2,12))
     ALLOCATE( climate%snapshot_p_anml%snapshot_baseline%Precip( mesh%vi1:mesh%vi2,12))
-    ALLOCATE( climate%snapshot_p_anml%T2m_anomaly(    mesh%vi1:mesh%vi2,12))
-    ALLOCATE( climate%snapshot_p_anml%Precip_anomaly( mesh%vi1:mesh%vi2,12))
-    ALLOCATE( climate%snapshot_p_anml%T2m(            mesh%vi1:mesh%vi2,12))
-    ALLOCATE( climate%snapshot_p_anml%Precip(         mesh%vi1:mesh%vi2,12))
+    ALLOCATE( climate%snapshot_p_anml%T2m_anomaly_0(    mesh%vi1:mesh%vi2,12))
+    ALLOCATE( climate%snapshot_p_anml%Precip_anomaly_0( mesh%vi1:mesh%vi2,12))
+    ALLOCATE( climate%snapshot_p_anml%T2m_anomaly_1(    mesh%vi1:mesh%vi2,12))
+    ALLOCATE( climate%snapshot_p_anml%Precip_anomaly_1( mesh%vi1:mesh%vi2,12))
+    ALLOCATE( climate%snapshot_p_anml%T2m_anomaly(      mesh%vi1:mesh%vi2,12))
+    ALLOCATE( climate%snapshot_p_anml%Precip_anomaly(   mesh%vi1:mesh%vi2,12))
+    ALLOCATE( climate%snapshot_p_anml%T2m(              mesh%vi1:mesh%vi2,12))
+    ALLOCATE( climate%snapshot_p_anml%Precip(           mesh%vi1:mesh%vi2,12))
     climate%snapshot_p_anml%snapshot_baseline%Hs     = 0._dp
     climate%snapshot_p_anml%snapshot_baseline%T2m    = 0._dp
     climate%snapshot_p_anml%snapshot_baseline%Precip = 0._dp
     climate%snapshot_p_anml%T2m_anomaly              = 0._dp
     climate%snapshot_p_anml%Precip_anomaly           = 0._dp
+    climate%snapshot_p_anml%T2m_anomaly_0            = 0._dp
+    climate%snapshot_p_anml%Precip_anomaly_0         = 0._dp
+    climate%snapshot_p_anml%T2m_anomaly_1            = 0._dp
+    climate%snapshot_p_anml%Precip_anomaly_1         = 0._dp
     climate%snapshot_p_anml%T2m                      = 0._dp
     climate%snapshot_p_anml%Precip                   = 0._dp
 

--- a/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
+++ b/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
@@ -194,7 +194,6 @@ CONTAINS
     ! Read in anomalies
 
     ! Initialise anomaly timeframes
-    IF (par%primary)  WRITE(*,"(A)") '    Reading anomalies...'
     climate%snapshot_p_anml%anomaly_t0 = C%start_time_of_run - 200._dp
     climate%snapshot_p_anml%anomaly_t1 = C%start_time_of_run - 100._dp
     call update_climate_timeframes( mesh, climate, C%start_time_of_run)

--- a/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
+++ b/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
@@ -1,0 +1,389 @@
+MODULE climate_snapshot_plus_anomalies
+
+  ! Snapshot + dT(time) climate model
+
+! ===== Preamble =====
+! ====================
+
+  USE precisions                                             , ONLY: dp
+  USE mpi_basic                                              , ONLY: par, sync
+  USE call_stack_and_comp_time_tracking                  , ONLY: crash, init_routine, finalise_routine, warning
+  USE model_configuration                                    , ONLY: C
+  USE parameters
+  USE mesh_types                                             , ONLY: type_mesh
+  USE ice_model_types                                        , ONLY: type_ice_model
+  USE climate_model_types                                    , ONLY: type_climate_model, type_climate_model_snapshot
+  USE global_forcing_types                                   , ONLY: type_global_forcing
+  use climate_realistic                                      , only: initialise_climate_model_realistic, initialise_insolation_forcing, remap_insolation
+  USE global_forcings_main
+  USE netcdf_io_main
+  USE netcdf_basic
+  use reallocate_mod                                         , only: reallocate_bounds
+  use mpi_distributed_memory                                 , only: distribute_from_primary
+  use climate_model_utilities
+  use series_utilities
+
+  IMPLICIT NONE
+
+  private
+
+  public :: run_climate_model_snp_p_anml
+  public :: initialise_climate_model_snp_p_anml
+  public :: remap_climate_snp_p_anml
+
+
+CONTAINS
+
+! ===== Main routines =====
+! =========================
+
+  SUBROUTINE run_climate_model_snp_p_anml( mesh, ice, climate, time)
+    ! Calculate the climate
+    !
+    ! Use a snapshot plus a prescribed uniform deltaT
+
+    ! In/output variables:
+    TYPE(type_mesh),                        INTENT(IN)    :: mesh
+    TYPE(type_ice_model),                   INTENT(IN)    :: ice
+    TYPE(type_climate_model),               INTENT(INOUT) :: climate
+    REAL(dp),                               INTENT(IN)    :: time
+
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                         :: routine_name = 'run_climate_model_snp_p_anml'
+    INTEGER                                               :: vi, m
+
+    ! Add routine to path
+    CALL init_routine( routine_name)
+
+    ! Run the chosen snapshot+deltaT(time) climate model
+    ! If the current model time falls outside the enveloping window
+    ! of the two timeframes that have been read, update them
+    if (time < climate%snapshot_p_anml%anomaly_t0 .or. time > climate%snapshot_p_anml%anomaly_t1) then
+      call update_climate_timeframes( mesh, climate, time)
+    end if
+
+    ! Interpolate between the two timeframes to find the applied anomaly
+    w0 = (climate%snapshot_p_anml%anomaly_t1 - time) / (climate%snapshot_p_anml%anomaly_t1 - self%anomaly_t0)
+    w1 = 1._dp - w0
+
+    do vi = mesh%vi1, mesh%vi2
+
+      ! Note that the baseline and the applied temperature are monthly, but the anomaly is annual
+      climate%snapshot_p_anml%T2m_anomaly( vi)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi)
+      climate%snapshot_p_anml%Precip_anomaly( vi) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi)
+      
+
+      ! Add anomaly to snapshot to find the applied temperature and precipitation
+      climate%snapshot_p_anml%T2m( vi,:)    = climate%snapshot_p_anml%T2m_baseline( vi,:)    + climate%snapshot_p_anml%T2m_anomaly( vi)
+      climate%snapshot_p_anml%Precip( vi,:) = climate%snapshot_p_anml%Precip_baseline( vi,:) + climate%snapshot_p_anml%Precip_anomaly( vi)
+      
+
+      ! Copy T2m to climate model
+      climate%T2m( vi,:)    = climate%snapshot_p_anml%T2m( vi,:)
+      climate%Precip( vi,:) = climate%snapshot_p_anml%Precip( vi,:)
+
+    end do
+
+    ! Update temperature and precipitation fields based on the mismatch between
+    ! the ice sheet surface elevation in the forcing climate and the model's ice sheet surface elevation
+    call apply_geometry_downscaling_corrections(mesh, ice, climate)
+
+    ! if needed for IMAU-ITM or climate matrix, we need to update insolation
+    IF (climate%snapshot%has_insolation) THEN
+      CALL get_insolation_at_time( mesh, time, climate%snapshot_p_anml%snapshot_baseline)
+      climate%Q_TOA          = climate%snapshot_p_anml%snapshot_baseline%Q_TOA
+      climate%snapshot%Q_TOA = climate%snapshot_p_anml%snapshot_baseline%Q_TOA
+    END IF
+
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+
+  END SUBROUTINE run_climate_model_snp_p_anml
+
+  SUBROUTINE initialise_climate_model_snp_p_anml( mesh, ice, climate, region_name)
+    ! Initialise the climate model
+    !
+    ! Use a realistic climate scheme
+
+    IMPLICIT NONE
+
+    ! In- and output variables
+    TYPE(type_mesh),                        INTENT(IN)    :: mesh
+    TYPE(type_ice_model),                   INTENT(IN)    :: ice
+    TYPE(type_climate_model),               INTENT(INOUT) :: climate
+    CHARACTER(LEN=3),                       INTENT(IN)    :: region_name
+    real(dp),                               INTENT(IN)    :: start_time_of_run
+
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                         :: routine_name = 'initialise_climate_model_snp_p_anml'
+    INTEGER                                               :: vi, m
+    CHARACTER(LEN=256)                                    :: filename_climate_snapshot
+    REAL(dp)                                              :: timeframe_init_insolation, w0, w1
+
+    ! Add routine to path
+    CALL init_routine( routine_name)
+
+    !ALLOCATE( climate%snapshot_p_anml%snapshot_baseline%Hs(     mesh%vi1:mesh%vi2))
+    !ALLOCATE( climate%snapshot_p_anml%snapshot_baseline%T2m(    mesh%vi1:mesh%vi2,12))
+    !ALLOCATE( climate%snapshot_p_anml%snapshot_baseline%Precip( mesh%vi1:mesh%vi2,12))
+    ALLOCATE( climate%snapshot_p_anml%T2m_anomaly(    mesh%vi1:mesh%vi2,12))
+    ALLOCATE( climate%snapshot_p_anml%Precip_anomaly( mesh%vi1:mesh%vi2,12))
+    
+    ! TODO: do we need to allocate these??
+    !ALLOCATE( climate%snapshot_p_anml%T2m_anomaly_0(    mesh%vi1:mesh%vi2,12))
+    !ALLOCATE( climate%snapshot_p_anml%Precip_anomaly_0( mesh%vi1:mesh%vi2,12))
+    !ALLOCATE( climate%snapshot_p_anml%T2m_anomaly_1(    mesh%vi1:mesh%vi2,12))
+    !ALLOCATE( climate%snapshot_p_anml%Precip_anomaly_1( mesh%vi1:mesh%vi2,12))
+
+
+    ! Run the chosen realistic climate model
+    climate%snapshot_p_anml%snapshot_baseline%has_insolation = .FALSE.
+
+    ! Read single-time data from external file
+    ! Determine which climate model to initialise for this region
+    select case( region_name)
+    case ('NAM')
+        filename_climate_snapshot                                      = C%climate_snp_p_anml_filename_snapshot_NAM
+        climate%snapshot_p_anml%filename_climate_anomalies             = C%climate_snp_p_anml_filename_anomalies_NAM
+        climate%snapshot_p_anml%snapshot_baseline%precip_CC_correction = C%precip_CC_correction_NAM
+        climate%snapshot_p_anml%snapshot_baseline%do_lapse_rates       = C%do_lapse_rate_corrections_NAM
+        climate%snapshot_p_anml%snapshot_baseline%lapse_rate_temp      = C%lapse_rate_temp_NAM
+        climate%snapshot_p_anml%snapshot_baseline%has_insolation       = C%choice_SMB_model_NAM == 'IMAU-ITM'
+    case ('EAS')
+        filename_climate_snapshot                                      = C%climate_snp_p_anml_filename_snapshot_EAS
+        climate%snapshot_p_anml%filename_climate_anomalies             = C%climate_snp_p_anml_filename_anomalies_EAS
+        climate%snapshot_p_anml%snapshot_baseline%precip_CC_correction = C%precip_CC_correction_EAS
+        climate%snapshot_p_anml%snapshot_baseline%do_lapse_rates       = C%do_lapse_rate_corrections_EAS
+        climate%snapshot_p_anml%snapshot_baseline%lapse_rate_temp      = C%lapse_rate_temp_EAS
+        climate%snapshot_p_anml%snapshot_baseline%has_insolation       = C%choice_SMB_model_EAS == 'IMAU-ITM'
+    case ('GRL')
+        filename_climate_snapshot                                      = C%climate_snp_p_anml_filename_snapshot_GRL
+        climate%snapshot_p_anml%filename_climate_anomalies             = C%climate_snp_p_anml_filename_anomalies_GRL
+        climate%snapshot_p_anml%snapshot_baseline%precip_CC_correction = C%precip_CC_correction_GRL
+        climate%snapshot_p_anml%snapshot_baseline%do_lapse_rates       = C%do_lapse_rate_corrections_GRL
+        climate%snapshot_p_anml%snapshot_baseline%lapse_rate_temp      = C%lapse_rate_temp_GRL
+        climate%snapshot_p_anml%snapshot_baseline%has_insolation       = C%choice_SMB_model_GRL == 'IMAU-ITM'
+    case ('ANT')
+        filename_climate_snapshot                                      = C%climate_snp_p_anml_filename_snapshot_ANT
+        climate%snapshot_p_anml%filename_climate_anomalies             = C%climate_snp_p_anml_filename_anomalies_ANT
+        climate%snapshot_p_anml%snapshot_baseline%precip_CC_correction = C%precip_CC_correction_ANT
+        climate%snapshot_p_anml%snapshot_baseline%do_lapse_rates       = C%do_lapse_rate_corrections_ANT
+        climate%snapshot_p_anml%snapshot_baseline%lapse_rate_temp      = C%lapse_rate_temp_ANT
+        climate%snapshot_p_anml%snapshot_baseline%has_insolation       = C%choice_SMB_model_ANT == 'IMAU-ITM'
+    case default
+      CALL crash('unknown region_name "' // region_name // '"')
+    end select
+
+    ! Read in baseline variables
+    CALL read_field_from_file_2D(         filename_climate_snapshot, 'Hs'    , mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%Hs)
+    CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'T2m'   , mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%T2m)
+    CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'Precip', mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline&Precip)
+
+    ! Read in anomalies
+
+    ! Initialise anomaly timeframes
+    climate%snapshot_p_anml%anomaly_t0 = C%start_time_of_run - 200._dp
+    climate%snapshot_p_anml%anomaly_t1 = C%start_time_of_run - 100._dp
+    call update_climate_timeframes( mesh, climate, C%start_time_of_run)
+
+    ! Calculate climate%snapshot_p_anml%T2m_anomaly
+    ! Interpolate between the two timeframes to find the applied anomaly
+    w0 = (climate%snapshot_p_anml%anomaly_t1 - C%start_time_of_run) / (climate%snapshot_p_anml%anomaly_t1 - climate%snapshot_p_anml%anomaly_t0)
+    w1 = 1._dp - w0
+
+    do vi = mesh%vi1, mesh%vi2
+
+      ! Note that the baseline and the applied temperature and precip are monthly, but the anomaly is annual
+      climate%snapshot_p_anml%T2m_anomaly( vi)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi)
+      climate%snapshot_p_anml%Precip_anomaly( vi) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi)
+
+      ! Add anomaly to snapshots to find the applied temperature and precipitation
+      climate%snapshot_p_anml%T2m( vi,:)    = climate%snapshot_p_anml%%snapshot_baseline%T2m( vi,:)    + climate%snapshot_p_anml%T2m_anomaly( vi)
+      climate%snapshot_p_anml%Precip( vi,:) = climate%snapshot_p_anml%%snapshot_baseline%Precip( vi,:) + climate%snapshot_p_anml%Precip_anomaly( vi)
+
+      ! Copy to climate model
+      climate%T2m( vi,:)    = climate%snapshot_p_anml%T2m( vi,:)
+      climate%Precip( vi,:) = climate%snapshot_p_anml%Precip( vi,:)
+
+    end do
+
+    call apply_geometry_downscaling_corrections( mesh, ice, climate)
+
+    ! Initialises the insolation (if needed)
+    IF (climate%snapshot_p_anml%snapshot_baseline%has_insolation) THEN
+    IF (C%choice_insolation_forcing == 'none') THEN
+        CALL crash('Chosen climate or SMB model cannot be used with choice_insolation_forcing = "none"!')
+    ELSE
+        CALL initialise_insolation_forcing( climate%snapshot_p_anml%snapshot_baseline, mesh)
+        IF (C%start_time_of_run < 0._dp) THEN
+            timeframe_init_insolation = C%start_time_of_run
+        ELSE
+            timeframe_init_insolation = 0._dp
+        END IF
+        CALL get_insolation_at_time( mesh, timeframe_init_insolation, climate%snapshot_p_anml%snapshot_baseline)
+        climate%Q_TOA          = climate%snapshot_p_anml%snapshot_baseline%Q_TOA
+        climate%snapshot%Q_TOA = climate%snapshot_p_anml%snapshot_baseline%Q_TOA
+    END IF
+    END IF
+
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+
+  END SUBROUTINE initialise_climate_model_snp_p_anml
+
+  SUBROUTINE remap_climate_snp_p_anml(mesh_old, mesh_new, ice, climate, region_name, time)
+  ! In/out variables
+    type(type_mesh),                        intent(in)    :: mesh_old
+    type(type_mesh),                        intent(in)    :: mesh_new
+    type(type_ice_model),                   intent(in)    :: ice
+    type(type_climate_model),               intent(inout) :: climate
+    character(LEN=3),                       intent(in)    :: region_name
+    real(dp),                               intent(in)    :: time
+
+    ! Local variables
+    character(LEN=256), parameter                         :: routine_name = 'remap_climate_snp_p_anml'
+    character(LEN=256)                                    :: choice_climate_model
+    character(LEN=256)                                    :: filename_climate_snapshot,filename_atm_dT
+    character(LEN=256)                                    :: choice_SMB_model
+    INTEGER                                               :: vi, m
+    real(dp)                                              :: w0, w1
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    select case( region_name)
+    case ('NAM')
+      filename_climate_snapshot                                      = C%climate_snp_p_anml_filename_snapshot_NAM
+      climate%snapshot_p_anml%filename_climate_anomalies             = C%climate_snp_p_anml_filename_anomalies_NAM
+      climate%snapshot_p_anml%snapshot_baseline%precip_CC_correction = C%precip_CC_correction_NAM
+      climate%snapshot_p_anml%snapshot_baseline%do_lapse_rates       = C%do_lapse_rate_corrections_NAM
+      climate%snapshot_p_anml%snapshot_baseline%lapse_rate_temp      = C%lapse_rate_temp_NAM
+      climate%snapshot_p_anml%snapshot_baseline%has_insolation       = C%choice_SMB_model_NAM == 'IMAU-ITM'
+    case ('EAS')
+      filename_climate_snapshot                                      = C%climate_snp_p_anml_filename_snapshot_EAS
+      climate%snapshot_p_anml%filename_climate_anomalies             = C%climate_snp_p_anml_filename_anomalies_EAS
+      climate%snapshot_p_anml%snapshot_baseline%precip_CC_correction = C%precip_CC_correction_EAS
+      climate%snapshot_p_anml%snapshot_baseline%do_lapse_rates       = C%do_lapse_rate_corrections_EAS
+      climate%snapshot_p_anml%snapshot_baseline%lapse_rate_temp      = C%lapse_rate_temp_EAS
+      climate%snapshot_p_anml%snapshot_baseline%has_insolation       = C%choice_SMB_model_EAS == 'IMAU-ITM'
+    case ('GRL')
+      filename_climate_snapshot                                      = C%climate_snp_p_anml_filename_snapshot_GRL
+      climate%snapshot_p_anml%filename_climate_anomalies             = C%climate_snp_p_anml_filename_anomalies_GRL
+      climate%snapshot_p_anml%snapshot_baseline%precip_CC_correction = C%precip_CC_correction_GRL
+      climate%snapshot_p_anml%snapshot_baseline%do_lapse_rates       = C%do_lapse_rate_corrections_GRL
+      climate%snapshot_p_anml%snapshot_baseline%lapse_rate_temp      = C%lapse_rate_temp_GRL
+      climate%snapshot_p_anml%snapshot_baseline%has_insolation       = C%choice_SMB_model_GRL == 'IMAU-ITM'
+    case ('ANT')
+      filename_climate_snapshot                                      = C%climate_snp_p_anml_filename_snapshot_ANT
+      climate%snapshot_p_anml%filename_climate_anomalies             = C%climate_snp_p_anml_filename_anomalies_ANT
+      climate%snapshot_p_anml%snapshot_baseline%precip_CC_correction = C%precip_CC_correction_ANT
+      climate%snapshot_p_anml%snapshot_baseline%do_lapse_rates       = C%do_lapse_rate_corrections_ANT
+      climate%snapshot_p_anml%snapshot_baseline%lapse_rate_temp      = C%lapse_rate_temp_ANT
+      climate%snapshot_p_anml%snapshot_baseline%has_insolation       = C%choice_SMB_model_ANT == 'IMAU-ITM'
+    case default
+      call crash('unknown region_name "' // region_name // '"')
+    end select
+
+    call reallocate_bounds( climate%snapshot_p_anml%snapshot_baseline%Hs, mesh_new%vi1, mesh_new%vi2)
+
+    CALL read_field_from_file_2D(         filename_climate_snapshot, 'Hs'    , mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%Hs)
+    CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'T2m'   , mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%T2m)
+    CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'Precip', mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline&Precip)
+
+    
+    ! Update anomaly timeframes
+    call update_climate_timeframes( mesh, climate, time)
+
+    ! Calculate climate%snapshot_p_anml%T2m_anomaly
+    ! Interpolate between the two timeframes to find the applied anomaly
+    w0 = (climate%snapshot_p_anml%anomaly_t1 - time) / (climate%snapshot_p_anml%anomaly_t1 - climate%snapshot_p_anml%anomaly_t0)
+    w1 = 1._dp - w0
+
+    do vi = mesh%vi1, mesh%vi2
+
+      ! Note that the baseline and the applied temperature and precip are monthly, but the anomaly is annual
+      climate%snapshot_p_anml%T2m_anomaly( vi)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi)
+      climate%snapshot_p_anml%Precip_anomaly( vi) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi)
+
+      ! Add anomaly to snapshots to find the applied temperature and precipitation
+      climate%snapshot_p_anml%T2m( vi,:)    = climate%snapshot_p_anml%%snapshot_baseline%T2m( vi,:)    + climate%snapshot_p_anml%T2m_anomaly( vi)
+      climate%snapshot_p_anml%Precip( vi,:) = climate%snapshot_p_anml%%snapshot_baseline%Precip( vi,:) + climate%snapshot_p_anml%Precip_anomaly( vi)
+
+      ! Copy to climate model
+      climate%T2m( vi,:)    = climate%snapshot_p_anml%T2m( vi,:)
+      climate%Precip( vi,:) = climate%snapshot_p_anml%Precip( vi,:)
+
+    end do
+
+    call apply_geometry_downscaling_corrections( mesh, ice, climate)
+    
+
+    IF (climate%snapshot_p_anml%snapshot_baseline%has_insolation .eqv. .TRUE.) THEN
+      call remap_insolation( climate%snapshot_p_anml%snapshot_baseline, mesh_new)
+    END IF
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  END SUBROUTINE remap_climate_snp_p_anml
+
+  SUBROUTINE apply_geometry_downscaling_corrections( mesh, ice, climate)
+    ! Applies the lapse rate corrections for temperature and precipitation
+    ! to correct for the mismatch between T and P at the forcing's ice surface elevation and the model's ice surface elevation
+
+    IMPLICIT NONE
+
+    TYPE(type_mesh),                       INTENT(IN)    :: mesh
+    TYPE(type_ice_model),                  INTENT(IN)    :: ice
+    TYPE(type_climate_model),              INTENT(INOUT) :: climate
+
+    ! Local Variables
+    CHARACTER(LEN=256), PARAMETER                        :: routine_name = 'apply_geometry_downscaling_corrections'
+    INTEGER                                              :: vi, m
+    REAL(dp)                                             :: deltaH, deltaT, deltaP
+    REAL(dp), DIMENSION(:,:), ALLOCATABLE                :: T_inv, T_inv_ref
+
+    ! Add routine to path
+    CALL init_routine( routine_name)
+
+    IF     ((C%choice_climate_model == 'snapshot_plus_anomalies') .AND. (climate%snapshot_p_anml%snapshot_baseline%do_lapse_rates .eqv. .TRUE.)) THEN
+
+      allocate( T_inv     (mesh%vi1:mesh%vi2, 12))
+      allocate( T_inv_ref (mesh%vi1:mesh%vi2, 12))
+
+
+      do vi = mesh%vi1, mesh%vi2
+
+        ! we only apply corrections where it is not open ocean
+        if (ice%mask_icefree_ocean( vi) .eqv. .FALSE.) then
+          deltaT  = (ice%Hs( vi) - climate%snapshot_p_anml%snapshot_baseline%Hs( vi)) * (-1._dp * abs(climate%snapshot_p_anml%snapshot_baseline%lapse_rate_temp))
+          do m = 1, 12
+            ! Do corrections - based on Eq. 11 of Albrecht et al. (2020; TC) for PISM
+            climate%T2m( vi, m)    = climate%T2m( vi, m)    + deltaT
+
+
+            ! Calculate inversion-layer temperatures
+            T_inv_ref( vi, m) = 88.9_dp + 0.67_dp *  climate%T2m( vi, m)
+            T_inv(     vi, m) = 88.9_dp + 0.67_dp * (climate%T2m( vi, m) - climate%snapshot_p_anml%snapshot_baseline%lapse_rate_temp * (ice%Hs( vi) - climate%snapshot_p_anml%snapshot_baseline%Hs( vi)))
+            ! Correct precipitation based on a simple Clausius-Clapeyron method (Jouzel & Merlivat, 1984; Huybrechts, 2002)
+            ! Same as implemented in IMAU-ICE
+            climate%Precip( vi, m) = climate%Precip( vi, m) * (T_inv_ref( vi, m) / T_inv( vi, m))**2 * EXP(22.47_dp * (T0 / T_inv_ref( vi, m) - T0 / T_inv( vi, m)))
+
+          end do ! m
+        end if
+      end do ! vi
+
+      deallocate(T_inv)
+      deallocate(T_inv_ref)
+
+    ELSEIF (C%choice_climate_model_realistic == 'climate_matrix') THEN
+      ! Not yet implemented! Will likely use the lambda field from Berends et al. (2018)
+    END IF
+
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+
+  END SUBROUTINE apply_geometry_downscaling_corrections
+
+
+END MODULE climate_snapshot_plus_transient_deltaT

--- a/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
+++ b/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
@@ -20,7 +20,7 @@ MODULE climate_snapshot_plus_anomalies
   USE netcdf_basic
   use reallocate_mod                                         , only: reallocate_bounds
   use mpi_distributed_memory                                 , only: distribute_from_primary
-  use climate_model_utilities
+  use climate_model_utilities                                , only: update_climate_timeframes, get_insolation_at_time
   use series_utilities
 
   IMPLICIT NONE
@@ -51,6 +51,7 @@ CONTAINS
     ! Local variables:
     CHARACTER(LEN=256), PARAMETER                         :: routine_name = 'run_climate_model_snp_p_anml'
     INTEGER                                               :: vi, m
+    REAL(dp)                                              :: w0, w1
 
     ! Add routine to path
     CALL init_routine( routine_name)
@@ -63,7 +64,7 @@ CONTAINS
     end if
 
     ! Interpolate between the two timeframes to find the applied anomaly
-    w0 = (climate%snapshot_p_anml%anomaly_t1 - time) / (climate%snapshot_p_anml%anomaly_t1 - self%anomaly_t0)
+    w0 = (climate%snapshot_p_anml%anomaly_t1 - time) / (climate%snapshot_p_anml%anomaly_t1 - climate%snapshot_p_anml%anomaly_t0)
     w1 = 1._dp - w0
 
     do m = 1,12
@@ -74,8 +75,8 @@ CONTAINS
       
 
       ! Add anomaly to snapshot to find the applied temperature and precipitation
-      climate%snapshot_p_anml%T2m( vi,m)    = climate%snapshot_p_anml%T2m_baseline( vi,m)    + climate%snapshot_p_anml%T2m_anomaly( vi, m)
-      climate%snapshot_p_anml%Precip( vi,m) = climate%snapshot_p_anml%Precip_baseline( vi,m) + climate%snapshot_p_anml%Precip_anomaly( vi, m)
+      climate%snapshot_p_anml%T2m( vi,m)    = climate%snapshot_p_anml%snapshot_baseline%T2m( vi,m)    + climate%snapshot_p_anml%T2m_anomaly( vi, m)
+      climate%snapshot_p_anml%Precip( vi,m) = climate%snapshot_p_anml%snapshot_baseline%Precip( vi,m) + climate%snapshot_p_anml%Precip_anomaly( vi, m)
       
 
       ! Copy T2m to climate model
@@ -113,7 +114,6 @@ CONTAINS
     TYPE(type_ice_model),                   INTENT(IN)    :: ice
     TYPE(type_climate_model),               INTENT(INOUT) :: climate
     CHARACTER(LEN=3),                       INTENT(IN)    :: region_name
-    real(dp),                               INTENT(IN)    :: start_time_of_run
 
     ! Local variables:
     CHARACTER(LEN=256), PARAMETER                         :: routine_name = 'initialise_climate_model_snp_p_anml'
@@ -171,7 +171,7 @@ CONTAINS
     ! Read in baseline variables
     CALL read_field_from_file_2D(         filename_climate_snapshot, 'Hs'    , mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%Hs)
     CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'T2m'   , mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%T2m)
-    CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'Precip', mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline&Precip)
+    CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'Precip', mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%Precip)
 
     ! Read in anomalies
 
@@ -193,8 +193,8 @@ CONTAINS
       climate%snapshot_p_anml%Precip_anomaly( vi,m) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi,m) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi,m)
 
       ! Add anomaly to snapshots to find the applied temperature and precipitation
-      climate%snapshot_p_anml%T2m( vi,m)    = climate%snapshot_p_anml%%snapshot_baseline%T2m( vi,m)    + climate%snapshot_p_anml%T2m_anomaly( vi,m)
-      climate%snapshot_p_anml%Precip( vi,m) = climate%snapshot_p_anml%%snapshot_baseline%Precip( vi,m) + climate%snapshot_p_anml%Precip_anomaly( vi,m)
+      climate%snapshot_p_anml%T2m( vi,m)    = climate%snapshot_p_anml%snapshot_baseline%T2m( vi,m)    + climate%snapshot_p_anml%T2m_anomaly( vi,m)
+      climate%snapshot_p_anml%Precip( vi,m) = climate%snapshot_p_anml%snapshot_baseline%Precip( vi,m) + climate%snapshot_p_anml%Precip_anomaly( vi,m)
 
       ! Copy to climate model
       climate%T2m( vi,m)    = climate%snapshot_p_anml%T2m( vi,m)
@@ -282,13 +282,13 @@ CONTAINS
 
     call reallocate_bounds( climate%snapshot_p_anml%snapshot_baseline%Hs, mesh_new%vi1, mesh_new%vi2)
 
-    CALL read_field_from_file_2D(         filename_climate_snapshot, 'Hs'    , mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%Hs)
-    CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'T2m'   , mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%T2m)
-    CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'Precip', mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline&Precip)
+    CALL read_field_from_file_2D(         filename_climate_snapshot, 'Hs'    , mesh_new, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%Hs)
+    CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'T2m'   , mesh_new, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%T2m)
+    CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'Precip', mesh_new, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%Precip)
 
     
     ! Update anomaly timeframes
-    call update_climate_timeframes( mesh, climate, time)
+    call update_climate_timeframes( mesh_new, climate, time)
 
     ! Calculate climate%snapshot_p_anml%T2m_anomaly
     ! Interpolate between the two timeframes to find the applied anomaly
@@ -296,23 +296,24 @@ CONTAINS
     w1 = 1._dp - w0
 
     do m = 1,12
-    do vi = mesh%vi1, mesh%vi2
+    do vi = mesh_new%vi1, mesh_new%vi2
 
       ! Note that the baseline and the applied temperature and precip are monthly, but the anomaly is annual
       climate%snapshot_p_anml%T2m_anomaly( vi,m)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi,m)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi,m)
       climate%snapshot_p_anml%Precip_anomaly( vi,m) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi,m) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi,m)
 
       ! Add anomaly to snapshots to find the applied temperature and precipitation
-      climate%snapshot_p_anml%T2m( vi,m)    = climate%snapshot_p_anml%%snapshot_baseline%T2m( vi,m)    + climate%snapshot_p_anml%T2m_anomaly( vi,m)
-      climate%snapshot_p_anml%Precip( vi,m) = climate%snapshot_p_anml%%snapshot_baseline%Precip( vi,m) + climate%snapshot_p_anml%Precip_anomaly( vi,m)
+      climate%snapshot_p_anml%T2m( vi,m)    = climate%snapshot_p_anml%snapshot_baseline%T2m( vi,m)    + climate%snapshot_p_anml%T2m_anomaly( vi,m)
+      climate%snapshot_p_anml%Precip( vi,m) = climate%snapshot_p_anml%snapshot_baseline%Precip( vi,m) + climate%snapshot_p_anml%Precip_anomaly( vi,m)
 
       ! Copy to climate model
       climate%T2m( vi,m)    = climate%snapshot_p_anml%T2m( vi,m)
       climate%Precip( vi,m) = climate%snapshot_p_anml%Precip( vi,m)
 
     end do
+    end do
 
-    call apply_geometry_downscaling_corrections( mesh, ice, climate)
+    call apply_geometry_downscaling_corrections( mesh_new, ice, climate)
     
 
     IF (climate%snapshot_p_anml%snapshot_baseline%has_insolation .eqv. .TRUE.) THEN
@@ -343,7 +344,7 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    IF     ((C%choice_climate_model == 'snapshot_plus_anomalies') .AND. (climate%snapshot_p_anml%snapshot_baseline%do_lapse_rates .eqv. .TRUE.)) THEN
+    IF     (climate%snapshot_p_anml%snapshot_baseline%do_lapse_rates .eqv. .TRUE.) THEN
 
       allocate( T_inv     (mesh%vi1:mesh%vi2, 12))
       allocate( T_inv_ref (mesh%vi1:mesh%vi2, 12))
@@ -373,8 +374,6 @@ CONTAINS
       deallocate(T_inv)
       deallocate(T_inv_ref)
 
-    ELSEIF (C%choice_climate_model_realistic == 'climate_matrix') THEN
-      ! Not yet implemented! Will likely use the lambda field from Berends et al. (2018)
     END IF
 
     ! Finalise routine path
@@ -383,4 +382,4 @@ CONTAINS
   END SUBROUTINE apply_geometry_downscaling_corrections
 
 
-END MODULE climate_snapshot_plus_transient_deltaT
+END MODULE climate_snapshot_plus_anomalies

--- a/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
+++ b/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
@@ -125,10 +125,20 @@ CONTAINS
     CALL init_routine( routine_name)
 
     ! Allocate variables that will be computed
+    ALLOCATE( climate%snapshot_p_anml%snapshot_baseline%Hs(     mesh%vi1:mesh%vi2))
+    ALLOCATE( climate%snapshot_p_anml%snapshot_baseline%T2m(    mesh%vi1:mesh%vi2,12))
+    ALLOCATE( climate%snapshot_p_anml%snapshot_baseline%Precip( mesh%vi1:mesh%vi2,12))
     ALLOCATE( climate%snapshot_p_anml%T2m_anomaly(    mesh%vi1:mesh%vi2,12))
     ALLOCATE( climate%snapshot_p_anml%Precip_anomaly( mesh%vi1:mesh%vi2,12))
     ALLOCATE( climate%snapshot_p_anml%T2m(            mesh%vi1:mesh%vi2,12))
     ALLOCATE( climate%snapshot_p_anml%Precip(         mesh%vi1:mesh%vi2,12))
+    climate%snapshot_p_anml%snapshot_baseline%Hs     = 0._dp
+    climate%snapshot_p_anml%snapshot_baseline%T2m    = 0._dp
+    climate%snapshot_p_anml%snapshot_baseline%Precip = 0._dp
+    climate%snapshot_p_anml%T2m_anomaly              = 0._dp
+    climate%snapshot_p_anml%Precip_anomaly           = 0._dp
+    climate%snapshot_p_anml%T2m                      = 0._dp
+    climate%snapshot_p_anml%Precip                   = 0._dp
 
     ! Run the chosen realistic climate model
     climate%snapshot_p_anml%snapshot_baseline%has_insolation = .FALSE.
@@ -169,13 +179,17 @@ CONTAINS
     end select
 
     ! Read in baseline variables
+    IF (par%primary)  WRITE(*,"(A)") '    Reading baseline Hs...'
     CALL read_field_from_file_2D(         filename_climate_snapshot, 'Hs'    , mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%Hs)
+    IF (par%primary)  WRITE(*,"(A)") '    Reading baseline T2m...'
     CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'T2m'   , mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%T2m)
+    IF (par%primary)  WRITE(*,"(A)") '    Reading baseline Precip...'
     CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'Precip', mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%Precip)
 
     ! Read in anomalies
 
     ! Initialise anomaly timeframes
+    IF (par%primary)  WRITE(*,"(A)") '    Reading anomalies...'
     climate%snapshot_p_anml%anomaly_t0 = C%start_time_of_run - 200._dp
     climate%snapshot_p_anml%anomaly_t1 = C%start_time_of_run - 100._dp
     call update_climate_timeframes( mesh, climate, C%start_time_of_run)

--- a/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
+++ b/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
@@ -66,22 +66,23 @@ CONTAINS
     w0 = (climate%snapshot_p_anml%anomaly_t1 - time) / (climate%snapshot_p_anml%anomaly_t1 - self%anomaly_t0)
     w1 = 1._dp - w0
 
+    do m = 1,12
     do vi = mesh%vi1, mesh%vi2
 
-      ! Note that the baseline and the applied temperature are monthly, but the anomaly is annual
-      climate%snapshot_p_anml%T2m_anomaly( vi)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi)
-      climate%snapshot_p_anml%Precip_anomaly( vi) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi)
+      climate%snapshot_p_anml%T2m_anomaly( vi, m)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi, m)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi, m)
+      climate%snapshot_p_anml%Precip_anomaly( vi, m) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi, m) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi, m)
       
 
       ! Add anomaly to snapshot to find the applied temperature and precipitation
-      climate%snapshot_p_anml%T2m( vi,:)    = climate%snapshot_p_anml%T2m_baseline( vi,:)    + climate%snapshot_p_anml%T2m_anomaly( vi)
-      climate%snapshot_p_anml%Precip( vi,:) = climate%snapshot_p_anml%Precip_baseline( vi,:) + climate%snapshot_p_anml%Precip_anomaly( vi)
+      climate%snapshot_p_anml%T2m( vi,m)    = climate%snapshot_p_anml%T2m_baseline( vi,m)    + climate%snapshot_p_anml%T2m_anomaly( vi, m)
+      climate%snapshot_p_anml%Precip( vi,m) = climate%snapshot_p_anml%Precip_baseline( vi,m) + climate%snapshot_p_anml%Precip_anomaly( vi, m)
       
 
       ! Copy T2m to climate model
-      climate%T2m( vi,:)    = climate%snapshot_p_anml%T2m( vi,:)
-      climate%Precip( vi,:) = climate%snapshot_p_anml%Precip( vi,:)
+      climate%T2m( vi,m)    = climate%snapshot_p_anml%T2m( vi,m)
+      climate%Precip( vi,m) = climate%snapshot_p_anml%Precip( vi,m)
 
+    end do
     end do
 
     ! Update temperature and precipitation fields based on the mismatch between
@@ -123,18 +124,11 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    !ALLOCATE( climate%snapshot_p_anml%snapshot_baseline%Hs(     mesh%vi1:mesh%vi2))
-    !ALLOCATE( climate%snapshot_p_anml%snapshot_baseline%T2m(    mesh%vi1:mesh%vi2,12))
-    !ALLOCATE( climate%snapshot_p_anml%snapshot_baseline%Precip( mesh%vi1:mesh%vi2,12))
+    ! Allocate variables that will be computed
     ALLOCATE( climate%snapshot_p_anml%T2m_anomaly(    mesh%vi1:mesh%vi2,12))
     ALLOCATE( climate%snapshot_p_anml%Precip_anomaly( mesh%vi1:mesh%vi2,12))
-    
-    ! TODO: do we need to allocate these??
-    !ALLOCATE( climate%snapshot_p_anml%T2m_anomaly_0(    mesh%vi1:mesh%vi2,12))
-    !ALLOCATE( climate%snapshot_p_anml%Precip_anomaly_0( mesh%vi1:mesh%vi2,12))
-    !ALLOCATE( climate%snapshot_p_anml%T2m_anomaly_1(    mesh%vi1:mesh%vi2,12))
-    !ALLOCATE( climate%snapshot_p_anml%Precip_anomaly_1( mesh%vi1:mesh%vi2,12))
-
+    ALLOCATE( climate%snapshot_p_anml%T2m(            mesh%vi1:mesh%vi2,12))
+    ALLOCATE( climate%snapshot_p_anml%Precip(         mesh%vi1:mesh%vi2,12))
 
     ! Run the chosen realistic climate model
     climate%snapshot_p_anml%snapshot_baseline%has_insolation = .FALSE.
@@ -191,20 +185,22 @@ CONTAINS
     w0 = (climate%snapshot_p_anml%anomaly_t1 - C%start_time_of_run) / (climate%snapshot_p_anml%anomaly_t1 - climate%snapshot_p_anml%anomaly_t0)
     w1 = 1._dp - w0
 
+    do m = 1,12
     do vi = mesh%vi1, mesh%vi2
 
       ! Note that the baseline and the applied temperature and precip are monthly, but the anomaly is annual
-      climate%snapshot_p_anml%T2m_anomaly( vi)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi)
-      climate%snapshot_p_anml%Precip_anomaly( vi) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi)
+      climate%snapshot_p_anml%T2m_anomaly( vi,m)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi,m)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi,m)
+      climate%snapshot_p_anml%Precip_anomaly( vi,m) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi,m) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi,m)
 
       ! Add anomaly to snapshots to find the applied temperature and precipitation
-      climate%snapshot_p_anml%T2m( vi,:)    = climate%snapshot_p_anml%%snapshot_baseline%T2m( vi,:)    + climate%snapshot_p_anml%T2m_anomaly( vi)
-      climate%snapshot_p_anml%Precip( vi,:) = climate%snapshot_p_anml%%snapshot_baseline%Precip( vi,:) + climate%snapshot_p_anml%Precip_anomaly( vi)
+      climate%snapshot_p_anml%T2m( vi,m)    = climate%snapshot_p_anml%%snapshot_baseline%T2m( vi,m)    + climate%snapshot_p_anml%T2m_anomaly( vi,m)
+      climate%snapshot_p_anml%Precip( vi,m) = climate%snapshot_p_anml%%snapshot_baseline%Precip( vi,m) + climate%snapshot_p_anml%Precip_anomaly( vi,m)
 
       ! Copy to climate model
-      climate%T2m( vi,:)    = climate%snapshot_p_anml%T2m( vi,:)
-      climate%Precip( vi,:) = climate%snapshot_p_anml%Precip( vi,:)
+      climate%T2m( vi,m)    = climate%snapshot_p_anml%T2m( vi,m)
+      climate%Precip( vi,m) = climate%snapshot_p_anml%Precip( vi,m)
 
+    end do
     end do
 
     call apply_geometry_downscaling_corrections( mesh, ice, climate)
@@ -299,19 +295,20 @@ CONTAINS
     w0 = (climate%snapshot_p_anml%anomaly_t1 - time) / (climate%snapshot_p_anml%anomaly_t1 - climate%snapshot_p_anml%anomaly_t0)
     w1 = 1._dp - w0
 
+    do m = 1,12
     do vi = mesh%vi1, mesh%vi2
 
       ! Note that the baseline and the applied temperature and precip are monthly, but the anomaly is annual
-      climate%snapshot_p_anml%T2m_anomaly( vi)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi)
-      climate%snapshot_p_anml%Precip_anomaly( vi) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi)
+      climate%snapshot_p_anml%T2m_anomaly( vi,m)    = w0 * climate%snapshot_p_anml%T2m_anomaly_0( vi,m)    + w1 * climate%snapshot_p_anml%T2m_anomaly_1( vi,m)
+      climate%snapshot_p_anml%Precip_anomaly( vi,m) = w0 * climate%snapshot_p_anml%Precip_anomaly_0( vi,m) + w1 * climate%snapshot_p_anml%Precip_anomaly_1( vi,m)
 
       ! Add anomaly to snapshots to find the applied temperature and precipitation
-      climate%snapshot_p_anml%T2m( vi,:)    = climate%snapshot_p_anml%%snapshot_baseline%T2m( vi,:)    + climate%snapshot_p_anml%T2m_anomaly( vi)
-      climate%snapshot_p_anml%Precip( vi,:) = climate%snapshot_p_anml%%snapshot_baseline%Precip( vi,:) + climate%snapshot_p_anml%Precip_anomaly( vi)
+      climate%snapshot_p_anml%T2m( vi,m)    = climate%snapshot_p_anml%%snapshot_baseline%T2m( vi,m)    + climate%snapshot_p_anml%T2m_anomaly( vi,m)
+      climate%snapshot_p_anml%Precip( vi,m) = climate%snapshot_p_anml%%snapshot_baseline%Precip( vi,m) + climate%snapshot_p_anml%Precip_anomaly( vi,m)
 
       ! Copy to climate model
-      climate%T2m( vi,:)    = climate%snapshot_p_anml%T2m( vi,:)
-      climate%Precip( vi,:) = climate%snapshot_p_anml%Precip( vi,:)
+      climate%T2m( vi,m)    = climate%snapshot_p_anml%T2m( vi,m)
+      climate%Precip( vi,m) = climate%snapshot_p_anml%Precip( vi,m)
 
     end do
 

--- a/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
+++ b/src/UFEMISM/climate/climate_snapshot_plus_anomalies.f90
@@ -187,11 +187,8 @@ CONTAINS
     end select
 
     ! Read in baseline variables
-    IF (par%primary)  WRITE(*,"(A)") '    Reading baseline Hs...'
     CALL read_field_from_file_2D(         filename_climate_snapshot, 'Hs'    , mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%Hs)
-    IF (par%primary)  WRITE(*,"(A)") '    Reading baseline T2m...'
     CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'T2m'   , mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%T2m)
-    IF (par%primary)  WRITE(*,"(A)") '    Reading baseline Precip...'
     CALL read_field_from_file_2D_monthly( filename_climate_snapshot, 'Precip', mesh, C%output_dir, climate%snapshot_p_anml%snapshot_baseline%Precip)
 
     ! Read in anomalies

--- a/src/UFEMISM/types/climate_model_types.f90
+++ b/src/UFEMISM/types/climate_model_types.f90
@@ -93,16 +93,16 @@ MODULE climate_model_types
     REAL(dp), DIMENSION(:,:), ALLOCATABLE   :: Precip                          ! Monthly mean precipitation anomaly (m)
 
     ! anomalies
-    REAL(dp), DIMENSION(:), ALLOCATABLE     :: T2m_anomaly                     ! Monthly mean 2m air temperature anomaly (K)
-    REAL(dp), DIMENSION(:), ALLOCATABLE     :: Precip_anomaly                  ! Monthly mean precipitation anomaly (m)
+    REAL(dp), DIMENSION(:,:), ALLOCATABLE     :: T2m_anomaly                   ! Monthly mean 2m air temperature anomaly (K)
+    REAL(dp), DIMENSION(:,:), ALLOCATABLE     :: Precip_anomaly                ! Monthly mean precipitation anomaly (m)
 
-    REAL(dp), DIMENSION(:), ALLOCATABLE     :: T2m_anomaly_0                   ! Prev. timeframe of monthly mean 2m air temperature anomaly (K)
-    REAL(dp), DIMENSION(:), ALLOCATABLE     :: Precip_anomaly_0                ! Prev. timeframe of monthly mean precipitation anomaly (m)
+    REAL(dp), DIMENSION(:,:), ALLOCATABLE     :: T2m_anomaly_0                 ! Prev. timeframe of monthly mean 2m air temperature anomaly (K)
+    REAL(dp), DIMENSION(:,:), ALLOCATABLE     :: Precip_anomaly_0              ! Prev. timeframe of monthly mean precipitation anomaly (m)
 
-    REAL(dp), DIMENSION(:), ALLOCATABLE     :: T2m_anomaly_1                   ! Next timeframe of monthly mean 2m air temperature anomaly (K)
-    REAL(dp), DIMENSION(:), ALLOCATABLE     :: Precip_anomaly_1                ! Next timeframe of monthly mean precipitation anomaly (m)
+    REAL(dp), DIMENSION(:,:), ALLOCATABLE     :: T2m_anomaly_1                 ! Next timeframe of monthly mean 2m air temperature anomaly (K)
+    REAL(dp), DIMENSION(:,:), ALLOCATABLE     :: Precip_anomaly_1              ! Next timeframe of monthly mean precipitation anomaly (m)
 
-    REAL(dp)                                  :: anomaly_t0, anomaly_t1          ! times of each timeframe
+    REAL(dp)                                  :: anomaly_t0, anomaly_t1        ! times of each timeframe
 
   END TYPE type_climate_model_snapshot_plus_anomalies
   

--- a/src/UFEMISM/types/climate_model_types.f90
+++ b/src/UFEMISM/types/climate_model_types.f90
@@ -83,6 +83,28 @@ MODULE climate_model_types
     REAL(dp)                                  :: deltaT
 
   END TYPE type_climate_model_snapshot_plus_transient_dT
+
+  TYPE type_climate_model_snapshot_plus_anomalies
+
+    TYPE(type_climate_model_snapshot)         :: snapshot_baseline
+    character(len=1024)                       :: filename_climate_anomalies
+
+    REAL(dp), DIMENSION(:,:), ALLOCATABLE   :: T2m                             ! Monthly mean 2m air temperature anomaly (K)
+    REAL(dp), DIMENSION(:,:), ALLOCATABLE   :: Precip                          ! Monthly mean precipitation anomaly (m)
+
+    ! anomalies
+    REAL(dp), DIMENSION(:), ALLOCATABLE     :: T2m_anomaly                     ! Monthly mean 2m air temperature anomaly (K)
+    REAL(dp), DIMENSION(:), ALLOCATABLE     :: Precip_anomaly                  ! Monthly mean precipitation anomaly (m)
+
+    REAL(dp), DIMENSION(:), ALLOCATABLE     :: T2m_anomaly_0                   ! Prev. timeframe of monthly mean 2m air temperature anomaly (K)
+    REAL(dp), DIMENSION(:), ALLOCATABLE     :: Precip_anomaly_0                ! Prev. timeframe of monthly mean precipitation anomaly (m)
+
+    REAL(dp), DIMENSION(:), ALLOCATABLE     :: T2m_anomaly_1                   ! Next timeframe of monthly mean 2m air temperature anomaly (K)
+    REAL(dp), DIMENSION(:), ALLOCATABLE     :: Precip_anomaly_1                ! Next timeframe of monthly mean precipitation anomaly (m)
+
+    REAL(dp)                                  :: anomaly_t0, anomaly_t1          ! times of each timeframe
+
+  END TYPE type_climate_model_snapshot_plus_anomalies
   
   TYPE type_climate_model_matrix
     ! The "matrix" climate model option: three GCM snapshots (warm, cold, and PI), and a PD reanalysis snapshot to use for bias correction
@@ -139,6 +161,7 @@ MODULE climate_model_types
     TYPE(type_climate_model_snapshot)                   :: snapshot
     TYPE(type_climate_model_snapshot_plus_unif_dT)      :: snapshot_unif_dT
     TYPE(type_climate_model_snapshot_plus_transient_dT) :: snapshot_trans_dT
+    TYPE(type_climate_model_snapshot_plus_anomalies)    :: snapshot_p_anml
     TYPE(type_climate_model_matrix)                     :: matrix             ! The "matrix"          climate model option: three GCM snapshots (warm, cold, and PI), and a PD reanalysis snapshot to use for bias correction
 
   END TYPE type_climate_model

--- a/src/UPSY/basic/model_configuration/model_configuration_type_and_namelist.f90
+++ b/src/UPSY/basic/model_configuration/model_configuration_type_and_namelist.f90
@@ -669,6 +669,10 @@ module model_configuration_type_and_namelist
     character(len=1024) :: filename_atmosphere_dT_GRL_config             = ''
     character(len=1024) :: filename_atmosphere_dT_ANT_config             = ''
 
+    ! == Climate snapshot_plus_anomalies
+    character(len=1024) :: filename_climate_snp_p_anml_snapshot_config   = ''
+    character(len=1024) :: filename_climate_snp_p_anml_anomalies_config  = ''
+
     ! == Climate - Insolation
     character(len=1024) :: choice_insolation_forcing_config             = 'none'                           ! 'none', 'static' or 'realistic'
     character(len=1024) :: filename_insolation_config                   = ''                               ! File with the insolation solution (Laskar 2004)
@@ -1856,6 +1860,9 @@ module model_configuration_type_and_namelist
     character(len=1024) :: filename_atmosphere_dT_GRL
     character(len=1024) :: filename_atmosphere_dT_ANT
 
+    ! == Climate snapshot_plus_anomalies
+    character(len=1024) :: filename_climate_snp_p_anml_snapshot
+    character(len=1024) :: filename_climate_snp_p_anml_anomalies
 
     ! == Climate - Insolation
     character(len=1024) :: choice_insolation_forcing
@@ -2850,6 +2857,8 @@ contains
       filename_atmosphere_dT_EAS_config                           , &
       filename_atmosphere_dT_GRL_config                           , &
       filename_atmosphere_dT_ANT_config                           , &
+      filename_climate_snp_p_anml_snapshot_config                 , &
+      filename_climate_snp_p_anml_anomalies_config                , &
       choice_insolation_forcing_config                            , &
       filename_insolation_config                                  , &
       static_insolation_time_config                               , &
@@ -3884,6 +3893,10 @@ contains
     C%filename_atmosphere_dT_EAS                             = filename_atmosphere_dT_EAS_config
     C%filename_atmosphere_dT_GRL                             = filename_atmosphere_dT_GRL_config
     C%filename_atmosphere_dT_ANT                             = filename_atmosphere_dT_ANT_config
+
+    ! == Climate snapshot_plus_anomalies
+    C%climate_snp_p_anml_filename_snapshot                   = filename_climate_snp_p_anml_snapshot_config
+    C%climate_snp_p_anml_filename_anomalies                  = filename_climate_snp_p_anml_anomalies_config
 
     C%choice_insolation_forcing                              = choice_insolation_forcing_config
     C%filename_insolation                                    = filename_insolation_config

--- a/src/UPSY/basic/model_configuration/model_configuration_type_and_namelist.f90
+++ b/src/UPSY/basic/model_configuration/model_configuration_type_and_namelist.f90
@@ -670,8 +670,14 @@ module model_configuration_type_and_namelist
     character(len=1024) :: filename_atmosphere_dT_ANT_config             = ''
 
     ! == Climate snapshot_plus_anomalies
-    character(len=1024) :: filename_climate_snp_p_anml_snapshot_config   = ''
-    character(len=1024) :: filename_climate_snp_p_anml_anomalies_config  = ''
+    character(len=1024) :: filename_climate_snp_p_anml_snapshot_NAM_config   = ''
+    character(len=1024) :: filename_climate_snp_p_anml_snapshot_EAS_config   = ''
+    character(len=1024) :: filename_climate_snp_p_anml_snapshot_ANT_config   = ''
+    character(len=1024) :: filename_climate_snp_p_anml_snapshot_GRL_config   = ''
+    character(len=1024) :: filename_climate_snp_p_anml_anomalies_EAS_config  = ''
+    character(len=1024) :: filename_climate_snp_p_anml_anomalies_NAM_config  = ''
+    character(len=1024) :: filename_climate_snp_p_anml_anomalies_GRL_config  = ''
+    character(len=1024) :: filename_climate_snp_p_anml_anomalies_ANT_config  = ''
 
     ! == Climate - Insolation
     character(len=1024) :: choice_insolation_forcing_config             = 'none'                           ! 'none', 'static' or 'realistic'
@@ -1861,8 +1867,14 @@ module model_configuration_type_and_namelist
     character(len=1024) :: filename_atmosphere_dT_ANT
 
     ! == Climate snapshot_plus_anomalies
-    character(len=1024) :: filename_climate_snp_p_anml_snapshot
-    character(len=1024) :: filename_climate_snp_p_anml_anomalies
+    character(len=1024) :: filename_climate_snp_p_anml_snapshot_NAM
+    character(len=1024) :: filename_climate_snp_p_anml_snapshot_EAS
+    character(len=1024) :: filename_climate_snp_p_anml_snapshot_GRL
+    character(len=1024) :: filename_climate_snp_p_anml_snapshot_ANT
+    character(len=1024) :: filename_climate_snp_p_anml_anomalies_NAM
+    character(len=1024) :: filename_climate_snp_p_anml_anomalies_EAS
+    character(len=1024) :: filename_climate_snp_p_anml_anomalies_GRL
+    character(len=1024) :: filename_climate_snp_p_anml_anomalies_ANT
 
     ! == Climate - Insolation
     character(len=1024) :: choice_insolation_forcing
@@ -2857,8 +2869,14 @@ contains
       filename_atmosphere_dT_EAS_config                           , &
       filename_atmosphere_dT_GRL_config                           , &
       filename_atmosphere_dT_ANT_config                           , &
-      filename_climate_snp_p_anml_snapshot_config                 , &
-      filename_climate_snp_p_anml_anomalies_config                , &
+      filename_climate_snp_p_anml_snapshot_NAM_config             , &
+      filename_climate_snp_p_anml_snapshot_EAS_config             , &
+      filename_climate_snp_p_anml_snapshot_ANT_config             , &
+      filename_climate_snp_p_anml_snapshot_GRL_config             , &
+      filename_climate_snp_p_anml_anomalies_EAS_config            , &
+      filename_climate_snp_p_anml_anomalies_NAM_config            , &
+      filename_climate_snp_p_anml_anomalies_GRL_config            , &
+      filename_climate_snp_p_anml_anomalies_ANT_config            , &
       choice_insolation_forcing_config                            , &
       filename_insolation_config                                  , &
       static_insolation_time_config                               , &
@@ -3895,8 +3913,14 @@ contains
     C%filename_atmosphere_dT_ANT                             = filename_atmosphere_dT_ANT_config
 
     ! == Climate snapshot_plus_anomalies
-    C%climate_snp_p_anml_filename_snapshot                   = filename_climate_snp_p_anml_snapshot_config
-    C%climate_snp_p_anml_filename_anomalies                  = filename_climate_snp_p_anml_anomalies_config
+    C%climate_snp_p_anml_filename_snapshot_NAM               = filename_climate_snp_p_anml_snapshot_NAM_config
+    C%climate_snp_p_anml_filename_snapshot_EAS               = filename_climate_snp_p_anml_snapshot_EAS_config
+    C%climate_snp_p_anml_filename_snapshot_GRL               = filename_climate_snp_p_anml_snapshot_GRL_config
+    C%climate_snp_p_anml_filename_snapshot_ANT               = filename_climate_snp_p_anml_snapshot_ANT_config
+    C%climate_snp_p_anml_filename_anomalies_NAM              = filename_climate_snp_p_anml_anomalies_NAM_config
+    C%climate_snp_p_anml_filename_anomalies_EAS              = filename_climate_snp_p_anml_anomalies_EAS_config
+    C%climate_snp_p_anml_filename_anomalies_GRL              = filename_climate_snp_p_anml_anomalies_GRL_config
+    C%climate_snp_p_anml_filename_anomalies_ANT              = filename_climate_snp_p_anml_anomalies_ANT_config
 
     C%choice_insolation_forcing                              = choice_insolation_forcing_config
     C%filename_insolation                                    = filename_insolation_config

--- a/src/UPSY/basic/model_configuration/model_configuration_type_and_namelist.f90
+++ b/src/UPSY/basic/model_configuration/model_configuration_type_and_namelist.f90
@@ -670,14 +670,14 @@ module model_configuration_type_and_namelist
     character(len=1024) :: filename_atmosphere_dT_ANT_config             = ''
 
     ! == Climate snapshot_plus_anomalies
-    character(len=1024) :: filename_climate_snp_p_anml_snapshot_NAM_config   = ''
-    character(len=1024) :: filename_climate_snp_p_anml_snapshot_EAS_config   = ''
-    character(len=1024) :: filename_climate_snp_p_anml_snapshot_ANT_config   = ''
-    character(len=1024) :: filename_climate_snp_p_anml_snapshot_GRL_config   = ''
-    character(len=1024) :: filename_climate_snp_p_anml_anomalies_EAS_config  = ''
-    character(len=1024) :: filename_climate_snp_p_anml_anomalies_NAM_config  = ''
-    character(len=1024) :: filename_climate_snp_p_anml_anomalies_GRL_config  = ''
-    character(len=1024) :: filename_climate_snp_p_anml_anomalies_ANT_config  = ''
+    character(len=1024) :: climate_snp_p_anml_filename_snapshot_NAM_config   = ''
+    character(len=1024) :: climate_snp_p_anml_filename_snapshot_EAS_config   = ''
+    character(len=1024) :: climate_snp_p_anml_filename_snapshot_GRL_config   = ''
+    character(len=1024) :: climate_snp_p_anml_filename_snapshot_ANT_config   = ''
+    character(len=1024) :: climate_snp_p_anml_filename_anomalies_EAS_config  = ''
+    character(len=1024) :: climate_snp_p_anml_filename_anomalies_NAM_config  = ''
+    character(len=1024) :: climate_snp_p_anml_filename_anomalies_GRL_config  = ''
+    character(len=1024) :: climate_snp_p_anml_filename_anomalies_ANT_config  = ''
 
     ! == Climate - Insolation
     character(len=1024) :: choice_insolation_forcing_config             = 'none'                           ! 'none', 'static' or 'realistic'
@@ -1867,14 +1867,14 @@ module model_configuration_type_and_namelist
     character(len=1024) :: filename_atmosphere_dT_ANT
 
     ! == Climate snapshot_plus_anomalies
-    character(len=1024) :: filename_climate_snp_p_anml_snapshot_NAM
-    character(len=1024) :: filename_climate_snp_p_anml_snapshot_EAS
-    character(len=1024) :: filename_climate_snp_p_anml_snapshot_GRL
-    character(len=1024) :: filename_climate_snp_p_anml_snapshot_ANT
-    character(len=1024) :: filename_climate_snp_p_anml_anomalies_NAM
-    character(len=1024) :: filename_climate_snp_p_anml_anomalies_EAS
-    character(len=1024) :: filename_climate_snp_p_anml_anomalies_GRL
-    character(len=1024) :: filename_climate_snp_p_anml_anomalies_ANT
+    character(len=1024) :: climate_snp_p_anml_filename_snapshot_NAM
+    character(len=1024) :: climate_snp_p_anml_filename_snapshot_EAS
+    character(len=1024) :: climate_snp_p_anml_filename_snapshot_GRL
+    character(len=1024) :: climate_snp_p_anml_filename_snapshot_ANT
+    character(len=1024) :: climate_snp_p_anml_filename_anomalies_NAM
+    character(len=1024) :: climate_snp_p_anml_filename_anomalies_EAS
+    character(len=1024) :: climate_snp_p_anml_filename_anomalies_GRL
+    character(len=1024) :: climate_snp_p_anml_filename_anomalies_ANT
 
     ! == Climate - Insolation
     character(len=1024) :: choice_insolation_forcing
@@ -2869,14 +2869,14 @@ contains
       filename_atmosphere_dT_EAS_config                           , &
       filename_atmosphere_dT_GRL_config                           , &
       filename_atmosphere_dT_ANT_config                           , &
-      filename_climate_snp_p_anml_snapshot_NAM_config             , &
-      filename_climate_snp_p_anml_snapshot_EAS_config             , &
-      filename_climate_snp_p_anml_snapshot_ANT_config             , &
-      filename_climate_snp_p_anml_snapshot_GRL_config             , &
-      filename_climate_snp_p_anml_anomalies_EAS_config            , &
-      filename_climate_snp_p_anml_anomalies_NAM_config            , &
-      filename_climate_snp_p_anml_anomalies_GRL_config            , &
-      filename_climate_snp_p_anml_anomalies_ANT_config            , &
+      climate_snp_p_anml_filename_snapshot_NAM_config             , &
+      climate_snp_p_anml_filename_snapshot_EAS_config             , &
+      climate_snp_p_anml_filename_snapshot_GRL_config             , &
+      climate_snp_p_anml_filename_snapshot_ANT_config             , &
+      climate_snp_p_anml_filename_anomalies_EAS_config            , &
+      climate_snp_p_anml_filename_anomalies_NAM_config            , &
+      climate_snp_p_anml_filename_anomalies_GRL_config            , &
+      climate_snp_p_anml_filename_anomalies_ANT_config            , &
       choice_insolation_forcing_config                            , &
       filename_insolation_config                                  , &
       static_insolation_time_config                               , &
@@ -3913,14 +3913,14 @@ contains
     C%filename_atmosphere_dT_ANT                             = filename_atmosphere_dT_ANT_config
 
     ! == Climate snapshot_plus_anomalies
-    C%climate_snp_p_anml_filename_snapshot_NAM               = filename_climate_snp_p_anml_snapshot_NAM_config
-    C%climate_snp_p_anml_filename_snapshot_EAS               = filename_climate_snp_p_anml_snapshot_EAS_config
-    C%climate_snp_p_anml_filename_snapshot_GRL               = filename_climate_snp_p_anml_snapshot_GRL_config
-    C%climate_snp_p_anml_filename_snapshot_ANT               = filename_climate_snp_p_anml_snapshot_ANT_config
-    C%climate_snp_p_anml_filename_anomalies_NAM              = filename_climate_snp_p_anml_anomalies_NAM_config
-    C%climate_snp_p_anml_filename_anomalies_EAS              = filename_climate_snp_p_anml_anomalies_EAS_config
-    C%climate_snp_p_anml_filename_anomalies_GRL              = filename_climate_snp_p_anml_anomalies_GRL_config
-    C%climate_snp_p_anml_filename_anomalies_ANT              = filename_climate_snp_p_anml_anomalies_ANT_config
+    C%climate_snp_p_anml_filename_snapshot_NAM               = climate_snp_p_anml_filename_snapshot_NAM_config
+    C%climate_snp_p_anml_filename_snapshot_EAS               = climate_snp_p_anml_filename_snapshot_EAS_config
+    C%climate_snp_p_anml_filename_snapshot_GRL               = climate_snp_p_anml_filename_snapshot_GRL_config
+    C%climate_snp_p_anml_filename_snapshot_ANT               = climate_snp_p_anml_filename_snapshot_ANT_config
+    C%climate_snp_p_anml_filename_anomalies_NAM              = climate_snp_p_anml_filename_anomalies_NAM_config
+    C%climate_snp_p_anml_filename_anomalies_EAS              = climate_snp_p_anml_filename_anomalies_EAS_config
+    C%climate_snp_p_anml_filename_anomalies_GRL              = climate_snp_p_anml_filename_anomalies_GRL_config
+    C%climate_snp_p_anml_filename_anomalies_ANT              = climate_snp_p_anml_filename_anomalies_ANT_config
 
     C%choice_insolation_forcing                              = choice_insolation_forcing_config
     C%filename_insolation                                    = filename_insolation_config


### PR DESCRIPTION
Adds `choice_climate_model = 'snapshot_plus_anomalies`, which functions in the same way as the respective SMB model, but adding anomalies of `T2m` and `Precip` to a climate snapshot.

Climate anomaly files are assumed to follow the same dimension structure as the snapshot file, with (time,month,y,x) dimensions where "time" is the equivalent year.

Tested from 2015 to 2100 using the CESM-WACCM2 anomalies provided for ISMIP7 (spatial resolution downsampled 4x to keep file size and memory manageable for a laptop), added on top of the RACMO snapshot.