### PR TITLE
Write/read CSR matrices to/from NetCDF

### DIFF
--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_solver_ocean_pressure.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_solver_ocean_pressure.f90
@@ -114,9 +114,6 @@ contains
 
     call setup_DIVA_solver_on_graphs( mesh, ice, DIVA)
 
-    ! DENK DROM
-    call save_graph_pair_as_netcdf( trim( C%output_dir)//'/DIVA_graphs', DIVA%DIVA_graphs%graphs)
-
     ! Calculate the driving stress and ocean back pressure
     call calc_driving_stress( DIVA%DIVA_graphs)
     call calc_ocean_back_pressure( DIVA%DIVA_graphs)

--- a/src/UPSY/UPSY_multinode_unit_test_program.f90
+++ b/src/UPSY/UPSY_multinode_unit_test_program.f90
@@ -19,6 +19,7 @@ program UPSY_multinode_unit_test_program
   use ut_halo_exchange, only: test_halo_exchange_main
   use ut_halo_exchange_mesh, only: test_mesh_halo_exchange_main
   use ut_mpi_CSR_matrix_algebra, only: test_CSR_matrix_algebra_main
+  use ut_netcdf_CSR_matrix, only: test_netcdf_CSR_matrix
 
   implicit none
 
@@ -66,6 +67,7 @@ program UPSY_multinode_unit_test_program
   call test_halo_exchange_main( test_name)
   call test_mesh_halo_exchange_main( test_name)
   call test_CSR_matrix_algebra_main( test_name)
+  call test_netcdf_CSR_matrix( test_name)
 
   ! Stop the clock
   tstop = MPI_WTIME()

--- a/src/UPSY/basic/CSR_matrix_algebra/CSR_matrix_mod.f90
+++ b/src/UPSY/basic/CSR_matrix_algebra/CSR_matrix_mod.f90
@@ -10,9 +10,11 @@ module CSR_matrix_mod
   use mpi_basic, only: par, sync
   use call_stack_and_comp_time_tracking, only: warning, crash, init_routine, finalise_routine
   use reallocate_mod, only: reallocate
-  use netcdf, only: NF90_INT, NF90_DOUBLE
-  use netcdf_basic_wrappers, only: create_dimension, create_variable
+  use netcdf, only: NF90_INT, NF90_DOUBLE, NF90_CREATE, NF90_NOCLOBBER, NF90_NETCDF4, NF90_DEF_DIM, &
+    NF90_DEF_VAR, NF90_INT, NF90_DOUBLE, NF90_PUT_VAR
+  use netcdf_basic_wrappers, only: create_dimension, create_variable, handle_netcdf_error
   use netcdf_write_var_primary, only: write_var_primary
+  use string_module, only: endswith, insert_val_into_string_int
 
   implicit none
 
@@ -48,20 +50,21 @@ module CSR_matrix_mod
 
       private
 
-      procedure, public  :: allocate          => allocate_matrix_CSR_dist
-      procedure, public  :: allocate_loc      => allocate_matrix_CSR_loc
-      procedure, public  :: deallocate        => deallocate_matrix_CSR_dist
-      procedure, public  :: duplicate         => duplicate_matrix_CSR_dist
-      procedure, public  :: add_entry         => add_entry_CSR_dist
-      procedure, public  :: add_empty_row     => add_empty_row_CSR_dist
-      procedure, public  :: gather_to_primary => gather_CSR_dist_to_primary
-      procedure, public  :: read_single_row   => read_single_row_CSR_dist
-      procedure, public  :: finalise          => finalise_matrix_CSR_dist
+      procedure, public  :: allocate               => allocate_matrix_CSR_dist
+      procedure, public  :: allocate_loc           => allocate_matrix_CSR_loc
+      procedure, public  :: deallocate             => deallocate_matrix_CSR_dist
+      procedure, public  :: duplicate              => duplicate_matrix_CSR_dist
+      procedure, public  :: add_entry              => add_entry_CSR_dist
+      procedure, public  :: add_empty_row          => add_empty_row_CSR_dist
+      procedure, public  :: gather_to_primary      => gather_CSR_dist_to_primary
+      procedure, public  :: read_single_row        => read_single_row_CSR_dist
+      procedure, public  :: finalise               => finalise_matrix_CSR_dist
       procedure, public  :: set_diagonal_to_one_and_rest_of_row_to_zero
-      procedure, public  :: write_to_NetCDF   => write_CSR_matrix_to_NetCDF
+      procedure, public  :: write_to_NetCDF        => write_CSR_matrix_to_NetCDF
+      procedure, public  :: write_to_dist_NetCDFs  => write_CSR_matrix_to_dist_NetCDFs
 
-      procedure, private :: extend            => extend_matrix_CSR_dist
-      procedure, private :: crop              => crop_matrix_CSR_dist
+      procedure, private :: extend                 => extend_matrix_CSR_dist
+      procedure, private :: crop                   => crop_matrix_CSR_dist
       procedure, private :: calc_j_node_range
       procedure, private :: set_row_to_value
       procedure, private :: set_row_diag_to_val
@@ -676,6 +679,79 @@ contains
     call finalise_routine( routine_name)
 
   end subroutine write_CSR_matrix_to_NetCDF
+
+  subroutine write_CSR_matrix_to_dist_NetCDFs( A, filename_base)
+    !< Write a CSR matrix to multiple NetCDF files (one for each process), including all the parallellisation info
+
+    ! In- and output variables:
+    class(type_CSR_matrix_dp), intent(in) :: A                !< The CSR matrix
+    character(len=*),          intent(in) :: filename_base    !< The name of the file
+
+    ! Local variables:
+    character(len=*), parameter   :: routine_name = 'write_CSR_matrix_to_dist_NetCDFs'
+    character(len=:), allocatable :: filename_base_sans_nc, filename_template, filename
+    integer                       :: ncid
+    integer                       :: id_dim_m, id_dim_n, id_dim_nnz
+    integer                       :: id_dim_m_loc, id_dim_m_locp1, id_dim_i1, id_dim_i2
+    integer                       :: id_dim_m_node, id_dim_i1_node, id_dim_i2_node
+    integer                       :: id_dim_n_loc, id_dim_j1, id_dim_j2
+    integer                       :: id_dim_n_node, id_dim_j1_node, id_dim_j2_node
+    integer                       :: id_var_ptr, id_var_ind, id_var_val
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Create a process-specific filename
+    if (endswith( filename_base, '.nc', case_sensitive = .false.)) then
+      filename_base_sans_nc = filename_base( 1: len_trim( filename_base)-3)
+    else
+      filename_base_sans_nc = filename_base( 1: len_trim( filename_base))
+    end if
+
+    filename_template = trim( filename_base_sans_nc) // '_proc_{proc}.nc'
+    filename = insert_val_into_string_int( filename_template, '{proc}', par%i)
+
+    ! Create a NetCDF file for each process
+    call handle_netcdf_error( NF90_CREATE( filename, ior( NF90_NOCLOBBER, NF90_NETCDF4), ncid), filename = filename)
+
+    ! Create dimensions and variables for the CSR matrix
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'm'         , A%m      , id_dim_m      ), filename = filename, dimvarname = 'm')
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'n'         , A%n      , id_dim_n      ), filename = filename, dimvarname = 'n')
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'nnz'       , A%nnz    , id_dim_nnz    ), filename = filename, dimvarname = 'nnz')
+
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'm_loc'     , A%m_loc  , id_dim_m_loc  ), filename = filename, dimvarname = 'm_loc')
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'm_locplus1', A%m_loc+1, id_dim_m_locp1), filename = filename, dimvarname = 'm_locplus1')
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'i1'        , A%i1     , id_dim_i1     ), filename = filename, dimvarname = 'i1')
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'i2'        , A%i2     , id_dim_i2     ), filename = filename, dimvarname = 'i2')
+
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'm_node'    , A%m_node , id_dim_m_node ), filename = filename, dimvarname = 'm_node')
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'i1_node'   , A%i1_node, id_dim_i1_node), filename = filename, dimvarname = 'i1_node')
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'i2_node'   , A%i2_node, id_dim_i2_node), filename = filename, dimvarname = 'i2_node')
+
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'n_loc'     , A%n_loc  , id_dim_n_loc  ), filename = filename, dimvarname = 'n_loc')
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'j1'        , A%j1     , id_dim_j1     ), filename = filename, dimvarname = 'j1')
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'j2'        , A%j2     , id_dim_j2     ), filename = filename, dimvarname = 'j2')
+
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'n_node'    , A%n_node , id_dim_n_node ), filename = filename, dimvarname = 'n_node')
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'j1_node'   , A%j1_node, id_dim_j1_node), filename = filename, dimvarname = 'j1_node')
+    call handle_netcdf_error( NF90_DEF_DIM( ncid, 'j2_node'   , A%j2_node, id_dim_j2_node), filename = filename, dimvarname = 'j2_node')
+
+    call handle_netcdf_error( NF90_DEF_VAR( ncid, name = 'ptr', xtype = NF90_INT, &
+      dimids = [id_dim_m_locp1], varid = id_var_ptr), filename = filename, dimvarname = 'ptr')
+    call handle_netcdf_error( NF90_DEF_VAR( ncid, name = 'ind', xtype = NF90_INT, &
+      dimids = [id_dim_nnz    ], varid = id_var_ind), filename = filename, dimvarname = 'ind')
+    call handle_netcdf_error( NF90_DEF_VAR( ncid, name = 'val', xtype = NF90_DOUBLE, &
+      dimids = [id_dim_nnz    ], varid = id_var_val), filename = filename, dimvarname = 'val')
+
+    ! Write data to the NetCDF file
+    call handle_netcdf_error( NF90_PUT_VAR( ncid, id_var_ptr, A%ptr), filename = filename, dimvarname = 'ptr')
+    call handle_netcdf_error( NF90_PUT_VAR( ncid, id_var_ind, A%ind), filename = filename, dimvarname = 'ind')
+    call handle_netcdf_error( NF90_PUT_VAR( ncid, id_var_val, A%val), filename = filename, dimvarname = 'val')
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine write_CSR_matrix_to_dist_NetCDFs
 
   ! ===== CSR matrices in local memory =====
   ! ========================================

--- a/src/UPSY/basic/CSR_matrix_algebra/CSR_matrix_mod.f90
+++ b/src/UPSY/basic/CSR_matrix_algebra/CSR_matrix_mod.f90
@@ -11,10 +11,12 @@ module CSR_matrix_mod
   use call_stack_and_comp_time_tracking, only: warning, crash, init_routine, finalise_routine
   use reallocate_mod, only: reallocate
   use netcdf, only: NF90_INT, NF90_DOUBLE, NF90_CREATE, NF90_NOCLOBBER, NF90_NETCDF4, NF90_DEF_DIM, &
-    NF90_DEF_VAR, NF90_INT, NF90_DOUBLE, NF90_PUT_VAR
+    NF90_DEF_VAR, NF90_INT, NF90_DOUBLE, NF90_PUT_VAR, NF90_OPEN, NF90_CLOSE, NF90_NOWRITE, &
+    NF90_INQ_DIMID, NF90_INQUIRE_DIMENSION, NF90_INQ_VARID, NF90_GET_VAR
   use netcdf_basic_wrappers, only: create_dimension, create_variable, handle_netcdf_error
   use netcdf_write_var_primary, only: write_var_primary
   use string_module, only: endswith, insert_val_into_string_int
+  use crash_mod, only: warning
 
   implicit none
 
@@ -62,6 +64,7 @@ module CSR_matrix_mod
       procedure, public  :: set_diagonal_to_one_and_rest_of_row_to_zero
       procedure, public  :: write_to_NetCDF        => write_CSR_matrix_to_NetCDF
       procedure, public  :: write_to_dist_NetCDFs  => write_CSR_matrix_to_dist_NetCDFs
+      procedure, public  :: read_from_dist_NetCDFs => read_CSR_matrix_from_dist_NetCDFs
 
       procedure, private :: extend                 => extend_matrix_CSR_dist
       procedure, private :: crop                   => crop_matrix_CSR_dist
@@ -748,10 +751,103 @@ contains
     call handle_netcdf_error( NF90_PUT_VAR( ncid, id_var_ind, A%ind), filename = filename, dimvarname = 'ind')
     call handle_netcdf_error( NF90_PUT_VAR( ncid, id_var_val, A%val), filename = filename, dimvarname = 'val')
 
+    call handle_netcdf_error( NF90_CLOSE( ncid))
+
     ! Finalise routine path
     call finalise_routine( routine_name)
 
   end subroutine write_CSR_matrix_to_dist_NetCDFs
+
+  subroutine read_CSR_matrix_from_dist_NetCDFs( A, filename_base)
+    !< Read a CSR matrix from multiple NetCDF files (one for each process)
+
+    ! In- and output variables:
+    class(type_CSR_matrix_dp), intent(inout) :: A                !< The CSR matrix
+    character(len=*),          intent(in   ) :: filename_base    !< The name of the file
+
+    ! Local variables:
+    character(len=*), parameter   :: routine_name = 'read_CSR_matrix_from_dist_NetCDFs'
+    character(len=:), allocatable :: filename_base_sans_nc, filename_template, filename
+    logical                       :: file_exists
+    integer                       :: ncid
+    integer                       :: id_var_ptr, id_var_ind, id_var_val
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Deallocate any memory that was already allocated for A
+    call A%deallocate
+
+    ! Create a process-specific filename
+    if (endswith( filename_base, '.nc', case_sensitive = .false.)) then
+      filename_base_sans_nc = filename_base( 1: len_trim( filename_base)-3)
+    else
+      filename_base_sans_nc = filename_base( 1: len_trim( filename_base))
+    end if
+
+    filename_template = trim( filename_base_sans_nc) // '_proc_{proc}.nc'
+    filename = insert_val_into_string_int( filename_template, '{proc}', par%i)
+
+    ! Check if this file actually exists
+    inquire( exist = file_exists, file = trim( filename))
+    if (.not. file_exists) call crash('file "' // trim( filename) // '" not found!')
+
+    ! Open the NetCDF file with read-only access
+    call handle_netcdf_error( NF90_OPEN( trim( filename), NF90_NOWRITE, ncid), filename = filename)
+
+    ! Read matrix dimensions
+    call inq_CSR_NetCDF_dim( filename, ncid, 'm'      , A%m      )
+    call inq_CSR_NetCDF_dim( filename, ncid, 'n'      , A%n      )
+    call inq_CSR_NetCDF_dim( filename, ncid, 'nnz'    , A%nnz    )
+    A%nnz_max = A%nnz
+
+    call inq_CSR_NetCDF_dim( filename, ncid, 'm_loc'  , A%m_loc  )
+    call inq_CSR_NetCDF_dim( filename, ncid, 'i1'     , A%i1     )
+    call inq_CSR_NetCDF_dim( filename, ncid, 'i2'     , A%i2     )
+
+    call inq_CSR_NetCDF_dim( filename, ncid, 'm_node' , A%m_node )
+    call inq_CSR_NetCDF_dim( filename, ncid, 'i1_node', A%i1_node)
+    call inq_CSR_NetCDF_dim( filename, ncid, 'i2_node', A%i2_node)
+
+    call inq_CSR_NetCDF_dim( filename, ncid, 'n_loc'  , A%n_loc  )
+    call inq_CSR_NetCDF_dim( filename, ncid, 'j1'     , A%j1     )
+    call inq_CSR_NetCDF_dim( filename, ncid, 'j2'     , A%j2     )
+
+    call inq_CSR_NetCDF_dim( filename, ncid, 'n_node' , A%n_node )
+    call inq_CSR_NetCDF_dim( filename, ncid, 'j1_node', A%j1_node)
+    call inq_CSR_NetCDF_dim( filename, ncid, 'j2_node', A%j2_node)
+
+    ! Allocate memory for A
+    allocate( A%ptr( A%i1: A%i2+1), source = 1)
+    allocate( A%ind( A%nnz_max), source = 0    )
+    allocate( A%val( A%nnz_max), source = 0._dp)
+
+    ! Read matrix data from the NetCDF file
+    call handle_netcdf_error( NF90_INQ_VARID( ncid, 'ptr', id_var_ptr))
+    call handle_netcdf_error( NF90_GET_VAR( ncid, id_var_ptr, A%ptr), filename = filename, dimvarname = 'ptr')
+    call handle_netcdf_error( NF90_INQ_VARID( ncid, 'ind', id_var_ind))
+    call handle_netcdf_error( NF90_GET_VAR( ncid, id_var_ind, A%ind), filename = filename, dimvarname = 'ind')
+    call handle_netcdf_error( NF90_INQ_VARID( ncid, 'val', id_var_val))
+    call handle_netcdf_error( NF90_GET_VAR( ncid, id_var_val, A%val), filename = filename, dimvarname = 'val')
+
+    call handle_netcdf_error( NF90_CLOSE( ncid))
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine read_CSR_matrix_from_dist_NetCDFs
+
+  subroutine inq_CSR_NetCDF_dim( filename, ncid, dim_name, dim_length)
+    character(len=*), intent(in   ) :: filename
+    integer,          intent(in   ) :: ncid
+    character(len=*), intent(in   ) :: dim_name
+    integer,          intent(  out) :: dim_length
+    integer :: id_dim
+    call handle_netcdf_error( NF90_INQ_DIMID( ncid, dim_name, id_dim), &
+      filename = filename, dimvarname = dim_name)
+    call handle_netcdf_error( NF90_INQUIRE_DIMENSION( ncid, id_dim, len = dim_length), &
+      filename = filename, dimvarname = dim_name)
+  end subroutine inq_CSR_NetCDF_dim
 
   ! ===== CSR matrices in local memory =====
   ! ========================================

--- a/src/UPSY/basic/CSR_matrix_algebra/CSR_matrix_mod.f90
+++ b/src/UPSY/basic/CSR_matrix_algebra/CSR_matrix_mod.f90
@@ -8,10 +8,11 @@ module CSR_matrix_mod
     MPI_STATUS, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_ALLREDUCE, MPI_MIN, MPI_MAX, MPI_IN_PLACE, &
     MPI_LOGICAL, MPI_LOR
   use mpi_basic, only: par, sync
-  use call_stack_and_comp_time_tracking, only: warning, crash, happy, init_routine, finalise_routine, colour_string
-  use parameters
+  use call_stack_and_comp_time_tracking, only: warning, crash, init_routine, finalise_routine
   use reallocate_mod, only: reallocate
-  use mpi_distributed_memory, only: partition_list, gather_to_all
+  use netcdf, only: NF90_INT, NF90_DOUBLE
+  use netcdf_basic_wrappers, only: create_dimension, create_variable
+  use netcdf_write_var_primary, only: write_var_primary
 
   implicit none
 
@@ -57,6 +58,7 @@ module CSR_matrix_mod
       procedure, public  :: read_single_row   => read_single_row_CSR_dist
       procedure, public  :: finalise          => finalise_matrix_CSR_dist
       procedure, public  :: set_diagonal_to_one_and_rest_of_row_to_zero
+      procedure, public  :: write_to_NetCDF   => write_CSR_matrix_to_NetCDF
 
       procedure, private :: extend            => extend_matrix_CSR_dist
       procedure, private :: crop              => crop_matrix_CSR_dist
@@ -636,6 +638,44 @@ contains
       end if
     end do
   end subroutine set_row_diag_to_val
+
+  subroutine write_CSR_matrix_to_NetCDF( A, filename, ncid)
+    !< Write a CSR matrix to a NetCDF file (or a group therein)
+
+    ! In- and output variables:
+    class(type_CSR_matrix_dp), intent(in) :: A           !< The CSR matrix
+    character(len=*),          intent(in) :: filename    !< The name of the file (only used for error messaging)
+    integer,                   intent(in) :: ncid        !< ID of a file, or a group within a file
+
+    ! Local variables:
+    character(len=*), parameter :: routine_name = 'write_CSR_matrix_to_NetCDF'
+    integer                     :: id_dim_m, id_dim_mp1, id_dim_n, id_dim_nnz, id_var_ptr, id_var_ind, id_var_val
+    type(type_CSR_matrix_dp)    :: A_tot
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Create dimensions
+    call create_dimension( filename, ncid, 'm'     , A%m  , id_dim_m  )
+    call create_dimension( filename, ncid, 'mplus1', A%m+1, id_dim_mp1)
+    call create_dimension( filename, ncid, 'n'     , A%n  , id_dim_n  )
+    call create_dimension( filename, ncid, 'nnz'   , A%nnz, id_dim_nnz)
+
+    ! Create variables
+    call create_variable( filename, ncid, 'ptr', NF90_INT   , [id_dim_mp1], id_var_ptr)
+    call create_variable( filename, ncid, 'ind', NF90_INT   , [id_dim_nnz], id_var_ind)
+    call create_variable( filename, ncid, 'val', NF90_DOUBLE, [id_dim_nnz], id_var_val)
+
+    ! Write variables
+    call A%gather_to_primary( A_tot)
+    call write_var_primary( filename, ncid, id_var_ptr, A_tot%ptr              )
+    call write_var_primary( filename, ncid, id_var_ind, A_tot%ind( 1:A_tot%nnz))
+    call write_var_primary( filename, ncid, id_var_val, A_tot%val( 1:A_tot%nnz))
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine write_CSR_matrix_to_NetCDF
 
   ! ===== CSR matrices in local memory =====
   ! ========================================

--- a/src/UPSY/basic/git_commit_hash_and_package_versions/git_commit_hash_and_package_versions.f90
+++ b/src/UPSY/basic/git_commit_hash_and_package_versions/git_commit_hash_and_package_versions.f90
@@ -18,13 +18,13 @@ module git_commit_hash_and_package_versions
   public :: compiler_flags
 
   ! These parameters will be set automatically when compiling the code!
-  character(len=*), parameter :: git_commit_hash         = 'INVALID'
-  logical,          parameter :: has_uncommitted_changes = .false.
-  character(len=*), parameter :: petsc_version           = 'INVALID'
-  character(len=*), parameter :: netcdf_version          = 'INVALID'
-  character(len=*), parameter :: openmpi_version         = 'INVALID'
-  character(len=*), parameter :: compiler_version        = 'INVALID'
-  character(len=*), parameter :: compiler_flags          = 'INVALID'
+  character(len=*), parameter :: git_commit_hash         = 'a480bf4388f37a0e7a00068dbc4adb1d2601ca83'
+  logical,          parameter :: has_uncommitted_changes = .true.
+  character(len=*), parameter :: petsc_version           = '3.24.6'
+  character(len=*), parameter :: netcdf_version          = '4.10.0'
+  character(len=*), parameter :: openmpi_version         = '5.0.9'
+  character(len=*), parameter :: compiler_version        = 'GNU Fortran (Homebrew GCC 15.2.0_1) 15.2.0'
+  character(len=*), parameter :: compiler_flags          = '-fdiagnostics-color=always -Og -Wall -ffree-line-length-none -cpp -Werror=implicit-interface -fimplicit-none -g -march=native -fcheck=all -fbacktrace -finit-real=nan -finit-integer=-42 -finit-character=33'
 
 contains
 

--- a/src/UPSY/basic/git_commit_hash_and_package_versions/git_commit_hash_and_package_versions.f90
+++ b/src/UPSY/basic/git_commit_hash_and_package_versions/git_commit_hash_and_package_versions.f90
@@ -18,13 +18,13 @@ module git_commit_hash_and_package_versions
   public :: compiler_flags
 
   ! These parameters will be set automatically when compiling the code!
-  character(len=*), parameter :: git_commit_hash         = 'a480bf4388f37a0e7a00068dbc4adb1d2601ca83'
-  logical,          parameter :: has_uncommitted_changes = .true.
-  character(len=*), parameter :: petsc_version           = '3.24.6'
-  character(len=*), parameter :: netcdf_version          = '4.10.0'
-  character(len=*), parameter :: openmpi_version         = '5.0.9'
-  character(len=*), parameter :: compiler_version        = 'GNU Fortran (Homebrew GCC 15.2.0_1) 15.2.0'
-  character(len=*), parameter :: compiler_flags          = '-fdiagnostics-color=always -Og -Wall -ffree-line-length-none -cpp -Werror=implicit-interface -fimplicit-none -g -march=native -fcheck=all -fbacktrace -finit-real=nan -finit-integer=-42 -finit-character=33'
+  character(len=*), parameter :: git_commit_hash         = 'INVALID'
+  logical,          parameter :: has_uncommitted_changes = .false.
+  character(len=*), parameter :: petsc_version           = 'INVALID'
+  character(len=*), parameter :: netcdf_version          = 'INVALID'
+  character(len=*), parameter :: openmpi_version         = 'INVALID'
+  character(len=*), parameter :: compiler_version        = 'INVALID'
+  character(len=*), parameter :: compiler_flags          = 'INVALID'
 
 contains
 

--- a/src/UPSY/basic/string_module.f90
+++ b/src/UPSY/basic/string_module.f90
@@ -10,7 +10,7 @@ module string_module
   public :: type_string_utilities
   public :: separate_strings_by_double_vertical_bars, colour_string, &
     insert_val_into_string_int, insert_val_into_string_dp, capitalise_string, &
-    remove_leading_spaces, str2int, int2str_with_leading_zeros, strrep, startswith
+    remove_leading_spaces, str2int, int2str_with_leading_zeros, strrep, startswith, endswith
 
   type type_string_utilities
       private

--- a/src/UPSY/io/netcdf_basic/netcdf_save_single_variables.f90
+++ b/src/UPSY/io/netcdf_basic/netcdf_save_single_variables.f90
@@ -18,93 +18,10 @@ module netcdf_save_single_variables
 
   private
 
-  public :: write_CSR_matrix_to_NetCDF, write_PETSc_matrix_to_NetCDF, &
-    save_variable_as_netcdf_logical_1D, save_variable_as_netcdf_int_1D, save_variable_as_netcdf_int_2D, &
+  public :: save_variable_as_netcdf_logical_1D, save_variable_as_netcdf_int_1D, save_variable_as_netcdf_int_2D, &
     save_variable_as_netcdf_dp_1D, save_variable_as_netcdf_dp_2D
 
 contains
-
-  subroutine write_PETSc_matrix_to_NetCDF( output_dir, A, filename)
-    !< Write a PETSc matrix to a NetCDF file
-
-    ! In- and output variables:
-    character(len=*), intent(in) :: output_dir
-    type(tMat),       intent(in) :: A
-    character(len=*), intent(in) :: filename
-
-    ! Local variables:
-    character(len=256), parameter   :: routine_name = 'write_PETSc_matrix_to_NetCDF'
-    type(type_CSR_matrix_dp) :: AA
-
-    ! Add routine to path
-    call init_routine( routine_name)
-
-    ! Get matrix in CSR format using native Fortran arrays
-    call mat_petsc2CSR( A, AA)
-
-    ! Write the CSR matrix to a file
-    call write_CSR_matrix_to_NetCDF( output_dir, AA, filename)
-
-    ! Clean up after yourself
-    call AA%deallocate
-
-    ! Finalise routine path
-    call finalise_routine( routine_name)
-
-  end subroutine write_PETSc_matrix_to_NetCDF
-
-  subroutine write_CSR_matrix_to_NetCDF( output_dir, AA, filename)
-    !< Write a CSR matrix to a NetCDF file
-
-    ! In- and output variables:
-    character(len=*),                intent(in) :: output_dir
-    type(type_CSR_matrix_dp), intent(in) :: AA
-    character(len=*),                intent(in) :: filename
-
-    ! Local variables:
-    character(len=256), parameter   :: routine_name = 'write_CSR_matrix_to_NetCDF'
-    character(len=256)              :: filename_applied
-    integer                         :: ncid
-    integer                         :: id_dim_m, id_dim_mp1, id_dim_n, id_dim_nnz
-    integer                         :: id_var_ptr, id_var_ind, id_var_val
-    type(type_CSR_matrix_dp) :: AA_tot
-
-    ! Add routine to path
-    call init_routine( routine_name)
-
-    ! Gather distributed matrix to the primary
-    call AA%gather_to_primary( AA_tot)
-
-    ! Append output directory to filename
-    filename_applied = trim( output_dir) // '/' // trim( filename) // '.nc'
-    call delete_existing_file( filename_applied)
-
-    ! Create a new NetCDF file
-    call create_new_netcdf_file_for_writing( filename_applied, ncid)
-
-    ! Create dimensions
-    call create_dimension( filename_applied, ncid, 'm'     , AA_tot%m  , id_dim_m  )
-    call create_dimension( filename_applied, ncid, 'mplus1', AA_tot%m+1, id_dim_mp1)
-    call create_dimension( filename_applied, ncid, 'n'     , AA_tot%n  , id_dim_n  )
-    call create_dimension( filename_applied, ncid, 'nnz'   , AA_tot%nnz, id_dim_nnz)
-
-    ! Create variables
-    call create_variable( filename_applied, ncid, 'ptr', NF90_INT   , [id_dim_mp1], id_var_ptr)
-    call create_variable( filename_applied, ncid, 'ind', NF90_INT   , [id_dim_nnz], id_var_ind)
-    call create_variable( filename_applied, ncid, 'val', NF90_DOUBLE, [id_dim_nnz], id_var_val)
-
-    ! Write to NetCDF
-    call write_var_primary( filename_applied, ncid, id_var_ptr, AA_tot%ptr               )
-    call write_var_primary( filename_applied, ncid, id_var_ind, AA_tot%ind( 1:AA_tot%nnz))
-    call write_var_primary(  filename_applied, ncid, id_var_val, AA_tot%val( 1:AA_tot%nnz))
-
-    ! Close the NetCDF file
-    call close_netcdf_file( ncid)
-
-    ! Finalise routine path
-    call finalise_routine( routine_name)
-
-  end subroutine write_CSR_matrix_to_NetCDF
 
   subroutine save_variable_as_netcdf_logical_1D( output_dir, d_partial, field_name)
     !< Save a single variable to a NetCDF file

--- a/src/UPSY/io/netcdf_output/netcdf_setup_grid_mesh_in_file.f90
+++ b/src/UPSY/io/netcdf_output/netcdf_setup_grid_mesh_in_file.f90
@@ -14,9 +14,8 @@ module netcdf_setup_grid_mesh_in_file
 
   private
 
+  public :: save_xy_grid_as_netcdf, save_mesh_as_netcdf, save_graph_as_netcdf
   public :: setup_xy_grid_in_netcdf_file, setup_mesh_in_netcdf_file, setup_graph_in_netcdf_file, write_matrix_operators_to_netcdf_file
-  public :: save_xy_grid_as_netcdf, save_mesh_as_netcdf, save_graph_as_netcdf, save_graph_pair_as_netcdf
-  public :: save_matrix_operator_as_netcdf_file
 
 contains
 
@@ -85,44 +84,6 @@ contains
     call finalise_routine( routine_name)
 
   end subroutine save_graph_as_netcdf
-
-  subroutine save_graph_pair_as_netcdf( filename, graphs)
-
-    ! In/output variables:
-    character(len=*),      intent(in   ) :: filename
-    type(type_graph_pair), intent(in   ) :: graphs
-
-    ! Local variables:
-    character(len=1024), parameter :: routine_name = 'save_graph_pair_as_netcdf'
-    integer                        :: ncid
-
-    ! Add routine to path
-    call init_routine( routine_name)
-
-    call save_graph_as_netcdf( trim( filename) // '_graph_a.nc', graphs%graph_a)
-    call save_graph_as_netcdf( trim( filename) // '_graph_b.nc', graphs%graph_b)
-
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M_ddx_b_b.nc'    , graphs%M_ddx_b_b    )
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M_ddy_b_b.nc'    , graphs%M_ddy_b_b    )
-
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M2_ddx_b_b.nc'   , graphs%M2_ddx_b_b   )
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M2_ddy_b_b.nc'   , graphs%M2_ddy_b_b   )
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M2_d2dx2_b_b.nc' , graphs%M2_d2dx2_b_b )
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M2_d2dxdy_b_b.nc', graphs%M2_d2dxdy_b_b)
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M2_d2dy2_b_b.nc' , graphs%M2_d2dy2_b_b )
-
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M_map_a_b.nc'    , graphs%M_map_a_b    )
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M_ddx_a_b.nc'    , graphs%M_ddx_a_b    )
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M_ddy_a_b.nc'    , graphs%M_ddy_a_b    )
-
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M_map_b_a.nc'    , graphs%M_map_b_a    )
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M_ddx_b_a.nc'    , graphs%M_ddx_b_a    )
-    call save_matrix_operator_as_netcdf_file( trim( filename) // '_M_ddy_b_a.nc'    , graphs%M_ddy_b_a    )
-
-    ! Finalise routine path
-    call finalise_routine( routine_name)
-
-  end subroutine save_graph_pair_as_netcdf
 
   subroutine setup_xy_grid_in_netcdf_file( filename, ncid, grid, do_include_lonlat)
     !< Set up a regular x/y-grid in an existing NetCDF file
@@ -884,88 +845,25 @@ contains
     !< Write a single matrix operator to the netcdf output file
 
     ! In/output variables:
-    character(len=*),                 intent(in   ) :: filename
-    integer,                          intent(inout) :: ncid
+    character(len=*),          intent(in   ) :: filename
+    integer,                   intent(inout) :: ncid
     type(type_CSR_matrix_dp),  intent(in   ) :: A
-    character(len=*),                 intent(in   ) :: name
+    character(len=*),          intent(in   ) :: name
 
     ! Local variables:
     character(len=1024), parameter  :: routine_name = 'write_matrix_operator_to_netcdf_file'
-    type(type_CSR_matrix_dp)        :: A_tot
-    integer                         :: ierr
-    integer                         :: grp_ncid, id_dim_m, id_dim_mp1, id_dim_n, id_dim_nnz
-    integer                         :: id_var_ptr, id_var_ind, id_var_val
+    integer                         :: grp_ncid
 
     call init_routine( routine_name)
 
-    ! Gather distributed matrix to the primary
-    call A%gather_to_primary( A_tot)
-
     ! Create a new NetCDF group for this matrix operator
-    ierr = NF90_DEF_GRP( ncid, name, grp_ncid)
+    call handle_netcdf_error( NF90_DEF_GRP( ncid, name, grp_ncid))
 
-    ! Create dimensions
-    call create_dimension( filename, grp_ncid, 'm'     , A_tot%m  , id_dim_m  )
-    call create_dimension( filename, grp_ncid, 'mplus1', A_tot%m+1, id_dim_mp1)
-    call create_dimension( filename, grp_ncid, 'n'     , A_tot%n  , id_dim_n  )
-    call create_dimension( filename, grp_ncid, 'nnz'   , A_tot%nnz, id_dim_nnz)
-
-    ! Create variables
-    call create_variable( filename, grp_ncid, 'ptr', NF90_INT   , [id_dim_mp1], id_var_ptr)
-    call create_variable( filename, grp_ncid, 'ind', NF90_INT   , [id_dim_nnz], id_var_ind)
-    call create_variable( filename, grp_ncid, 'val', NF90_DOUBLE, [id_dim_nnz], id_var_val)
-
-    ! Write to NetCDF
-    call write_var_primary( filename, grp_ncid, id_var_ptr, A_tot%ptr              )
-    call write_var_primary( filename, grp_ncid, id_var_ind, A_tot%ind( 1:A_tot%nnz))
-    call write_var_primary( filename, grp_ncid, id_var_val, A_tot%val( 1:A_tot%nnz))
+    ! Write the matrix to the group
+    call A%write_to_NetCDF( filename, grp_ncid)
 
     call finalise_routine( routine_name)
 
   end subroutine write_matrix_operator_to_netcdf_file
-
-  subroutine save_matrix_operator_as_netcdf_file( filename, A)
-    !< Save a single matrix operator as a netcdf file
-
-    ! In/output variables:
-    character(len=*),                intent(in) :: filename
-    type(type_CSR_matrix_dp), intent(in) :: A
-
-    ! Local variables:
-    character(len=1024), parameter  :: routine_name = 'save_matrix_operator_as_netcdf_file'
-    integer                         :: ncid
-    type(type_CSR_matrix_dp) :: A_tot
-    integer                         :: ierr
-    integer                         :: id_dim_m, id_dim_mp1, id_dim_n, id_dim_nnz
-    integer                         :: id_var_ptr, id_var_ind, id_var_val
-
-    call init_routine( routine_name)
-
-    call create_new_netcdf_file_for_writing( filename, ncid)
-
-    ! Gather distributed matrix to the primary
-    call A%gather_to_primary( A_tot)
-
-    ! Create dimensions
-    call create_dimension( filename, ncid, 'm'     , A_tot%m  , id_dim_m  )
-    call create_dimension( filename, ncid, 'mplus1', A_tot%m+1, id_dim_mp1)
-    call create_dimension( filename, ncid, 'n'     , A_tot%n  , id_dim_n  )
-    call create_dimension( filename, ncid, 'nnz'   , A_tot%nnz, id_dim_nnz)
-
-    ! Create variables
-    call create_variable( filename, ncid, 'ptr', NF90_INT   , [id_dim_mp1], id_var_ptr)
-    call create_variable( filename, ncid, 'ind', NF90_INT   , [id_dim_nnz], id_var_ind)
-    call create_variable( filename, ncid, 'val', NF90_DOUBLE, [id_dim_nnz], id_var_val)
-
-    ! Write to NetCDF
-    call write_var_primary( filename, ncid, id_var_ptr, A_tot%ptr              )
-    call write_var_primary( filename, ncid, id_var_ind, A_tot%ind( 1:A_tot%nnz))
-    call write_var_primary( filename, ncid, id_var_val, A_tot%val( 1:A_tot%nnz))
-
-    call close_netcdf_file( ncid)
-
-    call finalise_routine( routine_name)
-
-  end subroutine save_matrix_operator_as_netcdf_file
 
 end module netcdf_setup_grid_mesh_in_file

--- a/src/UPSY/validation/unit_tests/ut_mpi_CSR_matrix_vector_multiplication.f90
+++ b/src/UPSY/validation/unit_tests/ut_mpi_CSR_matrix_vector_multiplication.f90
@@ -18,7 +18,8 @@ module ut_mpi_CSR_matrix_vector_multiplication
 
   private
 
-  public :: test_CSR_matrix_vector_multiplication_main
+  public :: test_CSR_matrix_vector_multiplication_main, initialise_simple_matrix_equation_1, &
+    initialise_simple_matrix_equation_2
 
 contains
 

--- a/src/UPSY/validation/unit_tests/ut_netcdf_CSR_matrix.f90
+++ b/src/UPSY/validation/unit_tests/ut_netcdf_CSR_matrix.f90
@@ -1,0 +1,106 @@
+module ut_netcdf_CSR_matrix
+
+  ! Unit tests for the netcdf i/o - CSR matrix routines
+
+  use tests_main
+  use ut_basic
+  use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine
+  use precisions, only: dp
+  use CSR_matrix_mod, only: type_CSR_matrix_dp
+  use ut_mpi_CSR_matrix_vector_multiplication, only: initialise_simple_matrix_equation_1, &
+    initialise_simple_matrix_equation_2
+  use model_configuration, only: C
+
+  implicit none
+
+  private
+
+  public :: test_netcdf_CSR_matrix
+
+contains
+
+  subroutine test_netcdf_CSR_matrix( test_name_parent)
+    ! Test the netcdf i/o subroutines for x/y-gridded data
+
+    ! In/output variables:
+    character(len=*), intent(in) :: test_name_parent
+
+    ! Local variables:
+    character(len=*), parameter   :: routine_name = 'test_netcdf_CSR_matrix'
+    character(len=*), parameter   :: test_name_local = 'CSR_matrix_NetCDF'
+    character(len=:), allocatable :: test_name
+    type(type_CSR_matrix_dp)      :: A1, A2
+    real(dp), dimension(1)        :: x1, x2, y1, y2
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Add test name to list
+    test_name = trim( test_name_parent) // '/' // trim( test_name_local)
+
+    call initialise_simple_matrix_equation_1( A1, x1, y1)
+    call initialise_simple_matrix_equation_2( A2, x2, y2)
+
+    call test_netcdf_CSR_single_matrix( test_name, A1, '1')
+    call test_netcdf_CSR_single_matrix( test_name, A2, '2')
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine test_netcdf_CSR_matrix
+
+  subroutine test_netcdf_CSR_single_matrix( test_name_parent, A, test_number)
+    ! Test the netcdf i/o subroutines for x/y-gridded data
+
+    ! In/output variables:
+    character(len=*),         intent(in) :: test_name_parent
+    type(type_CSR_matrix_dp), intent(in) :: A
+    character(len=*),         intent(in) :: test_number
+
+    ! Local variables:
+    character(len=*), parameter   :: routine_name = 'test_netcdf_CSR_single_matrix'
+    character(len=*), parameter   :: test_name_local = 'CSR_matrix_NetCDF'
+    character(len=:), allocatable :: test_name
+    character(len=:), allocatable :: filename_base
+    type(type_CSR_matrix_dp)      :: A_from_file
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Add test name to list
+    test_name = trim( test_name_parent) // '/' // trim( test_name_local)
+
+    filename_base = trim( C%output_dir) // '/A_' // test_number // '.nc'
+    call A%write_to_dist_NetCDFs( filename_base)
+    call A_from_file%read_from_dist_NetCDFs( filename_base)
+
+    call unit_test( test_eq( A%m      , A_from_file%m      ), trim( test_name) // '_' // test_number // '_m')
+    call unit_test( test_eq( A%n      , A_from_file%n      ), trim( test_name) // '_' // test_number // '_n')
+    call unit_test( test_eq( A%nnz    , A_from_file%nnz    ), trim( test_name) // '_' // test_number // '_nnz')
+
+    call unit_test( test_eq( A%m_loc  , A_from_file%m_loc  ), trim( test_name) // '_' // test_number // '_m_loc')
+    call unit_test( test_eq( A%i1     , A_from_file%i1     ), trim( test_name) // '_' // test_number // '_i1')
+    call unit_test( test_eq( A%i2     , A_from_file%i2     ), trim( test_name) // '_' // test_number // '_i2')
+
+    call unit_test( test_eq( A%m_node , A_from_file%m_node ), trim( test_name) // '_' // test_number // '_m_node')
+    call unit_test( test_eq( A%i1_node, A_from_file%i1_node), trim( test_name) // '_' // test_number // '_i1_node')
+    call unit_test( test_eq( A%i2_node, A_from_file%i2_node), trim( test_name) // '_' // test_number // '_i2_node')
+
+    call unit_test( test_eq( A%n_loc  , A_from_file%n_loc  ), trim( test_name) // '_' // test_number // '_n_loc')
+    call unit_test( test_eq( A%j1     , A_from_file%j1     ), trim( test_name) // '_' // test_number // '_j1')
+    call unit_test( test_eq( A%j2     , A_from_file%j2     ), trim( test_name) // '_' // test_number // '_j2')
+
+    call unit_test( test_eq( A%n_node , A_from_file%n_node ), trim( test_name) // '_' // test_number // '_n_node')
+    call unit_test( test_eq( A%j1_node, A_from_file%j1_node), trim( test_name) // '_' // test_number // '_j1_node')
+    call unit_test( test_eq( A%j2_node, A_from_file%j2_node), trim( test_name) // '_' // test_number // '_j2_node')
+
+    call unit_test( test_eq( A%ptr(A%i1:A%i2), A_from_file%ptr(A%i1:A%i2)), trim( test_name) // '_' // test_number // '_ptr')
+    call unit_test( test_eq( A%ind           , A_from_file%ind           ), trim( test_name) // '_' // test_number // '_ind')
+    call unit_test( test_eq( A%val           , A_from_file%val           ), trim( test_name) // '_' // test_number // '_val')
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine test_netcdf_CSR_single_matrix
+
+end module ut_netcdf_CSR_matrix


### PR DESCRIPTION
Add code to write a CSR matrix to a set of NetCDF files (one for each process, including parallelisation info), and for reading it from those files. Includes a unit test to verify that the matrix that is read from the files is identical to the one that was written to it. Will be used to store remapping objects on disk.