### PR TITLE
Fix more memory leaks

### DIFF
--- a/src/UFEMISM/types/ice_model_types.f90
+++ b/src/UFEMISM/types/ice_model_types.f90
@@ -5,7 +5,6 @@ MODULE ice_model_types
 ! ===== Preamble =====
 ! ====================
 
-  USE petscksp                                               , ONLY: tMat
   USE precisions                                             , ONLY: dp
   use graph_types, only: type_graph_pair
   use mpi_f08, only: MPI_WIN
@@ -474,7 +473,7 @@ MODULE ice_model_types
     REAL(dp), DIMENSION(:    ), ALLOCATABLE :: divQ                        ! [m yr^-1] Horizontal ice flux divergence
     REAL(dp), DIMENSION(:    ), ALLOCATABLE :: R_shear                     ! [0-1]     uabs_base / uabs_surf (0 = pure vertical shear, viscous flow; 1 = pure sliding, plug flow)
     real(dp), dimension(:    ), allocatable :: Qspill                      ! [m yr^-1] Horizontal ice flux due to spill over of filled cells
-    real(dp), dimension(:,:  ), allocatable :: u_perp                      ! [m yr^-1] Perpendicular ice velocity to to edge. 
+    real(dp), dimension(:,:  ), allocatable :: u_perp                      ! [m yr^-1] Perpendicular ice velocity to to edge.
 
   ! == Basal hydrology ==
   ! =====================

--- a/src/UPSY/mesh/remapping/remapping_grid_to_mesh_vertices.f90
+++ b/src/UPSY/mesh/remapping/remapping_grid_to_mesh_vertices.f90
@@ -97,9 +97,9 @@ contains
       case default
         call crash('unknown method for grid_to_mesh remapping "' // trim( map%method) // '"')
       case ('1st_order_conservative')
-        map%M = M_cons_1st_order
+        call MatDuplicate( M_cons_1st_order, MAT_COPY_VALUES, map%M, perr)
       case ('2nd_order_conservative')
-        map%M = M_cons_2nd_order
+        call MatDuplicate( M_cons_2nd_order, MAT_COPY_VALUES, map%M, perr)
     end select
 
     call MatDestroy( w0, perr)

--- a/src/UPSY/mesh/remapping/remapping_grid_to_mesh_vertices.f90
+++ b/src/UPSY/mesh/remapping/remapping_grid_to_mesh_vertices.f90
@@ -98,17 +98,15 @@ contains
         call crash('unknown method for grid_to_mesh remapping "' // trim( map%method) // '"')
       case ('1st_order_conservative')
         map%M = M_cons_1st_order
-        ! Clean up the unused matrix
-        call MatDestroy( M_cons_2nd_order, perr)
       case ('2nd_order_conservative')
         map%M = M_cons_2nd_order
-        ! Clean up the unused matrix
-        call MatDestroy( M_cons_1st_order, perr)
     end select
 
     call MatDestroy( w0, perr)
     call MatDestroy( w1x, perr)
     call MatDestroy( w1y, perr)
+    call MatDestroy( M_cons_1st_order, perr)
+    call MatDestroy( M_cons_2nd_order, perr)
 
     call delete_grid_and_mesh_netcdf_dump_files( filename_grid, filename_mesh)
 

--- a/src/UPSY/mesh/remapping/remapping_mesh_to_mesh.f90
+++ b/src/UPSY/mesh/remapping/remapping_mesh_to_mesh.f90
@@ -254,15 +254,16 @@ contains
 
     call calc_remapping_matrix( mesh_src, w0, w1x, w1y, M_cons_1st_order, map%M)
 
+    call correct_mesh_to_mesh_map( mesh_src, mesh_dst, output_dir, M_cons_1st_order, map%M)
+
+    ! Clean up after yourself
     call MatDestroy( A_xdy_a_b, perr)
     call MatDestroy( A_mxydx_a_b, perr)
     call MatDestroy( A_xydy_a_b, perr)
-
     call MatDestroy( w0, perr)
     call MatDestroy( w1x, perr)
     call MatDestroy( w1y, perr)
-
-    call correct_mesh_to_mesh_map( mesh_src, mesh_dst, output_dir, M_cons_1st_order, map%M)
+    call MatDestroy( M_cons_1st_order, perr)
 
     ! Delete mesh netcdf dumps
     if (par%primary) then
@@ -317,15 +318,14 @@ contains
 
     call calc_remapping_matrix_tri( mesh_src, w0, w1x, w1y, M_cons_1st_order, map%M)
 
+    ! Clean up after yourself
     call MatDestroy( A_xdy, perr)
     call MatDestroy( A_mxydx, perr)
     call MatDestroy( A_xydy, perr)
-
     call MatDestroy( w0, perr)
     call MatDestroy( w1x, perr)
     call MatDestroy( w1y, perr)
-
-    ! call correct_mesh_to_mesh_map( mesh_src, mesh_dst, M_cons_1st_order, map%M)
+    call MatDestroy( M_cons_1st_order, perr)
 
     ! Delete mesh netcdf dumps
     if (par%primary) then

--- a/src/UPSY/types/remapping_types.f90
+++ b/src/UPSY/types/remapping_types.f90
@@ -17,6 +17,10 @@ module remapping_types
     character(len=1024) :: method    = ''       ! Remapping method (nearest-neighbour, bilinear, 2-nd order conservative, etc.)
     type(tMat)          :: M                    ! The actual operator matrix
 
+  contains
+
+    final :: finalise
+
   end type type_map
 
   type type_single_row_mapping_matrices
@@ -30,5 +34,11 @@ module remapping_types
   end type type_single_row_mapping_matrices
 
 contains
+
+  subroutine finalise( self)
+    type(type_map) :: self
+    integer :: perr
+    call MatDestroy( self%M, perr)
+  end subroutine finalise
 
 end module remapping_types


### PR DESCRIPTION
Fix some more PETSc matrix memory leaks, and add a 'final' procedure to type_map (see https://github.com/UPSY-group/UPSY-models/issues/625)