### PR TITLE
add print_PETSc_KSP_PC_type

### DIFF
--- a/src/UPSY/basic/petsc_basic.f90
+++ b/src/UPSY/basic/petsc_basic.f90
@@ -23,6 +23,7 @@ MODULE petsc_basic
     mat_CSR2petsc, mat_petsc2CSR, multiply_PETSc_matrix_with_vector_1D, multiply_PETSc_matrix_with_vector_2D
 
   INTEGER :: perr    ! Error flag for PETSc routines
+  character(len=:), allocatable :: PETSc_KSPtype_printed, PETSc_PCtype_printed
 
 CONTAINS
 
@@ -164,7 +165,7 @@ CONTAINS
     call KSPSetTolerances( KSP_solver, rtol, abstol, PETSC_DEFAULT_REAL, 2000, perr)
 
     ! Set preconditioner
-!    call KSPGetPC( KSP_solver, precond, perr)
+    call KSPGetPC( KSP_solver, precond, perr)
     select case (PETSc_PCtype_)
     case default
       call crash('unknown PETSc_PCtype "' // trim( PETSc_PCtype_) // '"')
@@ -189,6 +190,7 @@ CONTAINS
     ! These options will override those specified above as long as
     ! KSPSetFromOptions() is called _after_ any other customization routines.
     call KSPSetFromOptions( KSP_solver, perr)
+    call print_PETSc_KSP_PC_type( KSP_solver, precond)
 
     ! == Solve Ax=b
     ! =============
@@ -333,6 +335,7 @@ CONTAINS
     ! These options will override those specified above as long as
     ! KSPSetFromOptions() is called _after_ any other customization routines.
     call KSPSetFromOptions( KSP_solver, perr)
+    call print_PETSc_KSP_PC_type( KSP_solver, precond)
 
     ! == Solve Ax=b
     ! =============
@@ -355,6 +358,66 @@ CONTAINS
     call finalise_routine( routine_name)
 
   end subroutine solve_matrix_equation_PETSc_new
+
+  subroutine print_PETSc_KSP_PC_type( KSP_solver, precond)
+    ! Query which KSP and PC we're actually using, and tell the user
+
+    ! In/output variables:
+    type(tKSP), intent(in) :: KSP_solver
+    type(tPC),  intent(in) :: precond
+
+    ! Local variables:
+    character(len=1024), parameter :: routine_name = 'solve_matrix_equation_PETSc'
+    character(len=1024)            :: PETSc_KSPtype_applied, PETSc_PCtype_applied
+    logical                        :: do_print_KSP, do_print_PC
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    ! KSP solver
+    call KSPGetType( KSP_solver, PETSc_KSPtype_applied, perr)
+
+    do_print_KSP = .false.
+    if (.not. allocated( PETSc_KSPtype_printed)) then
+      do_print_KSP = .true.
+      PETSc_KSPtype_printed = trim( PETSc_KSPtype_applied)
+    else
+      ! Maybe the KSP type has changed; check for this
+      if (trim( PETSc_KSPtype_applied) /= PETSc_KSPtype_printed) then
+        deallocate( PETSc_KSPtype_printed)
+        do_print_KSP = .true.
+        PETSc_KSPtype_printed = trim( PETSc_KSPtype_applied)
+      end if
+    end if
+
+    if (do_print_KSP .and. par%primary) then
+      write(0,*) '  Using PETSc KSP solver ', colour_string( PETSc_KSPtype_printed, 'light blue')
+    end if
+
+    ! Preconditioner
+    call PCGetType( precond, PETSc_PCtype_applied, perr)
+
+    do_print_PC = .false.
+    if (.not. allocated( PETSc_PCtype_printed)) then
+      do_print_PC = .true.
+      PETSc_PCtype_printed = trim( PETSc_PCtype_applied)
+    else
+      ! Maybe the PC type has changed; check for this
+      if (trim( PETSc_PCtype_applied) /= PETSc_PCtype_printed) then
+        deallocate( PETSc_PCtype_printed)
+        do_print_PC = .true.
+        PETSc_PCtype_printed = trim( PETSc_PCtype_applied)
+      end if
+    end if
+
+    if (do_print_PC .and. par%primary) then
+      write(0,*) '  Using PETSc preconditioner ', colour_string( PETSc_PCtype_printed, 'light blue')
+    end if
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine print_PETSc_KSP_PC_type
 
   SUBROUTINE solve_matrix_equation_PETSc_KSPSolve( KSP_solver, b, x)
     ! Solve the matrix equation using a Krylov solver from PETSc


### PR DESCRIPTION
Print once to the terminal which PETSc KSP solver and preconditioner are being used. On my Macbook and in the GitHub workflow, this is gmres+bjacobi by default.