### PR TITLE
fix if statement for conda env

### DIFF
--- a/src/UPSY/basic/git_commit_hash_and_package_versions/add_git_commit_hash_and_package_versions_to_code.csh
+++ b/src/UPSY/basic/git_commit_hash_and_package_versions/add_git_commit_hash_and_package_versions_to_code.csh
@@ -35,10 +35,12 @@ endif
 set petsc_version = "UNKNOWN"
 
 # Try conda environment first if activated
-if ($?CONDA_PREFIX && "$CONDA_PREFIX" != "" && -f "$CONDA_PREFIX/lib/pkgconfig/PETSc.pc") then
-  set tmp = `sed -n 's/^Version: *//p' "$CONDA_PREFIX/lib/pkgconfig/PETSc.pc"`
-  if ("$tmp" != "") then
-    set petsc_version = "$tmp"
+if ($?CONDA_PREFIX) then
+  if ("$CONDA_PREFIX" != "" && -f "$CONDA_PREFIX/lib/pkgconfig/PETSc.pc") then
+    set tmp = `sed -n 's/^Version: *//p' "$CONDA_PREFIX/lib/pkgconfig/PETSc.pc"`
+    if ("$tmp" != "") then
+      set petsc_version = "$tmp"
+    endif
   endif
 endif
 


### PR DESCRIPTION
If no conda is present on a machine, the code failed to define the git hash. This should now be solved