### PR TITLE
Fix memory leaks

### DIFF
--- a/src/UPSY/mesh/remapping/remapping_grid_to_mesh_triangles.f90
+++ b/src/UPSY/mesh/remapping/remapping_grid_to_mesh_triangles.f90
@@ -54,6 +54,7 @@ contains
     type(tMat)                            :: w0, w1x, w1y
     type(type_sparse_matrix_CSR_dp)       :: grid_M_ddx_CSR, grid_M_ddy_CSR
     character(len=1024)                   :: filename_grid, filename_mesh
+    type(PetscErrorCode)                  :: perr
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -81,6 +82,10 @@ contains
     call calc_matrix_operators_grid( grid, grid_M_ddx_CSR, grid_M_ddy_CSR)
 
     call calc_remapping_matrix( w0, w1x, w1y, grid_M_ddx_CSR, grid_M_ddy_CSR, map%M)
+
+    call MatDestroy( w0, perr)
+    call MatDestroy( w1x, perr)
+    call MatDestroy( w1y, perr)
 
     call delete_grid_and_mesh_netcdf_dump_files( filename_grid, filename_mesh)
 
@@ -536,6 +541,11 @@ contains
     ! M = w0 + w1x * M_ddx + w1y * M_ddy
     call MatMatMult( w1y, grid_M_ddy, MAT_INITIAL_MATRIX, PETSC_DEFAULT_real, M2, perr)
     call MatAXPY( M, 1._dp, M2, DifFERENT_NONZERO_PATTERN, perr)
+
+    call MatDestroy( grid_M_ddx, perr)
+    call MatDestroy( grid_M_ddy, perr)
+    call MatDestroy( M1, perr)
+    call MatDestroy( M2, perr)
 
     ! Finalise routine path
     call finalise_routine( routine_name)

--- a/src/UPSY/mesh/remapping/remapping_grid_to_mesh_vertices.f90
+++ b/src/UPSY/mesh/remapping/remapping_grid_to_mesh_vertices.f90
@@ -105,6 +105,8 @@ contains
     call MatDestroy( w0, perr)
     call MatDestroy( w1x, perr)
     call MatDestroy( w1y, perr)
+    call MatDestroy( M_cons_1st_order, perr)
+    call MatDestroy( M_cons_2nd_order, perr)
 
     call delete_grid_and_mesh_netcdf_dump_files( filename_grid, filename_mesh)
 

--- a/src/UPSY/mesh/remapping/remapping_grid_to_mesh_vertices.f90
+++ b/src/UPSY/mesh/remapping/remapping_grid_to_mesh_vertices.f90
@@ -98,8 +98,12 @@ contains
         call crash('unknown method for grid_to_mesh remapping "' // trim( map%method) // '"')
       case ('1st_order_conservative')
         map%M = M_cons_1st_order
+        ! Clean up the unused matrix
+        call MatDestroy( M_cons_2nd_order, perr)
       case ('2nd_order_conservative')
         map%M = M_cons_2nd_order
+        ! Clean up the unused matrix
+        call MatDestroy( M_cons_1st_order, perr)
     end select
 
     call MatDestroy( w0, perr)

--- a/src/UPSY/mesh/remapping/remapping_grid_to_mesh_vertices.f90
+++ b/src/UPSY/mesh/remapping/remapping_grid_to_mesh_vertices.f90
@@ -105,8 +105,6 @@ contains
     call MatDestroy( w0, perr)
     call MatDestroy( w1x, perr)
     call MatDestroy( w1y, perr)
-    call MatDestroy( M_cons_1st_order, perr)
-    call MatDestroy( M_cons_2nd_order, perr)
 
     call delete_grid_and_mesh_netcdf_dump_files( filename_grid, filename_mesh)
 

--- a/src/UPSY/mesh/remapping/remapping_grid_to_mesh_vertices.f90
+++ b/src/UPSY/mesh/remapping/remapping_grid_to_mesh_vertices.f90
@@ -56,6 +56,7 @@ contains
     type(tMat)                            :: M_cons_1st_order, M_cons_2nd_order
     type(type_sparse_matrix_CSR_dp)       :: grid_M_ddx_CSR, grid_M_ddy_CSR
     character(len=1024)                   :: filename_grid, filename_mesh
+    type(PetscErrorCode)                  :: perr
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -100,6 +101,10 @@ contains
       case ('2nd_order_conservative')
         map%M = M_cons_2nd_order
     end select
+
+    call MatDestroy( w0, perr)
+    call MatDestroy( w1x, perr)
+    call MatDestroy( w1y, perr)
 
     call delete_grid_and_mesh_netcdf_dump_files( filename_grid, filename_mesh)
 
@@ -554,6 +559,12 @@ contains
     call MatConvert( M_cons_1st_order, MATAIJ, MAT_INITIAL_MATRIX, M_cons_2nd_order, perr)
     call MatAXPY( M_cons_2nd_order, 1._dp, M1, DifFERENT_NONZERO_PATTERN, perr)
     call MatAXPY( M_cons_2nd_order, 1._dp, M2, DifFERENT_NONZERO_PATTERN, perr)
+
+    ! Destroy matrices
+    call MatDestroy( grid_M_ddx, perr)
+    call MatDestroy( grid_M_ddy, perr)
+    call MatDestroy( M1, perr)
+    call MatDestroy( M2, perr)
 
     ! Finalise routine path
     call finalise_routine( routine_name)

--- a/src/UPSY/mesh/remapping/remapping_mesh_to_mesh.f90
+++ b/src/UPSY/mesh/remapping/remapping_mesh_to_mesh.f90
@@ -261,7 +261,6 @@ contains
     call MatDestroy( w0, perr)
     call MatDestroy( w1x, perr)
     call MatDestroy( w1y, perr)
-    call MatDestroy( M_cons_1st_order, perr)
 
     call correct_mesh_to_mesh_map( mesh_src, mesh_dst, output_dir, M_cons_1st_order, map%M)
 

--- a/src/UPSY/mesh/remapping/remapping_mesh_to_mesh.f90
+++ b/src/UPSY/mesh/remapping/remapping_mesh_to_mesh.f90
@@ -261,6 +261,7 @@ contains
     call MatDestroy( w0, perr)
     call MatDestroy( w1x, perr)
     call MatDestroy( w1y, perr)
+    call MatDestroy( M_cons_1st_order, perr)
 
     call correct_mesh_to_mesh_map( mesh_src, mesh_dst, output_dir, M_cons_1st_order, map%M)
 

--- a/src/UPSY/mesh/remapping/remapping_mesh_to_mesh.f90
+++ b/src/UPSY/mesh/remapping/remapping_mesh_to_mesh.f90
@@ -229,6 +229,7 @@ contains
     type(tMat)                          :: M_cons_1st_order
     character(len=1024)                 :: filename_mesh_src, filename_mesh_dst
     integer                             :: stat
+    type(PetscErrorCode)                :: perr
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -252,6 +253,14 @@ contains
     call calc_w_matrices( mesh_src, mesh_dst, A_xdy_a_b, A_mxydx_a_b, A_xydy_a_b, w0, w1x, w1y)
 
     call calc_remapping_matrix( mesh_src, w0, w1x, w1y, M_cons_1st_order, map%M)
+
+    call MatDestroy( A_xdy_a_b, perr)
+    call MatDestroy( A_mxydx_a_b, perr)
+    call MatDestroy( A_xydy_a_b, perr)
+
+    call MatDestroy( w0, perr)
+    call MatDestroy( w1x, perr)
+    call MatDestroy( w1y, perr)
 
     call correct_mesh_to_mesh_map( mesh_src, mesh_dst, output_dir, M_cons_1st_order, map%M)
 
@@ -283,6 +292,7 @@ contains
     type(tMat)                          :: M_cons_1st_order
     character(len=1024)                 :: filename_mesh_src, filename_mesh_dst
     integer                             :: stat
+    type(PetscErrorCode)                :: perr
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -306,6 +316,14 @@ contains
     call calc_w_matrices_tri( mesh_src, mesh_dst, A_xdy, A_mxydx, A_xydy, w0, w1x, w1y)
 
     call calc_remapping_matrix_tri( mesh_src, w0, w1x, w1y, M_cons_1st_order, map%M)
+
+    call MatDestroy( A_xdy, perr)
+    call MatDestroy( A_mxydx, perr)
+    call MatDestroy( A_xydy, perr)
+
+    call MatDestroy( w0, perr)
+    call MatDestroy( w1x, perr)
+    call MatDestroy( w1y, perr)
 
     ! call correct_mesh_to_mesh_map( mesh_src, mesh_dst, M_cons_1st_order, map%M)
 
@@ -358,6 +376,13 @@ contains
     call MatAXPY( A_mxydx_a_b, 1._dp, A_mxydx_b_a_T, UNKNOWN_NONZERO_PATTERN, perr)
     call MatAXPY( A_xydy_a_b , 1._dp, A_xydy_b_a_T , UNKNOWN_NONZERO_PATTERN, perr)
 
+    call MatDestroy( A_xdy_b_a  , perr)
+    call MatDestroy( A_mxydx_b_a, perr)
+    call MatDestroy( A_xydy_b_a , perr)
+    call MatDestroy( A_xdy_b_a_T  , perr)
+    call MatDestroy( A_mxydx_b_a_T, perr)
+    call MatDestroy( A_xydy_b_a_T , perr)
+
     ! Finalise routine path
     call finalise_routine( routine_name)
 
@@ -398,6 +423,13 @@ contains
     call MatAXPY( A_xdy  , 1._dp, A_xdy_src_dst_T  , UNKNOWN_NONZERO_PATTERN, perr)
     call MatAXPY( A_mxydx, 1._dp, A_mxydx_src_dst_T, UNKNOWN_NONZERO_PATTERN, perr)
     call MatAXPY( A_xydy , 1._dp, A_xydy_src_dst_T , UNKNOWN_NONZERO_PATTERN, perr)
+
+    call MatDestroy( A_xdy_src_dst  , perr)
+    call MatDestroy( A_mxydx_src_dst, perr)
+    call MatDestroy( A_xydy_src_dst , perr)
+    call MatDestroy( A_xdy_src_dst_T, perr)
+    call MatDestroy( A_mxydx_src_dst_T, perr)
+    call MatDestroy( A_xydy_src_dst_T, perr)
 
     ! Finalise routine path
     call finalise_routine( routine_name)
@@ -652,6 +684,12 @@ contains
     call MatAXPY( M, 1._dp, M1, DifFERENT_NONZERO_PATTERN, perr)
     call MatAXPY( M, 1._dp, M2, DifFERENT_NONZERO_PATTERN, perr)
 
+    call MatDestroy( M_map_a_b, perr)
+    call MatDestroy( M_ddx_a_b, perr)
+    call MatDestroy( M_ddy_a_b, perr)
+    call MatDestroy( M1, perr)
+    call MatDestroy( M2, perr)
+
     ! Finalise routine path
     call finalise_routine( routine_name)
 
@@ -693,6 +731,11 @@ contains
     call MatConvert( M_cons_1st_order, MATAIJ, MAT_INITIAL_MATRIX, M, perr)
     call MatAXPY( M, 1._dp, M1, DifFERENT_NONZERO_PATTERN, perr)
     call MatAXPY( M, 1._dp, M2, DifFERENT_NONZERO_PATTERN, perr)
+
+    call MatDestroy( M_ddx_b_b, perr)
+    call MatDestroy( M_ddy_b_b, perr)
+    call MatDestroy( M1, perr)
+    call MatDestroy( M2, perr)
 
     ! Finalise routine path
     call finalise_routine( routine_name)

--- a/src/UPSY/mesh/remapping/remapping_mesh_vertices_to_grid.f90
+++ b/src/UPSY/mesh/remapping/remapping_mesh_vertices_to_grid.f90
@@ -47,6 +47,7 @@ contains
     type(type_sparse_matrix_CSR_dp)        :: A_xdy_g_b_CSR, A_mxydx_g_b_CSR, A_xydy_g_b_CSR
     type(tMat)                             :: w0, w1x, w1y
     character(len=1024)                    :: filename_grid, filename_mesh
+    integer                                :: perr
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -75,6 +76,10 @@ contains
     call check_remapping_matrix_validity( mesh, grid, map%M)
 
     call delete_grid_and_mesh_netcdf_dump_files( filename_grid, filename_mesh)
+
+    call MatDestroy( w0, perr)
+    call MatDestroy( w1x, perr)
+    call MatDestroy( w1y, perr)
 
     ! Finalise routine path
     call finalise_routine( routine_name)
@@ -516,6 +521,12 @@ contains
     ! M = (w0 * M_map_a_b) + (w1x * M_ddx_a_b) + (w1y * M_ddy_a_b)
     call MatMatMult( w1y, M_ddy_a_b, MAT_INITIAL_MATRIX, PETSC_DEFAULT_real, M2, perr)
     call MatAXPY( M, 1._dp, M2, DifFERENT_NONZERO_PATTERN, perr)
+
+    call MatDestroy( M_map_a_b, perr)
+    call MatDestroy( M_ddx_a_b, perr)
+    call MatDestroy( M_ddy_a_b, perr)
+    call MatDestroy( M1, perr)
+    call MatDestroy( M2, perr)
 
     ! Finalise routine path
     call finalise_routine( routine_name)


### PR DESCRIPTION
This should solve the vast majority of memory leaks, except for :
- on the order of 1 GB (in Antarctic automated test at 1 core, less when running on more cores) of memory that's not freed after the model finishes. As this doesn't affect the model run itself, and won't cause it to crash, I give this low priority.

Memory leaks were primarily created by the creation of temporary PETSc matrices (local tMat variables) which weren't destroyed. These accumulated due to annual reading and remapping of ISMIP7 forcing files.

Doing a last test now before opening the PR.

**update 1** YAY, memory leak reduced from 1.6 GB to 19 MB (negligible) with annual ocean forcing
**update 2** More good news: no significant memory leaks related to MPI
**update 3** Woohoo, also a coupled run with LADDIE showed no significant memory leaks.