### PR TITLE
skip mesh setups during read from file

### DIFF
--- a/src/UPSY/io/netcdf_input/netcdf_read_field_from_mesh_file.f90
+++ b/src/UPSY/io/netcdf_input/netcdf_read_field_from_mesh_file.f90
@@ -35,12 +35,11 @@ contains
     ! Local variables:
     character(len=1024), parameter        :: routine_name = 'read_field_from_mesh_file_int_2D'
     integer                               :: ncid
-    type(type_mesh)                       :: mesh_loc
-    integer                               :: id_var
+    integer                               :: id_var, id_dim
     character(len=1024)                   :: var_name
     integer , dimension(:  ), allocatable :: d_mesh
     integer , dimension(:,:), allocatable :: d_mesh_with_time
-    integer                               :: ti
+    integer                               :: ti, nV
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -51,8 +50,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt(  filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -62,18 +64,18 @@ contains
     call check_mesh_field_int_2D( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nV))
+    if (par%primary) allocate( d_mesh( nV))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, 1))
+      if (par%primary) allocate( d_mesh_with_time( nV, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ mesh_loc%nV, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ nV, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,1)
       ! Clean up after yourself
@@ -109,12 +111,11 @@ contains
     ! Local variables:
     character(len=1024), parameter        :: routine_name = 'read_field_from_mesh_file_int_2D_b'
     integer                               :: ncid
-    type(type_mesh)                       :: mesh_loc
-    integer                               :: id_var
+    integer                               :: id_var, id_dim
     character(len=1024)                   :: var_name
     integer , dimension(:  ), allocatable :: d_mesh
     integer , dimension(:,:), allocatable :: d_mesh_with_time
-    integer                               :: ti
+    integer                               :: ti, nTri
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -125,8 +126,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt(  filename, ncid, field_name_options_dim_nTri, id_dim, dim_length = nTri)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -136,18 +140,18 @@ contains
     call check_mesh_field_int_2D_b( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nTri))
+    if (par%primary) allocate( d_mesh( nTri))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nTri, 1))
+      if (par%primary) allocate( d_mesh_with_time( nTri, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ mesh_loc%nTri, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ nTri, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,1)
       ! Clean up after yourself
@@ -183,12 +187,11 @@ contains
     ! Local variables:
     character(len=1024), parameter        :: routine_name = 'read_field_from_mesh_file_dp_2D'
     integer                               :: ncid
-    type(type_mesh)                       :: mesh_loc
-    integer                               :: id_var
+    integer                               :: id_var, id_dim
     character(len=1024)                   :: var_name
     real(dp), dimension(:  ), allocatable :: d_mesh
     real(dp), dimension(:,:), allocatable :: d_mesh_with_time
-    integer                               :: ti
+    integer                               :: ti, nV
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -199,8 +202,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt(  filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -210,18 +216,18 @@ contains
     call check_mesh_field_dp_2D( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nV))
+    if (par%primary) allocate( d_mesh( nV))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, 1))
+      if (par%primary) allocate( d_mesh_with_time( nV, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ mesh_loc%nV, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ nV, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,1)
       ! Clean up after yourself
@@ -257,12 +263,11 @@ contains
     ! Local variables:
     character(len=1024), parameter        :: routine_name = 'read_field_from_mesh_file_dp_2D_b'
     integer                               :: ncid
-    type(type_mesh)                       :: mesh_loc
-    integer                               :: id_var
+    integer                               :: id_var, id_dim
     character(len=1024)                   :: var_name
     real(dp), dimension(:  ), allocatable :: d_mesh
     real(dp), dimension(:,:), allocatable :: d_mesh_with_time
-    integer                               :: ti
+    integer                               :: ti, nTri
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -273,8 +278,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt(  filename, ncid, field_name_options_dim_nTri, id_dim, dim_length = nTri)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -284,18 +292,18 @@ contains
     call check_mesh_field_dp_2D_b( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nTri))
+    if (par%primary) allocate( d_mesh( nTri))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nTri, 1))
+      if (par%primary) allocate( d_mesh_with_time( nTri, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ mesh_loc%nTri, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, ti /), count = (/ nTri, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,1)
       ! Clean up after yourself
@@ -331,12 +339,11 @@ contains
     ! Local variables:
     character(len=1024), parameter          :: routine_name = 'read_field_from_mesh_file_dp_2D_monthly'
     integer                                 :: ncid
-    type(type_mesh)                         :: mesh_loc
-    integer                                 :: id_var
+    integer                                 :: id_var, id_dim
     character(len=1024)                     :: var_name
     real(dp), dimension(:,:  ), allocatable :: d_mesh
     real(dp), dimension(:,:,:), allocatable :: d_mesh_with_time
-    integer                                 :: ti
+    integer                                 :: ti, nV
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -347,8 +354,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt(  filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
 
     ! Look for the specified variable in the file
     call inquire_var_multopt( filename, ncid, field_name_options, id_var, var_name = var_name)
@@ -361,18 +371,18 @@ contains
     call check_mesh_field_dp_2D_monthly( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nV, 12))
+    if (par%primary) allocate( d_mesh( nV, 12))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, 12, 1))
+      if (par%primary) allocate( d_mesh_with_time( nV, 12, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ mesh_loc%nV, 12, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ nV, 12, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,:,1)
       ! Clean up after yourself
@@ -408,14 +418,13 @@ contains
     ! Local variables:
     character(len=1024), parameter          :: routine_name = 'read_field_from_mesh_file_dp_3D'
     integer                                 :: ncid
-    type(type_mesh)                         :: mesh_loc
     integer                                 :: nzeta_loc
     real(dp), dimension(:), allocatable     :: zeta_loc
-    integer                                 :: id_var
+    integer                                 :: id_var, id_dim
     character(len=1024)                     :: var_name
     real(dp), dimension(:,:  ), allocatable :: d_mesh
     real(dp), dimension(:,:,:), allocatable :: d_mesh_with_time
-    integer                                 :: ti
+    integer                                 :: ti, nV
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -426,8 +435,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt(  filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
 
     ! Set up the vertical coordinate zeta from the file
     call setup_zeta_from_file( filename, ncid, nzeta_loc, zeta_loc)
@@ -440,18 +452,18 @@ contains
     call check_mesh_field_dp_3D( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nV, nzeta_loc))
+    if (par%primary) allocate( d_mesh( nV, nzeta_loc))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, nzeta_loc, 1))
+      if (par%primary) allocate( d_mesh_with_time( nV, nzeta_loc, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ mesh_loc%nV, nzeta_loc, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ nV, nzeta_loc, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,:,1)
       ! Clean up after yourself
@@ -487,14 +499,13 @@ contains
     ! Local variables:
     character(len=1024), parameter          :: routine_name = 'read_field_from_mesh_file_dp_3D_b'
     integer                                 :: ncid
-    type(type_mesh)                         :: mesh_loc
     integer                                 :: nzeta_loc
     real(dp), dimension(:), allocatable     :: zeta_loc
-    integer                                 :: id_var
+    integer                                 :: id_var, id_dim
     character(len=1024)                     :: var_name
     real(dp), dimension(:,:  ), allocatable :: d_mesh
     real(dp), dimension(:,:,:), allocatable :: d_mesh_with_time
-    integer                                 :: ti
+    integer                                 :: ti, nTri
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -505,8 +516,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt(  filename, ncid, field_name_options_dim_nTri, id_dim, dim_length = nTri)
 
     ! Set up the vertical coordinate zeta from the file
     call setup_zeta_from_file( filename, ncid, nzeta_loc, zeta_loc)
@@ -519,18 +533,18 @@ contains
     call check_mesh_field_dp_3D_b( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nTri, nzeta_loc))
+    if (par%primary) allocate( d_mesh( nTri, nzeta_loc))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nTri, nzeta_loc, 1))
+      if (par%primary) allocate( d_mesh_with_time( nTri, nzeta_loc, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ mesh_loc%nTri, nzeta_loc, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ nTri, nzeta_loc, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,:,1)
       ! Clean up after yourself
@@ -566,14 +580,13 @@ contains
     ! Local variables:
     character(len=1024), parameter          :: routine_name = 'read_field_from_mesh_file_dp_3D_ocean'
     integer                                 :: ncid
-    type(type_mesh)                         :: mesh_loc
     integer                                 :: ndepth_loc
     real(dp), dimension(:), allocatable     :: depth_loc
-    integer                                 :: id_var
+    integer                                 :: id_var, id_dim
     character(len=1024)                     :: var_name
     real(dp), dimension(:,:  ), allocatable :: d_mesh
     real(dp), dimension(:,:,:), allocatable :: d_mesh_with_time
-    integer                                 :: ti
+    integer                                 :: ti, nV
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -584,8 +597,11 @@ contains
     ! Open the NetCDF file
     call open_existing_netcdf_file_for_reading( filename, ncid)
 
-    ! Set up the mesh from the file
-    call setup_mesh_from_file( filename, ncid, mesh_loc)
+    ! Check mesh dimensions and variables for validity
+    call check_mesh_dimensions( filename, ncid)
+
+    ! Inquire mesh dimensions
+    call inquire_dim_multopt(  filename, ncid, field_name_options_dim_nV, id_dim, dim_length = nV)
 
     ! Set up the vertical coordinate depth from the file
     call setup_depth_from_file( filename, ncid, ndepth_loc, depth_loc)
@@ -598,18 +614,18 @@ contains
     call check_mesh_field_dp_3D_ocean( filename, ncid, var_name, should_have_time = present( time_to_read))
 
     ! allocate memory
-    if (par%primary) allocate( d_mesh( mesh_loc%nV, ndepth_loc))
+    if (par%primary) allocate( d_mesh( nV, ndepth_loc))
 
     ! Read data from file
     if (.not. present( time_to_read)) then
       call read_var_primary( filename, ncid, id_var, d_mesh)
     else
       ! allocate memory
-      if (par%primary) allocate( d_mesh_with_time( mesh_loc%nV, ndepth_loc, 1))
+      if (par%primary) allocate( d_mesh_with_time( nV, ndepth_loc, 1))
       ! Find out which timeframe to read
       call find_timeframe( filename, ncid, time_to_read, ti)
       ! Read data
-      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ mesh_loc%nV, ndepth_loc, 1 /) )
+      call read_var_primary( filename, ncid, id_var, d_mesh_with_time, start = (/ 1, 1, ti /), count = (/ nV, ndepth_loc, 1 /) )
       ! Copy to output memory
       if (par%primary) d_mesh = d_mesh_with_time( :,:,1)
       ! Clean up after yourself


### PR DESCRIPTION
This resolves most delay during the restart from mesh. In one pan-Antarctic example, the non-Laddie initialisation is brought back from about 1.5 hours to 20 minutes.

Still, there are two points where the full mesh is generated: geometry and thermodynamics, which are not so easily avoided. Will create a separate issue for that and look at it later.