### PR TITLE
Replace unit test analysis script

### DIFF
--- a/.github/workflows/UPSY_test_suite.yml
+++ b/.github/workflows/UPSY_test_suite.yml
@@ -21,7 +21,6 @@ jobs:
 
   unit_tests:
     uses: ./.github/workflows/UPSY_unit_tests.yml
-    needs: setup_and_cache_Matlab
 
   mesh_creation:
     uses: ./.github/workflows/UPSY_component_test_mesh_creation.yml

--- a/.github/workflows/UPSY_unit_tests.yml
+++ b/.github/workflows/UPSY_unit_tests.yml
@@ -17,11 +17,6 @@ jobs:
     # Install all required packages and compile the code
     # ==================================================
 
-      - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v3
-        with:
-          cache: true
-
       - name: Set up Homebrew (ubuntu)                 # Not installed by default on ubuntu runners
         if: matrix.os == 'ubuntu-latest'
         id: set-up-homebrew
@@ -88,9 +83,10 @@ jobs:
       - name: Run multi-node unit tests
         run: mpiexec  -n 7 --map-by :OVERSUBSCRIBE  build/src/UPSY/UPSY_multinode_unit_test_program
 
-      - name: Check test results
-        uses: matlab-actions/run-command@v3
-        with:
-          command: |
-            addpath('automated_testing/unit_tests/analysis_scripts')
-            verify_unit_tests_results('${{github.workspace}}/automated_testing')
+      - name: Check unit tests (macos)
+        if: matrix.os == 'macos-latest'
+        run: ./check_unit_tests.csh
+
+      - name: Check unit tests (ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: csh check_unit_tests.csh

--- a/.github/workflows/UPSY_unit_tests.yml
+++ b/.github/workflows/UPSY_unit_tests.yml
@@ -85,8 +85,8 @@ jobs:
 
       - name: Check unit tests (macos)
         if: matrix.os == 'macos-latest'
-        run: ./check_unit_tests.csh
+        run: ./automated_testing/check_unit_tests.csh
 
       - name: Check unit tests (ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: csh check_unit_tests.csh
+        run: csh automated_testing/check_unit_tests.csh

--- a/automated_testing/check_unit_tests.csh
+++ b/automated_testing/check_unit_tests.csh
@@ -11,11 +11,11 @@ if (! -e $output_file) then
 endif
 
 # Find failed tests
-set failed_count = `grep -c "^Unit test failed:" $output_file`
+set failed_count = `grep -c "^ Unit test failed:" $output_file`
 
 if ($failed_count > 0) then
     echo "The following unit tests failed:"
-    grep "^Unit test failed:" $output_file
+    grep "^ Unit test failed:" $output_file
     echo ""
     echo "Unit tests failed. Exiting with error code 1."
     exit 1

--- a/automated_testing/check_unit_tests.csh
+++ b/automated_testing/check_unit_tests.csh
@@ -1,0 +1,25 @@
+#!/bin/csh
+
+# Script to check unit test results and fail if any tests failed
+
+set output_file = "automated_testing/unit_tests/results/unit_tests_output.txt"
+
+# Check if the file exists
+if (! -e $output_file) then
+    echo "Error: Unit test output file '$output_file' not found."
+    exit 1
+endif
+
+# Find failed tests
+set failed_count = `grep -c "^Unit test failed:" $output_file`
+
+if ($failed_count > 0) then
+    echo "The following unit tests failed:"
+    grep "^Unit test failed:" $output_file
+    echo ""
+    echo "Unit tests failed. Exiting with error code 1."
+    exit 1
+else
+    echo "All unit tests passed."
+    exit 0
+endif


### PR DESCRIPTION
Replace the Matlab script with a shell script. Now it actually fails the workflow when not all unit tests pass, and as a bonus it's also a lot faster (since we don't have to load Matlab anymore).