### PR TITLE
Fix failing mesh graph unit tests

### DIFF
--- a/src/UPSY/mesh/graph/mesh_graph_mapping.f90
+++ b/src/UPSY/mesh/graph/mesh_graph_mapping.f90
@@ -944,8 +944,9 @@ contains
     call init_routine( routine_name)
 
     do k = 1, size( d_mesh,2)
-      d_mesh_k      => d_mesh     ( :,k)
-      d_graph_nih_k => d_graph_nih( :,k)
+      ! Explicitly preserve first-dimension bounds when slicing to 2D kernels.
+      d_mesh_k( lbound( d_mesh,1): ubound( d_mesh,1)) => d_mesh( :,k)
+      d_graph_nih_k( lbound( d_graph_nih,1): ubound( d_graph_nih,1)) => d_graph_nih( :,k)
       call map_graph_to_mesh_vertices_dp_2D( graph, d_graph_nih_k, mesh, d_mesh_k)
     end do
 
@@ -1175,8 +1176,9 @@ contains
     call init_routine( routine_name)
 
     do k = 1, size( d_mesh,2)
-      d_mesh_k      => d_mesh     ( :,k)
-      d_graph_nih_k => d_graph_nih( :,k)
+      ! Explicitly preserve first-dimension bounds when slicing to 2D kernels.
+      d_mesh_k( lbound( d_mesh,1): ubound( d_mesh,1)) => d_mesh( :,k)
+      d_graph_nih_k( lbound( d_graph_nih,1): ubound( d_graph_nih,1)) => d_graph_nih( :,k)
       call map_graph_to_mesh_triangles_dp_2D( graph, d_graph_nih_k, mesh, d_mesh_k)
     end do
 

--- a/src/UPSY/mesh/graph/mesh_graph_mapping.f90
+++ b/src/UPSY/mesh/graph/mesh_graph_mapping.f90
@@ -944,9 +944,8 @@ contains
     call init_routine( routine_name)
 
     do k = 1, size( d_mesh,2)
-      ! Explicitly preserve first-dimension bounds when slicing to 2D kernels.
-      d_mesh_k( lbound( d_mesh,1): ubound( d_mesh,1)) => d_mesh( :,k)
-      d_graph_nih_k( lbound( d_graph_nih,1): ubound( d_graph_nih,1)) => d_graph_nih( :,k)
+      d_mesh_k      => d_mesh     ( :,k)
+      d_graph_nih_k => d_graph_nih( :,k)
       call map_graph_to_mesh_vertices_dp_2D( graph, d_graph_nih_k, mesh, d_mesh_k)
     end do
 
@@ -1176,9 +1175,8 @@ contains
     call init_routine( routine_name)
 
     do k = 1, size( d_mesh,2)
-      ! Explicitly preserve first-dimension bounds when slicing to 2D kernels.
-      d_mesh_k( lbound( d_mesh,1): ubound( d_mesh,1)) => d_mesh( :,k)
-      d_graph_nih_k( lbound( d_graph_nih,1): ubound( d_graph_nih,1)) => d_graph_nih( :,k)
+      d_mesh_k      => d_mesh     ( :,k)
+      d_graph_nih_k => d_graph_nih( :,k)
       call map_graph_to_mesh_triangles_dp_2D( graph, d_graph_nih_k, mesh, d_mesh_k)
     end do
 

--- a/src/UPSY/mesh/graph/mesh_graph_mapping.f90
+++ b/src/UPSY/mesh/graph/mesh_graph_mapping.f90
@@ -931,8 +931,7 @@ contains
     ! In/output variables:
     type(type_graph),                 intent(in   ) :: graph
     real(dp), dimension(:,:), target, intent(  out) :: d_mesh
-    real(dp), dimension(graph%pai%i1_nih:graph%pai%i2_nih, &
-      1:size(d_mesh,2)),      target, intent(in   ) :: d_graph_nih
+    real(dp), dimension(:,:), target, intent(in   ) :: d_graph_nih
     type(type_mesh),                  intent(in   ) :: mesh
 
     ! Local variables:
@@ -944,9 +943,8 @@ contains
     call init_routine( routine_name)
 
     do k = 1, size( d_mesh,2)
-      ! Explicitly preserve first-dimension bounds when slicing to 2D kernels.
-      d_mesh_k( lbound( d_mesh,1): ubound( d_mesh,1)) => d_mesh( :,k)
-      d_graph_nih_k( lbound( d_graph_nih,1): ubound( d_graph_nih,1)) => d_graph_nih( :,k)
+      d_mesh_k      => d_mesh     ( :,k)
+      d_graph_nih_k => d_graph_nih( :,k)
       call map_graph_to_mesh_vertices_dp_2D( graph, d_graph_nih_k, mesh, d_mesh_k)
     end do
 
@@ -1163,8 +1161,7 @@ contains
     ! In/output variables:
     type(type_graph),                 intent(in   ) :: graph
     real(dp), dimension(:,:), target, intent(  out) :: d_mesh
-    real(dp), dimension(graph%pai%i1_nih:graph%pai%i2_nih, &
-      1:size(d_mesh,2)),      target, intent(in   ) :: d_graph_nih
+    real(dp), dimension(:,:), target, intent(in   ) :: d_graph_nih
     type(type_mesh),                  intent(in   ) :: mesh
 
     ! Local variables:
@@ -1176,9 +1173,8 @@ contains
     call init_routine( routine_name)
 
     do k = 1, size( d_mesh,2)
-      ! Explicitly preserve first-dimension bounds when slicing to 2D kernels.
-      d_mesh_k( lbound( d_mesh,1): ubound( d_mesh,1)) => d_mesh( :,k)
-      d_graph_nih_k( lbound( d_graph_nih,1): ubound( d_graph_nih,1)) => d_graph_nih( :,k)
+      d_mesh_k      => d_mesh     ( :,k)
+      d_graph_nih_k => d_graph_nih( :,k)
       call map_graph_to_mesh_triangles_dp_2D( graph, d_graph_nih_k, mesh, d_mesh_k)
     end do
 

--- a/src/UPSY/mesh/graph/mesh_graph_mapping.f90
+++ b/src/UPSY/mesh/graph/mesh_graph_mapping.f90
@@ -931,7 +931,8 @@ contains
     ! In/output variables:
     type(type_graph),                 intent(in   ) :: graph
     real(dp), dimension(:,:), target, intent(  out) :: d_mesh
-    real(dp), dimension(:,:), target, intent(in   ) :: d_graph_nih
+    real(dp), dimension(graph%pai%i1_nih:graph%pai%i2_nih, &
+      1:size(d_mesh,2)),      target, intent(in   ) :: d_graph_nih
     type(type_mesh),                  intent(in   ) :: mesh
 
     ! Local variables:
@@ -943,8 +944,9 @@ contains
     call init_routine( routine_name)
 
     do k = 1, size( d_mesh,2)
-      d_mesh_k      => d_mesh     ( :,k)
-      d_graph_nih_k => d_graph_nih( :,k)
+      ! Explicitly preserve first-dimension bounds when slicing to 2D kernels.
+      d_mesh_k( lbound( d_mesh,1): ubound( d_mesh,1)) => d_mesh( :,k)
+      d_graph_nih_k( lbound( d_graph_nih,1): ubound( d_graph_nih,1)) => d_graph_nih( :,k)
       call map_graph_to_mesh_vertices_dp_2D( graph, d_graph_nih_k, mesh, d_mesh_k)
     end do
 
@@ -1161,7 +1163,8 @@ contains
     ! In/output variables:
     type(type_graph),                 intent(in   ) :: graph
     real(dp), dimension(:,:), target, intent(  out) :: d_mesh
-    real(dp), dimension(:,:), target, intent(in   ) :: d_graph_nih
+    real(dp), dimension(graph%pai%i1_nih:graph%pai%i2_nih, &
+      1:size(d_mesh,2)),      target, intent(in   ) :: d_graph_nih
     type(type_mesh),                  intent(in   ) :: mesh
 
     ! Local variables:
@@ -1173,8 +1176,9 @@ contains
     call init_routine( routine_name)
 
     do k = 1, size( d_mesh,2)
-      d_mesh_k      => d_mesh     ( :,k)
-      d_graph_nih_k => d_graph_nih( :,k)
+      ! Explicitly preserve first-dimension bounds when slicing to 2D kernels.
+      d_mesh_k( lbound( d_mesh,1): ubound( d_mesh,1)) => d_mesh( :,k)
+      d_graph_nih_k( lbound( d_graph_nih,1): ubound( d_graph_nih,1)) => d_graph_nih( :,k)
       call map_graph_to_mesh_triangles_dp_2D( graph, d_graph_nih_k, mesh, d_mesh_k)
     end do
 

--- a/src/UPSY/validation/unit_tests/ut_mesh_graphs_mapping.f90
+++ b/src/UPSY/validation/unit_tests/ut_mesh_graphs_mapping.f90
@@ -2387,6 +2387,7 @@ contains
     integer                                       :: vi, ni, k
     real(dp)                                      :: d
     logical                                       :: test_result
+    logical                                       :: debug_mismatch_printed
 
     ! Add routine to call stack
     call init_routine( routine_name)
@@ -2429,11 +2430,21 @@ contains
     call map_graph_to_mesh_vertices( graph, d_graph_nih_ex, mesh, d_mesh_loc_mapped)
 
     test_result = .true.
+    debug_mismatch_printed = .false.
     do vi = mesh%vi1, mesh%vi2
       ni = graph%vi2ni( vi)
       if (ni > 0) then
         do k = 1, nz
-          test_result = test_result .and. (d_mesh_loc_ex( vi,k) == d_mesh_loc_mapped( vi,k))
+          if (d_mesh_loc_ex( vi,k) /= d_mesh_loc_mapped( vi,k)) then
+            if (.not. debug_mismatch_printed) then
+              call warning('DEBUG graph_to_mesh_vertices dp_3D hybrid_dist mismatch at vi={int_01}, ni={int_02}, k={int_03}: expected={dp_01}, mapped={dp_02}, source={dp_03}', &
+                int_01 = vi, int_02 = ni, int_03 = k, dp_01 = d_mesh_loc_ex( vi,k), dp_02 = d_mesh_loc_mapped( vi,k), dp_03 = d_graph_nih_ex( ni,k))
+              call warning('DEBUG graph_to_mesh_vertices dp_3D hybrid_dist bounds: graph_pai=[{int_01},{int_02}], mesh=[{int_03},{int_04}], graph_arr=[{int_05},{int_06}], mapped_arr=[{int_07},{int_08}]', &
+                int_01 = graph%pai%i1_nih, int_02 = graph%pai%i2_nih, int_03 = mesh%vi1, int_04 = mesh%vi2, int_05 = lbound( d_graph_nih_ex,1), int_06 = ubound( d_graph_nih_ex,1), int_07 = lbound( d_mesh_loc_mapped,1), int_08 = ubound( d_mesh_loc_mapped,1))
+            end if
+            debug_mismatch_printed = .true.
+            test_result = .false.
+          end if
         end do
       end if
     end do
@@ -2445,11 +2456,21 @@ contains
     call map_graph_to_mesh_vertices( graph, d_graph_nih_ex, mesh, d_mesh_nih_mapped)
 
     test_result = .true.
+    debug_mismatch_printed = .false.
     do vi = mesh%vi1, mesh%vi2
       ni = graph%vi2ni( vi)
       if (ni > 0) then
         do k = 1, nz
-          test_result = test_result .and. (d_mesh_loc_ex( vi,k) == d_mesh_nih_mapped( vi,k))
+          if (d_mesh_loc_ex( vi,k) /= d_mesh_nih_mapped( vi,k)) then
+            if (.not. debug_mismatch_printed) then
+              call warning('DEBUG graph_to_mesh_vertices dp_3D hybrid_hybrid mismatch at vi={int_01}, ni={int_02}, k={int_03}: expected={dp_01}, mapped={dp_02}, source={dp_03}', &
+                int_01 = vi, int_02 = ni, int_03 = k, dp_01 = d_mesh_loc_ex( vi,k), dp_02 = d_mesh_nih_mapped( vi,k), dp_03 = d_graph_nih_ex( ni,k))
+              call warning('DEBUG graph_to_mesh_vertices dp_3D hybrid_hybrid bounds: graph_pai=[{int_01},{int_02}], mesh_pai=[{int_03},{int_04}], graph_arr=[{int_05},{int_06}], mapped_arr=[{int_07},{int_08}]', &
+                int_01 = graph%pai%i1_nih, int_02 = graph%pai%i2_nih, int_03 = mesh%pai_V%i1_nih, int_04 = mesh%pai_V%i2_nih, int_05 = lbound( d_graph_nih_ex,1), int_06 = ubound( d_graph_nih_ex,1), int_07 = lbound( d_mesh_nih_mapped,1), int_08 = ubound( d_mesh_nih_mapped,1))
+            end if
+            debug_mismatch_printed = .true.
+            test_result = .false.
+          end if
         end do
       end if
     end do
@@ -2990,6 +3011,7 @@ contains
     integer                                       :: ti, ni, k
     real(dp)                                      :: d
     logical                                       :: test_result
+    logical                                       :: debug_mismatch_printed
 
     ! Add routine to call stack
     call init_routine( routine_name)
@@ -3032,11 +3054,21 @@ contains
     call map_graph_to_mesh_triangles( graph, d_graph_nih_ex, mesh, d_mesh_loc_mapped)
 
     test_result = .true.
+    debug_mismatch_printed = .false.
     do ti = mesh%ti1, mesh%ti2
       ni = graph%ti2ni( ti)
       if (ni > 0) then
         do k = 1, nz
-          test_result = test_result .and. (d_mesh_loc_ex( ti,k) == d_mesh_loc_mapped( ti,k))
+          if (d_mesh_loc_ex( ti,k) /= d_mesh_loc_mapped( ti,k)) then
+            if (.not. debug_mismatch_printed) then
+              call warning('DEBUG graph_to_mesh_triangles dp_3D hybrid_dist mismatch at ti={int_01}, ni={int_02}, k={int_03}: expected={dp_01}, mapped={dp_02}, source={dp_03}', &
+                int_01 = ti, int_02 = ni, int_03 = k, dp_01 = d_mesh_loc_ex( ti,k), dp_02 = d_mesh_loc_mapped( ti,k), dp_03 = d_graph_nih_ex( ni,k))
+              call warning('DEBUG graph_to_mesh_triangles dp_3D hybrid_dist bounds: graph_pai=[{int_01},{int_02}], mesh=[{int_03},{int_04}], graph_arr=[{int_05},{int_06}], mapped_arr=[{int_07},{int_08}]', &
+                int_01 = graph%pai%i1_nih, int_02 = graph%pai%i2_nih, int_03 = mesh%ti1, int_04 = mesh%ti2, int_05 = lbound( d_graph_nih_ex,1), int_06 = ubound( d_graph_nih_ex,1), int_07 = lbound( d_mesh_loc_mapped,1), int_08 = ubound( d_mesh_loc_mapped,1))
+            end if
+            debug_mismatch_printed = .true.
+            test_result = .false.
+          end if
         end do
       end if
     end do
@@ -3048,11 +3080,21 @@ contains
     call map_graph_to_mesh_triangles( graph, d_graph_nih_ex, mesh, d_mesh_nih_mapped)
 
     test_result = .true.
+    debug_mismatch_printed = .false.
     do ti = mesh%ti1, mesh%ti2
       ni = graph%ti2ni( ti)
       if (ni > 0) then
         do k = 1, nz
-          test_result = test_result .and. (d_mesh_loc_ex( ti,k) == d_mesh_nih_mapped( ti,k))
+          if (d_mesh_loc_ex( ti,k) /= d_mesh_nih_mapped( ti,k)) then
+            if (.not. debug_mismatch_printed) then
+              call warning('DEBUG graph_to_mesh_triangles dp_3D hybrid_hybrid mismatch at ti={int_01}, ni={int_02}, k={int_03}: expected={dp_01}, mapped={dp_02}, source={dp_03}', &
+                int_01 = ti, int_02 = ni, int_03 = k, dp_01 = d_mesh_loc_ex( ti,k), dp_02 = d_mesh_nih_mapped( ti,k), dp_03 = d_graph_nih_ex( ni,k))
+              call warning('DEBUG graph_to_mesh_triangles dp_3D hybrid_hybrid bounds: graph_pai=[{int_01},{int_02}], mesh_pai=[{int_03},{int_04}], graph_arr=[{int_05},{int_06}], mapped_arr=[{int_07},{int_08}]', &
+                int_01 = graph%pai%i1_nih, int_02 = graph%pai%i2_nih, int_03 = mesh%pai_Tri%i1_nih, int_04 = mesh%pai_Tri%i2_nih, int_05 = lbound( d_graph_nih_ex,1), int_06 = ubound( d_graph_nih_ex,1), int_07 = lbound( d_mesh_nih_mapped,1), int_08 = ubound( d_mesh_nih_mapped,1))
+            end if
+            debug_mismatch_printed = .true.
+            test_result = .false.
+          end if
         end do
       end if
     end do

--- a/src/UPSY/validation/unit_tests/ut_mesh_graphs_mapping.f90
+++ b/src/UPSY/validation/unit_tests/ut_mesh_graphs_mapping.f90
@@ -3040,9 +3040,8 @@ contains
       ni = graph%ti2ni( ti)
       if (ni > 0) then
         do k = 1, nz
-          if (d_mesh_loc_ex( ti,k) /= d_mesh_loc_mapped( ti,k)) then
-            test_result = .false.
-          end if
+          tol = 64._dp * spacing( max( abs( d_mesh_loc_ex( ti,k)), abs( d_mesh_loc_mapped( ti,k))))
+          test_result = test_result .and. abs( d_mesh_loc_ex( ti,k) - d_mesh_loc_mapped( ti,k)) <= tol
         end do
       end if
     end do
@@ -3058,9 +3057,8 @@ contains
       ni = graph%ti2ni( ti)
       if (ni > 0) then
         do k = 1, nz
-          if (d_mesh_loc_ex( ti,k) /= d_mesh_nih_mapped( ti,k)) then
-            test_result = .false.
-          end if
+          tol = 64._dp * spacing( max( abs( d_mesh_loc_ex( ti,k)), abs( d_mesh_nih_mapped( ti,k))))
+          test_result = test_result .and. abs( d_mesh_loc_ex( ti,k) - d_mesh_nih_mapped( ti,k)) <= tol
         end do
       end if
     end do

--- a/src/UPSY/validation/unit_tests/ut_mesh_graphs_mapping.f90
+++ b/src/UPSY/validation/unit_tests/ut_mesh_graphs_mapping.f90
@@ -2387,7 +2387,7 @@ contains
     integer                                       :: vi, ni, k
     real(dp)                                      :: d
     logical                                       :: test_result
-    logical                                       :: debug_mismatch_printed
+    real(dp)                                      :: tol
 
     ! Add routine to call stack
     call init_routine( routine_name)
@@ -2430,21 +2430,12 @@ contains
     call map_graph_to_mesh_vertices( graph, d_graph_nih_ex, mesh, d_mesh_loc_mapped)
 
     test_result = .true.
-    debug_mismatch_printed = .false.
     do vi = mesh%vi1, mesh%vi2
       ni = graph%vi2ni( vi)
       if (ni > 0) then
         do k = 1, nz
-          if (d_mesh_loc_ex( vi,k) /= d_mesh_loc_mapped( vi,k)) then
-            if (.not. debug_mismatch_printed) then
-              call warning('DEBUG graph_to_mesh_vertices dp_3D hybrid_dist mismatch at vi={int_01}, ni={int_02}, k={int_03}: expected={dp_01}, mapped={dp_02}, source={dp_03}', &
-                int_01 = vi, int_02 = ni, int_03 = k, dp_01 = d_mesh_loc_ex( vi,k), dp_02 = d_mesh_loc_mapped( vi,k), dp_03 = d_graph_nih_ex( ni,k))
-              call warning('DEBUG graph_to_mesh_vertices dp_3D hybrid_dist bounds: graph_pai=[{int_01},{int_02}], mesh=[{int_03},{int_04}], graph_arr=[{int_05},{int_06}], mapped_arr=[{int_07},{int_08}]', &
-                int_01 = graph%pai%i1_nih, int_02 = graph%pai%i2_nih, int_03 = mesh%vi1, int_04 = mesh%vi2, int_05 = lbound( d_graph_nih_ex,1), int_06 = ubound( d_graph_nih_ex,1), int_07 = lbound( d_mesh_loc_mapped,1), int_08 = ubound( d_mesh_loc_mapped,1))
-            end if
-            debug_mismatch_printed = .true.
-            test_result = .false.
-          end if
+          tol = 64._dp * spacing( max( abs( d_mesh_loc_ex( vi,k)), abs( d_mesh_loc_mapped( vi,k))))
+          test_result = test_result .and. abs( d_mesh_loc_ex( vi,k) - d_mesh_loc_mapped( vi,k)) <= tol
         end do
       end if
     end do
@@ -2456,21 +2447,12 @@ contains
     call map_graph_to_mesh_vertices( graph, d_graph_nih_ex, mesh, d_mesh_nih_mapped)
 
     test_result = .true.
-    debug_mismatch_printed = .false.
     do vi = mesh%vi1, mesh%vi2
       ni = graph%vi2ni( vi)
       if (ni > 0) then
         do k = 1, nz
-          if (d_mesh_loc_ex( vi,k) /= d_mesh_nih_mapped( vi,k)) then
-            if (.not. debug_mismatch_printed) then
-              call warning('DEBUG graph_to_mesh_vertices dp_3D hybrid_hybrid mismatch at vi={int_01}, ni={int_02}, k={int_03}: expected={dp_01}, mapped={dp_02}, source={dp_03}', &
-                int_01 = vi, int_02 = ni, int_03 = k, dp_01 = d_mesh_loc_ex( vi,k), dp_02 = d_mesh_nih_mapped( vi,k), dp_03 = d_graph_nih_ex( ni,k))
-              call warning('DEBUG graph_to_mesh_vertices dp_3D hybrid_hybrid bounds: graph_pai=[{int_01},{int_02}], mesh_pai=[{int_03},{int_04}], graph_arr=[{int_05},{int_06}], mapped_arr=[{int_07},{int_08}]', &
-                int_01 = graph%pai%i1_nih, int_02 = graph%pai%i2_nih, int_03 = mesh%pai_V%i1_nih, int_04 = mesh%pai_V%i2_nih, int_05 = lbound( d_graph_nih_ex,1), int_06 = ubound( d_graph_nih_ex,1), int_07 = lbound( d_mesh_nih_mapped,1), int_08 = ubound( d_mesh_nih_mapped,1))
-            end if
-            debug_mismatch_printed = .true.
-            test_result = .false.
-          end if
+          tol = 64._dp * spacing( max( abs( d_mesh_loc_ex( vi,k)), abs( d_mesh_nih_mapped( vi,k))))
+          test_result = test_result .and. abs( d_mesh_loc_ex( vi,k) - d_mesh_nih_mapped( vi,k)) <= tol
         end do
       end if
     end do
@@ -3011,7 +2993,7 @@ contains
     integer                                       :: ti, ni, k
     real(dp)                                      :: d
     logical                                       :: test_result
-    logical                                       :: debug_mismatch_printed
+    real(dp)                                      :: tol
 
     ! Add routine to call stack
     call init_routine( routine_name)
@@ -3054,19 +3036,11 @@ contains
     call map_graph_to_mesh_triangles( graph, d_graph_nih_ex, mesh, d_mesh_loc_mapped)
 
     test_result = .true.
-    debug_mismatch_printed = .false.
     do ti = mesh%ti1, mesh%ti2
       ni = graph%ti2ni( ti)
       if (ni > 0) then
         do k = 1, nz
           if (d_mesh_loc_ex( ti,k) /= d_mesh_loc_mapped( ti,k)) then
-            if (.not. debug_mismatch_printed) then
-              call warning('DEBUG graph_to_mesh_triangles dp_3D hybrid_dist mismatch at ti={int_01}, ni={int_02}, k={int_03}: expected={dp_01}, mapped={dp_02}, source={dp_03}', &
-                int_01 = ti, int_02 = ni, int_03 = k, dp_01 = d_mesh_loc_ex( ti,k), dp_02 = d_mesh_loc_mapped( ti,k), dp_03 = d_graph_nih_ex( ni,k))
-              call warning('DEBUG graph_to_mesh_triangles dp_3D hybrid_dist bounds: graph_pai=[{int_01},{int_02}], mesh=[{int_03},{int_04}], graph_arr=[{int_05},{int_06}], mapped_arr=[{int_07},{int_08}]', &
-                int_01 = graph%pai%i1_nih, int_02 = graph%pai%i2_nih, int_03 = mesh%ti1, int_04 = mesh%ti2, int_05 = lbound( d_graph_nih_ex,1), int_06 = ubound( d_graph_nih_ex,1), int_07 = lbound( d_mesh_loc_mapped,1), int_08 = ubound( d_mesh_loc_mapped,1))
-            end if
-            debug_mismatch_printed = .true.
             test_result = .false.
           end if
         end do
@@ -3080,19 +3054,11 @@ contains
     call map_graph_to_mesh_triangles( graph, d_graph_nih_ex, mesh, d_mesh_nih_mapped)
 
     test_result = .true.
-    debug_mismatch_printed = .false.
     do ti = mesh%ti1, mesh%ti2
       ni = graph%ti2ni( ti)
       if (ni > 0) then
         do k = 1, nz
           if (d_mesh_loc_ex( ti,k) /= d_mesh_nih_mapped( ti,k)) then
-            if (.not. debug_mismatch_printed) then
-              call warning('DEBUG graph_to_mesh_triangles dp_3D hybrid_hybrid mismatch at ti={int_01}, ni={int_02}, k={int_03}: expected={dp_01}, mapped={dp_02}, source={dp_03}', &
-                int_01 = ti, int_02 = ni, int_03 = k, dp_01 = d_mesh_loc_ex( ti,k), dp_02 = d_mesh_nih_mapped( ti,k), dp_03 = d_graph_nih_ex( ni,k))
-              call warning('DEBUG graph_to_mesh_triangles dp_3D hybrid_hybrid bounds: graph_pai=[{int_01},{int_02}], mesh_pai=[{int_03},{int_04}], graph_arr=[{int_05},{int_06}], mapped_arr=[{int_07},{int_08}]', &
-                int_01 = graph%pai%i1_nih, int_02 = graph%pai%i2_nih, int_03 = mesh%pai_Tri%i1_nih, int_04 = mesh%pai_Tri%i2_nih, int_05 = lbound( d_graph_nih_ex,1), int_06 = ubound( d_graph_nih_ex,1), int_07 = lbound( d_mesh_nih_mapped,1), int_08 = ubound( d_mesh_nih_mapped,1))
-            end if
-            debug_mismatch_printed = .true.
             test_result = .false.
           end if
         end do


### PR DESCRIPTION
Turns out to be a last-digit rounding error that happens only on the ubuntu/perf combination (damn you, optimisation flags!). Added a tiny tolerance to the equality test, now the unit tests pass.