### PR TITLE
Add unused MISMIP+ full test

### DIFF
--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_01_5km_spinup_part0.cfg
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_01_5km_spinup_part0.cfg
@@ -1,0 +1,798 @@
+&CONFIG
+
+  ! General model instructions
+  ! ==========================
+
+    ! Output directory
+    create_procedural_output_dir_config          = .FALSE.                          ! Automatically create an output directory with a procedural name (e.g. results_20210720_001/)
+    fixed_output_dir_config                      = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_5km_spinup_part0' ! If not, create a directory with this name instead (stops the program if this directory already exists)
+
+    ! Debugging
+    do_benchmarks_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
+    do_unit_tests_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
+    do_check_for_NaN_config                      = .FALSE.                          ! Whether or not fields should be checked for NaN values
+    do_time_display_config                       = .false.                           ! Print current model time to screen
+
+  ! == Time of simulation
+  ! =====================
+
+    start_time_of_run_config                     = 0.0                              ! [yr] Start time of the simulation
+    end_time_of_run_config                       = 20000.0                          ! [yr] End   time of the simulation
+
+  ! == Which model regions to simulate
+  ! ==================================
+
+    dt_coupling_config                           = 100.0                            ! [yr] Interval of coupling between the different model regions
+    do_NAM_config                                = .FALSE.
+    do_EAS_config                                = .FALSE.
+    do_GRL_config                                = .FALSE.
+    do_ANT_config                                = .TRUE.
+
+  ! == The four model regions
+  ! =========================
+
+    ! North America
+    lambda_M_NAM_config                          = 265.0                            ! [degrees east]  [default: 265.0]   Longitude of the pole of the stereographic projection for the North America domain
+    phi_M_NAM_config                             =  62.0                            ! [degrees north] [default:  62.0]   Latitude  of the pole of the stereographic projection for the North America domain
+    beta_stereo_NAM_config                       =  71.0                            ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the North America domain
+    xmin_NAM_config                              = -3600000.0                       ! [m]             [default: -3600E3] Western  boundary     of the North America domain
+    xmax_NAM_config                              =  3600000.0                       ! [m]             [default:  3600E3] Eastern  boundary     of the North America domain
+    ymin_NAM_config                              = -2400000.0                       ! [m]             [default: -2400E3] Southern boundary     of the North America domain
+    ymax_NAM_config                              =  2400000.0                       ! [m]             [default:  2400E3] Northern boundary     of the North America domain
+
+    ! Eurasia
+    lambda_M_EAS_config                          = 40.0                             ! [degrees east]  [default:  40.0]   Longitude of the pole of the stereographic projection for the Eurasia domain
+    phi_M_EAS_config                             = 70.0                             ! [degrees north] [default:  70.0]   Latitude  of the pole of the stereographic projection for the Eurasia domain
+    beta_stereo_EAS_config                       = 71.0                             ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the Eurasia domain
+    xmin_EAS_config                              = -3400000.0                       ! [m]             [default: -3400E3] Western  boundary     of the Eurasia domain
+    xmax_EAS_config                              =  3400000.0                       ! [m]             [default:  3400E3] Eastern  boundary     of the Eurasia domain
+    ymin_EAS_config                              = -2080000.0                       ! [m]             [default: -2080E3] Southern boundary     of the Eurasia domain
+    ymax_EAS_config                              =  2080000.0                       ! [m]             [default:  2080E3] Northern boundary     of the Eurasia domain
+
+    ! Greenland
+    lambda_M_GRL_config                          = -45.0                            ! [degrees east]  [default: -45.0]   Longitude of the pole of the stereographic projection for the Greenland domain
+    phi_M_GRL_config                             = 90.0                             ! [degrees north] [default:  90.0]   Latitude  of the pole of the stereographic projection for the Greenland domain
+    beta_stereo_GRL_config                       = 70.0                             ! [degrees]       [default:  70.0]   Standard parallel     of the stereographic projection for the Greenland domain
+    xmin_GRL_config                              =  -720000.0                       ! [m]             [default:  -720E3] Western  boundary     of the Greenland domain [m]
+    xmax_GRL_config                              =   960000.0                       ! [m]             [default:   960E3] Eastern  boundary     of the Greenland domain [m]
+    ymin_GRL_config                              = -3450000.0                       ! [m]             [default: -3450E3] Southern boundary     of the Greenland domain [m]
+    ymax_GRL_config                              =  -570000.0                       ! [m]             [default:  -570E3] Northern boundary     of the Greenland domain [m]
+
+    ! Antarctica
+    lambda_M_ANT_config                          = 0.0                              ! [degrees east]  [default:   0.0]   Longitude of the pole of the stereographic projection for the Antarctica domain
+    phi_M_ANT_config                             = -90.0                            ! [degrees north] [default: -90.0]   Latitude  of the pole of the stereographic projection for the Antarctica domain
+    beta_stereo_ANT_config                       = 71.0                             ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the Antarctica domain
+    xmin_ANT_config                              = 0.0                              ! [m]             [default: -3040E3] Western  boundary     of the Antarctica domain [m]
+    xmax_ANT_config                              = 800000.0                         ! [m]             [default:  3040E3] Eastern  boundary     of the Antarctica domain [m]
+    ymin_ANT_config                              = -40000.0                         ! [m]             [default: -3040E3] Southern boundary     of the Antarctica domain [m]
+    ymax_ANT_config                              =  40000.0                         ! [m]             [default:  3040E3] Northern boundary     of the Antarctica domain [m]
+
+  ! == Reference geometries (initial, present-day, and GIA equilibrium)
+  ! ===================================================================
+
+    ! Some pre-processing stuff for reference ice geometry
+    refgeo_Hi_min_config                         = 2.0                              ! [m]             [default: 2.0]     Remove ice thinner than this value in the reference ice geometry. Particularly useful for BedMachine Greenland, which somehow covers the entire tundra with half a meter of ice...
+    do_smooth_geometry_config                    = .FALSE                           ! Whether or not to smooth the reference bedrock
+    r_smooth_geometry_config                     = 0.5                              ! [m]             Geometry smoothing radius
+    remove_Lake_Vostok_config                    = .FALSE.                          ! Whether or not to replace subglacial Lake Vostok in Antarctica with ice (recommended to set to TRUE, otherwise it will really slow down your model for the first few hundred years...)
+
+    ! == Initial geometry
+    ! ===================
+
+    choice_refgeo_init_NAM_config                = 'read_from_file'                 ! Choice of initial geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_init_EAS_config                = 'read_from_file'                 ! Choice of initial geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_init_GRL_config                = 'read_from_file'                 ! Choice of initial geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_init_ANT_config                = 'idealised'                      ! Choice of initial geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_init == 'idealised'
+    choice_refgeo_init_idealised_config          = 'MISMIPplus'                        ! Choice of idealised initial geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_init_idealised_config              = 1000.0                           ! Resolution of square grid used for idealised initial geometry
+    ! Path to file containing initial geometry when choice_refgeo_init == 'read_from_file'
+    filename_refgeo_init_NAM_config              = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_init_EAS_config              = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_init_GRL_config              = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_init_ANT_config              = 'external/data/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_init_NAM_config             = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_init_EAS_config             = 1E9
+    timeframe_refgeo_init_GRL_config             = 1E9
+    timeframe_refgeo_init_ANT_config             = 1E9
+
+    ! == Present-day geometry
+    ! =======================
+
+    choice_refgeo_PD_NAM_config                  = 'read_from_file'                 ! Choice of present-day geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_EAS_config                  = 'read_from_file'                 ! Choice of present-day geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_GRL_config                  = 'read_from_file'                 ! Choice of present-day geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_ANT_config                  = 'idealised'                      ! Choice of present-day geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_PD == 'idealised'
+    choice_refgeo_PD_idealised_config            = 'MISMIPplus'                        ! Choice of idealised present-day geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_PD_idealised_config                = 1000.0                           ! Resolution of square grid used for idealised present-day geometry
+    ! Path to file containing present-day geometry when choice_refgeo_PD == 'read_from_file'
+    filename_refgeo_PD_NAM_config                = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_PD_EAS_config                = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_PD_GRL_config                = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_PD_ANT_config                = 'external/data/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_PD_NAM_config               = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_PD_EAS_config               = 1E9
+    timeframe_refgeo_PD_GRL_config               = 1E9
+    timeframe_refgeo_PD_ANT_config               = 1E9
+
+    ! == GIA equilibrium geometry
+    ! ===========================
+
+    choice_refgeo_GIAeq_NAM_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_EAS_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_GRL_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_ANT_config               = 'idealised'                      ! Choice of GIA equilibrium reference geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_GIAeq == 'idealised'
+    choice_refgeo_GIAeq_idealised_config         = 'MISMIPplus'                        ! Choice of idealised GIA equilibrium reference geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_GIAeq_idealised_config             = 1000.0                           ! Resolution of square grid used for idealised GIA equilibrium reference geometry
+    ! Path to file containing GIA equilibrium reference geometry when choice_refgeo_GIAeq == 'read_from_file'
+    filename_refgeo_GIAeq_NAM_config             = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_GIAeq_EAS_config             = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_GIAeq_GRL_config             = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_GIAeq_ANT_config             = 'external/data/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_GIAeq_NAM_config            = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_GIAeq_EAS_config            = 1E9
+    timeframe_refgeo_GIAeq_GRL_config            = 1E9
+    timeframe_refgeo_GIAeq_ANT_config            = 1E9
+
+    ! == Parameters for idealised geometries
+    ! ======================================
+
+    refgeo_idealised_slabonaslope_Hi_config      = 0.0                              ! Suggested value: 2000 m
+    refgeo_idealised_slabonaslope_dhdx_config    = 1.0                              ! Suggested value: -0.001
+    refgeo_idealised_Halfar_H0_config            = 0.0                              ! Suggested value: 3000 m
+    refgeo_idealised_Halfar_R0_config            = 0.0                              ! Suggested value: 500E3 m
+    refgeo_idealised_Bueler_H0_config            = 0.0                              ! Suggested value: 3000 m
+    refgeo_idealised_Bueler_R0_config            = 0.0                              ! Suggested value: 500E3 m
+    refgeo_idealised_Bueler_lambda_config        = 0.0                              ! Suggested value: 5.0
+    refgeo_idealised_SSA_icestream_Hi_config     = -1.0                             ! Suggested value: 2000 m
+    refgeo_idealised_SSA_icestream_dhdx_config   = 1.0                              ! Suggested value: -0.0003
+    refgeo_idealised_SSA_icestream_L_config      = 0.0                              ! Suggested value: 150 km
+    refgeo_idealised_SSA_icestream_m_config      = 0.0                              ! Suggested value: 1.0
+    refgeo_idealised_MISMIP_mod_Hi_init_config   = -1.0                             ! Suggested value: 100 m
+    refgeo_idealised_ISMIP_HOM_L_config          = 0.0                              ! Suggested value: 5E3 - 160E3 m
+    refgeo_idealised_MISMIPplus_Hi_init_config   = 100.0                            ! Suggested value: 100 m
+    refgeo_idealised_MISMIPplus_tune_A_config    = .TRUE.                           ! If so, the uniform flow factor A is tuned to achieve a steady-state mid-stream grounding-line position at x = 450 km
+
+  ! == Mesh generation
+  ! ==================
+
+    ! How to set up the initial mesh
+    choice_initial_mesh_NAM_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_EAS_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_GRL_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_ANT_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+
+    ! Paths to files containing initial meshes, if choice_initial_mesh == 'read_from_file'
+    filename_initial_mesh_NAM_config             = ''
+    filename_initial_mesh_EAS_config             = ''
+    filename_initial_mesh_GRL_config             = ''
+    filename_initial_mesh_ANT_config             = ''
+
+    ! Resolutions for different parts of the ice sheet
+    maximum_resolution_uniform_config            = 20e3                             ! [m]          Maximum resolution for the entire domain
+    maximum_resolution_grounded_ice_config       = 20e3                             ! [m]          Maximum resolution for grounded ice
+    maximum_resolution_floating_ice_config       = 10e3                             ! [m]          Maximum resolution for floating ice
+    maximum_resolution_grounding_line_config     = 5e3                              ! [m]          Maximum resolution for the grounding line
+    maximum_resolution_calving_front_config      = 5e3                              ! [m]          Maximum resolution for the calving front
+    maximum_resolution_ice_front_config          = 20e3                             ! [m]          Maximum resolution for the ice front
+    maximum_resolution_coastline_config          = 1000e3                           ! [m]          Maximum resolution for the coastline
+
+    ! Widths for each resolution band
+    grounding_line_width_config                  = 2.5e3                            ! [m]          Width of the band around the grounding line that should get this resolution
+    calving_front_width_config                   = 2.5e3                            ! [m]          Width of the band around the calving front that should get this resolution
+    ice_front_width_config                       = 10e3                             ! [m]          Width of the band around the ice front that should get this resolution
+    coastline_width_config                       = 1000e3                           ! [m]          Width of the band around the coastline that should get this resolution
+
+    ! Regions of interest
+    choice_regions_of_interest_config            = ''                               ! Regions of interest where other (higher) resolutions apply. Separated by double vertical bars "||", e.g. "PineIsland||Thwaites"
+    ROI_maximum_resolution_uniform_config        = 100e3                            ! [m]          Maximum resolution for the entire domain
+    ROI_maximum_resolution_grounded_ice_config   = 50e3                             ! [m]          Maximum resolution for grounded ice
+    ROI_maximum_resolution_floating_ice_config   = 20e3                             ! [m]          Maximum resolution for floating ice
+    ROI_maximum_resolution_grounding_line_config = 5e3                              ! [m]          Maximum resolution for the grounding line
+    ROI_maximum_resolution_calving_front_config  = 10e3                             ! [m]          Maximum resolution for the calving front
+    ROI_maximum_resolution_ice_front_config      = 20e3                             ! [m]          Maximum resolution for the ice front
+    ROI_maximum_resolution_coastline_config      = 50e3                             ! [m]          Maximum resolution for the coastline
+
+    ! Widths for each resolution band
+    ROI_grounding_line_width_config              = 2e3                              ! [m]          Width of the band around the grounding line that should get this resolution
+    ROI_calving_front_width_config               = 10e3                             ! [m]          Width of the band around the calving front that should get this resolution
+    ROI_ice_front_width_config                   = 20e3                             ! [m]          Width of the band around the ice front that should get this resolution
+    ROI_coastline_width_config                   = 50e3                             ! [m]          Width of the band around the coastline that should get this resolution
+
+    ! Mesh update settings
+    allow_mesh_updates_config                    = .TRUE.                           ! [-]          Whether or not mesh updates are allowed
+    dt_mesh_update_min_config                    = 50.0                             ! [yr]         Minimum amount of time between mesh updates
+    minimum_mesh_fitness_coefficient_config      = 0.95                             ! [-]          If the mesh fitness drops below this threshold, trigger a mesh update
+    do_out_of_time_calving_front_relax_config    = .TRUE.                           !              Whether or not to step out of time and relax the calving front for a few iterations after a mesh update
+
+    ! Advanced geometry parameters
+    do_singlecore_mesh_creation_config           = .TRUE.                           !              Whether or not to use only a single core for mesh generation (for better reproducibility)
+    alpha_min_config                             = 0.4363                           ! [radians]    Smallest allowed internal triangle angle (recommended value: 25 degrees = 0.4363)
+    nit_Lloyds_algorithm_config                  = 3                                ! [-]          Number of iterations of Lloyds algorithm to be applied after refinement
+    mesh_resolution_tolerance_config             = 1.25                             ! [-]          Factors the target resolution for trangle-size requirement. 1=strict, use >1 to avoid unnecesarily high resolution
+
+    ! Square grid used for smoothing
+    dx_square_grid_smooth_NAM_config             = 2000.0
+    dx_square_grid_smooth_EAS_config             = 2000.0
+    dx_square_grid_smooth_GRL_config             = 2000.0
+    dx_square_grid_smooth_ANT_config             = 2000.0
+
+  ! == The scaled vertical coordinate zeta
+  ! ======================================
+
+    choice_zeta_grid_config                      = 'regular'                        ! The type of vertical grid to use; can be "regular", "irregular_log", "old_15_layer_zeta"
+    nz_config                                    = 12                               ! The number of vertical layers to use
+    zeta_irregular_log_R_config                  = 10.0                             ! Ratio between surface and base layer spacings
+
+  ! == Ice dynamics - velocity
+  ! ==========================
+
+    ! General
+    choice_stress_balance_approximation_config   = 'DIVA'                           ! Choice of stress balance approximation: "none" (= no flow, though geometry can still change due to mass balance), "SIA", "SSA", "SIA/SSA", "DIVA", "BPA"
+    choice_hybrid_SIASSA_scheme_config           = 'add'                            ! Choice of scheme for combining SIA and SSA velocities in the hybrid approach
+    do_include_SSADIVA_crossterms_config         = .TRUE.                           ! Whether or not to include the gradients of the effective viscosity (the "cross-terms") in the solution of the SSA/DIVA
+
+    ! Hybrid DIVA/BPA
+    choice_hybrid_DIVA_BPA_mask_NAM_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for North America
+    choice_hybrid_DIVA_BPA_mask_EAS_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Eurasia
+    choice_hybrid_DIVA_BPA_mask_GRL_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Greenland
+    choice_hybrid_DIVA_BPA_mask_ANT_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Antarctica
+
+    filename_hybrid_DIVA_BPA_mask_NAM_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for North America
+    filename_hybrid_DIVA_BPA_mask_EAS_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Eurasia
+    filename_hybrid_DIVA_BPA_mask_GRL_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Greenland
+    filename_hybrid_DIVA_BPA_mask_ANT_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Antarctica
+
+    ! Initialisation
+    choice_initial_velocity_NAM_config           = 'zero'                           ! Can be 'zero', 'read_from_file'
+    choice_initial_velocity_EAS_config           = 'zero'
+    choice_initial_velocity_GRL_config           = 'zero'
+    choice_initial_velocity_ANT_config           = 'zero'
+    ! Paths to files containing initial velocity fields
+    filename_initial_velocity_NAM_config         = ''
+    filename_initial_velocity_EAS_config         = ''
+    filename_initial_velocity_GRL_config         = ''
+    filename_initial_velocity_ANT_config         = ''
+    ! Timeframes to read from the initial velocity files (set to 1E9    if the file has no time dimension)
+    timeframe_initial_velocity_NAM_config        = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_initial_velocity_EAS_config        = 1E9
+    timeframe_initial_velocity_GRL_config        = 1E9
+    timeframe_initial_velocity_ANT_config        = 1E9
+
+    ! Some parameters for numerically solving the stress balance
+    SIA_maximum_diffusivity_config               = 1E5                              ! Limit the diffusivity in the SIA to this value
+    visc_it_norm_dUV_tol_config                  = 5E-5                             ! Stop criterion for the viscosity iteration: the L2-norm of successive velocity solutions should be smaller than this number
+    visc_it_nit_config                           = 50                               ! Maximum number of effective viscosity iterations
+    visc_it_relax_config                         = 0.2                              ! Relaxation parameter for subsequent viscosity iterations (for improved stability)
+    visc_eff_min_config                          = 1E4                              ! Minimum value for effective viscosity
+    vel_max_config                               = 5000.0                           ! Velocities are limited to this value
+    stress_balance_PETSc_rtol_config             = 1E-7                             ! PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
+    stress_balance_PETSc_abstol_config           = 1E-5                             ! PETSc solver - stop criterion, absolute difference
+
+    ! Boundary conditions
+    BC_u_west_config                             = 'zero'                           ! Boundary conditions for the ice velocity field at the domain border
+    BC_u_east_config                             = 'infinite'                       ! Allowed choices: "infinite", "zero", "periodic_ISMIP-HOM"
+    BC_u_south_config                            = 'infinite'
+    BC_u_north_config                            = 'infinite'
+    BC_v_west_config                             = 'zero'
+    BC_v_east_config                             = 'zero'
+    BC_v_south_config                            = 'zero'
+    BC_v_north_config                            = 'zero'
+
+  ! == Ice dynamics - sliding
+  ! =========================
+
+    ! General
+    choice_sliding_law_config                    = 'Schoof2005'                     ! Choice of sliding law: "no_sliding", "idealised", "Coulomb", "Budd", "Weertman", "Tsai2015", "Schoof2005", "Zoet-Iverson"
+    choice_idealised_sliding_law_config          = ''                               ! "ISMIP_HOM_C", "ISMIP_HOM_D", "ISMIP_HOM_E", "ISMIP_HOM_F"
+
+    ! Parameters for different sliding laws
+    slid_Weertman_m_config                       = 3.0                              ! Exponent in Weertman sliding law
+    slid_Budd_q_plastic_config                   = 0.3                              ! Scaling exponent in Budd sliding law
+    slid_Budd_u_threshold_config                 = 100.0                            ! Threshold velocity in Budd sliding law
+    slid_ZI_p_config                             = 5.0                              ! Velocity exponent used in the Zoet-Iverson sliding law
+    slid_ZI_ut_config                            = 200.0                            ! (uniform) transition velocity used in the Zoet-Iverson sliding law [m/yr]
+
+    ! Sub-grid scaling of basal friction
+    do_GL_subgrid_friction_config                = .TRUE.                           ! Whether or not to scale basal friction with the sub-grid grounded fraction (needed to get proper GL migration; only turn this off for showing the effect on the MISMIP_mod results!)
+    choice_subgrid_grounded_fraction_config      = 'bilin_interp_TAF+bedrock_CDF'   ! Choice of scheme to calculate the sub-grid grounded fractions: 'trilin', 'bedrock_CDF'
+    do_read_bedrock_cdf_from_file_config         = .FALSE.                          ! Whether or not to read the bedrock CDF from the initial mesh file. Requires choice_initial_mesh_XXX_config =  'read_from_file'!
+    subgrid_bedrock_cdf_nbins_config             = 11                               ! Number of bins to be used for sub-grid bedrock cumulative density functions
+    do_subgrid_friction_on_A_grid_config         = .FALSE.                          ! Whether or not to apply a preliminary scaling to basal hydrology and bed roughness on the A grid, before the final scaling of beta on the b grid. The exponent of this scaling is computed based on ice thickness.
+    subgrid_friction_exponent_on_B_grid_config   = 2.0                              ! Exponent to which f_grnd should be raised before being used to scale beta
+
+    ! Stability
+    slid_beta_max_config                         = 1E20                             ! Maximum value for basal friction coefficient
+    slid_delta_v_config                          = 1.0E-3                           ! Normalisation parameter to prevent errors when velocity is zero
+
+  ! == Ice dynamics - ice thickness calculation
+  ! ===========================================
+
+    ! Calculation of dH/dt
+    choice_ice_integration_method_config         = 'semi-implicit'                  ! Choice of ice thickness integration scheme: "none" (i.e. unchanging geometry), "explicit", "semi-implicit"
+    dHi_semiimplicit_fs_config                   = 1.5                              ! Factor for the semi-implicit ice thickness solver (0 = explicit, 0<f<1 = semi-implicit, 1 = implicit, >1 = over-implicit)
+    dHi_PETSc_rtol_config                        = 1E-8                             ! dHi PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
+    dHi_PETSc_abstol_config                      = 1E-6                             ! dHi PETSc solver - stop criterion, absolute difference
+
+    ! Boundary conditions
+    BC_H_west_config                             = 'infinite'                       ! Boundary conditions for ice thickness at the domain boundary
+    BC_H_east_config                             = 'zero'                           ! Allowed choices:  "infinite", "zero", "ISMIP_HOM_F"
+    BC_H_south_config                            = 'infinite'
+    BC_H_north_config                            = 'infinite'
+
+  ! == Ice dynamics - target quantities
+  ! ===================================
+
+    ! Target dHi_dt
+    do_target_dHi_dt_config                      = .FALSE.                          ! Whether or not to use a target dHi_dt field from an external file to alter the modelled one
+    do_limit_target_dHi_dt_to_SMB_config         = .TRUE.                           ! Whether or not to limit a target dHi_dt field to available SMB in that area, so it does not melt all ice there
+    target_dHi_dt_t_end_config                   = 9.9e9                            ! End time of target dHi_dt application
+
+    ! Files containing a target dHi_dt for inversions
+    filename_dHi_dt_target_NAM_config            = ''
+    filename_dHi_dt_target_EAS_config            = ''
+    filename_dHi_dt_target_GRL_config            = ''
+    filename_dHi_dt_target_ANT_config            = ''
+
+    ! Timeframes for reading target dHi_dt from file (set to 1E9_dp if the file has no time dimension)
+    timeframe_dHi_dt_target_NAM_config           = 1E9
+    timeframe_dHi_dt_target_EAS_config           = 1E9
+    timeframe_dHi_dt_target_GRL_config           = 1E9
+    timeframe_dHi_dt_target_ANT_config           = 1E9
+
+  ! == Ice dynamics - time stepping
+  ! ===============================
+
+    ! Time stepping
+    choice_timestepping_config                   = 'pc'                             ! Choice of timestepping method: "direct", "pc" (NOTE: 'direct' does not work with DIVA ice dynamcis!)
+    dt_ice_max_config                            = 10.0                             ! [yr] Maximum time step of the ice dynamics model
+    dt_ice_min_config                            = 0.1                              ! [yr] Minimum time step of the ice dynamics model
+    dt_ice_startup_phase_config                  = 0.0                              ! [yr] Length of time window after start_time and before end_time when dt = dt_min, to ensure smooth restarts
+    do_grounded_only_adv_dt_config               = .FALSE.                          ! If .TRUE., only grounded ice is used in the computation of the advective time step limit (CFL condition)
+
+    ! Predictor-corrector ice-thickness update
+    pc_epsilon_config                            = 0.005                            ! Target truncation error in dHi_dt [m/yr] (epsilon in Robinson et al., 2020, Eq. 33)
+    pc_k_I_config                                = 0.2                              ! Exponent k_I in  Robinson et al., 2020, Eq. 33
+    pc_k_p_config                                = 0.2                              ! Exponent k_p in  Robinson et al., 2020, Eq. 33
+    pc_eta_min_config                            = 1E-8                             ! Normalisation term in estimation of the truncation error (Robinson et al., Eq. 32)
+    pc_max_time_step_increase_config             = 1.1                              ! Each new time step is only allowed to be this much larger than the previous one
+    pc_nit_max_config                            = 50                               ! Maximum number of times a PC timestep can be repeated with reduced dt
+    pc_guilty_max_config                         = 0.0                              ! [%] Maximum percentage of grounded vertices allowed to have a truncation error larger than the tolerance pc_epsilon
+
+    ! Initialisation of the predictor-corrector ice-thickness update
+    pc_choice_initialise_NAM_config              = 'zero'                           ! How to initialise the p/c scheme: 'zero', 'read_from_file'
+    pc_choice_initialise_EAS_config              = 'zero'
+    pc_choice_initialise_GRL_config              = 'zero'
+    pc_choice_initialise_ANT_config              = 'zero'
+    ! Paths to files containing initial fields & values for the p/c scheme
+    filename_pc_initialise_NAM_config            = ''
+    filename_pc_initialise_EAS_config            = ''
+    filename_pc_initialise_GRL_config            = ''
+    filename_pc_initialise_ANT_config            = ''
+    ! Timeframes to read from the p/c scheme initial file (set to 1E9    if the file has no time dimension)
+    timeframe_pc_initialise_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_pc_initialise_EAS_config           = 1E9
+    timeframe_pc_initialise_GRL_config           = 1E9
+    timeframe_pc_initialise_ANT_config           = 1E9
+
+  ! == Ice dynamics - calving
+  ! =========================
+
+    choice_calving_law_config                    = 'none'                           ! Choice of calving law: "none", "threshold_thickness"
+    calving_threshold_thickness_shelf_config     = 100.0                            ! Threshold ice thickness for ice shelf calving front in the "threshold_thickness" calving law
+    calving_threshold_thickness_sheet_config     = 0.0                              ! Threshold ice thickness for ice sheet calving front in the "threshold_thickness" calving law
+    max_calving_rounds_config                    = 20                               ! Maximum number of calving loops during chain reaction
+    do_remove_shelves_config                     = .FALSE.                          ! If set to TRUE, all floating ice is always instantly removed (used in the ABUMIP-ABUK experiment)
+    remove_shelves_larger_than_PD_config         = .FALSE.                          ! If set to TRUE, all floating ice beyond the present-day calving front is removed (used for some Antarctic spin-ups)
+    continental_shelf_calving_config             = .FALSE.                          ! If set to TRUE, all ice beyond the continental shelf edge (set by a maximum depth) is removed
+    continental_shelf_min_height_config          = -2000.0                          ! Maximum depth of the continental shelf
+
+  ! == Ice dynamics - stabilisation
+  ! ===============================
+
+    choice_mask_noice_config                     = 'MISMIP+'                        ! Choice of mask_noice configuration
+    Hi_min_config                                = 0.0                              ! [m] Minimum ice thickness: thinner ice gets temporarily added to the no-ice mask and eventually removed
+    Hi_thin_config                               = 0.0                              ! [m] Thin-ice thickness threshold: thinner ice is considered dynamically unreliable (e.g. over steep slopes)
+    remove_ice_absent_at_PD_config               = .FALSE.                          ! If set to TRUE, all ice not present in PD data is always instantly removed
+
+    ! Geometry relaxation
+    geometry_relaxation_t_years_config           = 0.0                              ! [yr] Amount of years (out-of-time) during which the geometry will relaxed during initialisation: no mass balance, thickness alterations, inversions, or target thinning rates will be applied during this time
+
+    ! Mask conservation
+    do_protect_grounded_mask_config              = .FALSE.                          ! If set to TRUE, grounded ice will not be allowed to cross the floatation threshold and will stay minimally grounded.
+    protect_grounded_mask_t_end_config           = 20000.0                          ! End time of grounded mask protection. After this time, it will be allowed to thin and become afloat
+
+    ! Fix/delay ice thickness evolution
+    do_fixiness_before_start_config              = .TRUE.                           ! Whether or not to apply fixiness values before fixiness_t_start
+    fixiness_t_start_config                      = -9.9E9                           ! Start time of linear transition between fixed/delayed and free evolution
+    fixiness_t_end_config                        = -8.8E8                           ! End   time of linear transition between fixed/delayed and free evolution
+    fixiness_H_gl_gr_config                      = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_gl_fl_config                      = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_grounded_config                   = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_floating_config                   = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_freeland_config                   = .FALSE.                          ! Fix (.TRUE.) ice-free vertices between fixiness_t_start and fixiness_t_end
+    fixiness_H_freeocean_config                  = .FALSE.                          ! Fix (.TRUE.) ice-free vertices between fixiness_t_start and fixiness_t_end
+
+    ! Limit ice thickness evolution
+    do_limitness_before_start_config             = .TRUE.                           ! Whether or not to apply limitness values before limitness_t_start
+    limitness_t_start_config                     = -9.9E9                           ! Start time of linear transition between limited and free evolution
+    limitness_t_end_config                       = -8.8E8                           ! End   time of linear transition between limited and free evolution
+    limitness_H_gl_gr_config                     = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_gl_fl_config                     = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_grounded_config                  = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_floating_config                  = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    modiness_H_style_config                      = 'none'                           ! Dynamic "modiness" limitness-like term: "none", "Ti_hom", "Ti_hom_up", "Ti_hom_down"
+    modiness_T_hom_ref_config                    = 5.0                              ! Reference Ti_hom for the modiness cold exponential style
+
+  ! == Basal hydrology
+  ! ==================
+
+    ! Basal hydrology
+    choice_basal_hydrology_model_config          = 'Martin2011'                     ! Choice of basal hydrology model: "saturated", "Martin2011"
+    Martin2011_hydro_Hb_min_config               = 0.0                              ! Martin et al. (2011) basal hydrology model: low-end  Hb  value of bedrock-dependent pore-water pressure
+    Martin2011_hydro_Hb_max_config               = 1000.0                           ! Martin et al. (2011) basal hydrology model: high-end Hb  value of bedrock-dependent pore-water pressure
+
+  ! == Bed roughness
+  ! ================
+
+    choice_bed_roughness_config                  = 'parameterised'                  ! Choice of source for friction coefficients: "uniform", "parameterised", "read_from_file"
+    choice_bed_roughness_parameterised_config    = 'MISMIPplus'                        ! "Martin2011", "SSA_icestream", "MISMIPplus", "BIVMIP_A", "BIVMIP_B", "BIVMIP_C"
+    ! Paths to files containing bed roughness fields for the chosen sliding law
+    filename_bed_roughness_NAM_config            = ''
+    filename_bed_roughness_EAS_config            = ''
+    filename_bed_roughness_GRL_config            = ''
+    filename_bed_roughness_ANT_config            = ''
+    ! Timeframes to read from the bed roughness file (set to 1E9    if the file has no time dimension)
+    timeframe_bed_roughness_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_bed_roughness_EAS_config           = 1E9
+    timeframe_bed_roughness_GRL_config           = 1E9
+    timeframe_bed_roughness_ANT_config           = 1E9
+    ! Values for uniform bed roughness
+    slid_Weertman_beta_sq_uniform_config         = 1.0E4                            ! Uniform value for beta_sq  in Weertman sliding law
+    slid_Coulomb_phi_fric_uniform_config         = 15.0                             ! Uniform value for phi_fric in Coulomb sliding law
+    slid_Budd_phi_fric_uniform_config            = 15.0                             ! Uniform value for phi_fric in Budd sliding law
+    slid_Tsai2015_alpha_sq_uniform_config        = 0.5                              ! Uniform value for alpha_sq in the Tsai2015 sliding law
+    slid_Tsai2015_beta_sq_uniform_config         = 1.0E4                            ! Uniform value for beta_sq  in the Tsai2015 sliding law
+    slid_Schoof2005_alpha_sq_uniform_config      = 0.5                              ! Uniform value for alpha_sq in the Schoof2005 sliding law
+    slid_Schoof2005_beta_sq_uniform_config       = 1.0E4                            ! Uniform value for beta_sq  in the Schoof2005 sliding law
+    slid_ZI_phi_fric_uniform_config              = 10.0                             ! Uniform value for phi_fric in the Zoet-Iverson sliding law
+    ! Parameters for bed roughness parameterisations
+    Martin2011till_phi_Hb_min_config             = -1000.0                          ! Martin et al. (2011) bed roughness parameterisation: low-end  Hb  value of bedrock-dependent till friction angle
+    Martin2011till_phi_Hb_max_config             = 0.0                              ! Martin et al. (2011) bed roughness parameterisation: high-end Hb  value of bedrock-dependent till friction angle
+    Martin2011till_phi_min_config                = 5.0                              ! Martin et al. (2011) bed roughness parameterisation: low-end  phi value of bedrock-dependent till friction angle
+    Martin2011till_phi_max_config                = 20.0                             ! Martin et al. (2011) bed roughness parameterisation: high-end phi value of bedrock-dependent till friction angle
+
+  ! == Bed roughness inversion by nudging
+  ! =====================================
+
+    ! General
+    do_bed_roughness_nudging_config              = .FALSE.                          !           Whether or not to nudge the basal roughness
+    choice_bed_roughness_nudging_method_config   = ''                               !           Choice of bed roughness nudging method
+    choice_inversion_target_geometry_config      = ''                               !           Which reference geometry to use as the target geometry (can be "init" or "PD")
+    bed_roughness_nudging_dt_config              = 5.0                              ! [yr]      Time step for bed roughness updates
+    bed_roughness_nudging_t_start_config         = -9.9E9                           ! [yr]      Earliest model time when nudging is allowed
+    bed_roughness_nudging_t_end_config           = +9.9E9                           ! [yr]      Latest   model time when nudging is allowed
+    generic_bed_roughness_min_config             = 0.1                              ! [?]       Smallest allowed value for the first  inverted bed roughness field
+    generic_bed_roughness_max_config             = 30.0                             ! [?]       Largest  allowed value for the first  inverted bed roughness field
+
+    ! Basal inversion model based on flowline-averaged values of H and dH/dt
+    bednudge_H_dHdt_flowline_t_scale_config      = 100.0                            ! [yr]      Timescale
+    bednudge_H_dHdt_flowline_dH0_config          = 100.0                            ! [m]       Ice thickness error scale
+    bednudge_H_dHdt_flowline_dHdt0_config        = 0.6                              ! [m yr^-1] Thinning rate scale
+    bednudge_H_dHdt_flowline_Hi_scale_config     = 300.0                            ! [m]       Ice thickness weight scale
+    bednudge_H_dHdt_flowline_u_scale_config      = 3000.0                           ! [m yr^-1] Ice velocity  weight scale
+    bednudge_H_dHdt_flowline_r_smooth_config     = 2500.0                           ! [m]       Radius for Gaussian filter used to smooth dC/dt as regularisation
+    bednudge_H_dHdt_flowline_w_smooth_config     = 0.5                              ! [-]       Relative contribution of smoothed dC/dt in regularisation
+
+  ! == Geothermal heat flux
+  ! =======================
+
+    choice_geothermal_heat_flux_config           = 'uniform'                        ! Choice of geothermal heat flux; can be 'uniform' or 'read_from_file'
+    uniform_geothermal_heat_flux_config          = 1.72E06                          ! Value when choice_geothermal_heat_flux == 'uniform' (1.72E06 J m^-2 yr^-1 according to Sclater et al. (1980))
+    filename_geothermal_heat_flux_config         = 'external/data/GHF/geothermal_heatflux_ShapiroRitzwoller2004_global_1x1_deg.nc'
+
+  ! == Thermodynamics
+  ! =================
+
+    ! Initial temperature profile
+    choice_initial_ice_temperature_NAM_config    = 'Robin'                          ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "read_from_file"
+    choice_initial_ice_temperature_EAS_config    = 'Robin'
+    choice_initial_ice_temperature_GRL_config    = 'Robin'
+    choice_initial_ice_temperature_ANT_config    = 'uniform'
+    ! Uniform initial ice temperature, if choice_initial_ice_temperature == 'uniform'
+    uniform_initial_ice_temperature_NAM_config   = 270.0                            ! Uniform ice temperature (applied when choice_initial_ice_temperature_config = "uniform")
+    uniform_initial_ice_temperature_EAS_config   = 270.0
+    uniform_initial_ice_temperature_GRL_config   = 270.0
+    uniform_initial_ice_temperature_ANT_config   = 270.0
+    ! Paths to files containing initial temperature fields, if
+    filename_initial_ice_temperature_NAM_config  = ''
+    filename_initial_ice_temperature_EAS_config  = ''
+    filename_initial_ice_temperature_GRL_config  = ''
+    filename_initial_ice_temperature_ANT_config  = ''
+    ! Timeframes to read from the bed roughness file (set to 1E9    if the file has no time dimension)
+    timeframe_initial_ice_temperature_NAM_config = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_initial_ice_temperature_EAS_config = 1E9
+    timeframe_initial_ice_temperature_GRL_config = 1E9
+    timeframe_initial_ice_temperature_ANT_config = 1E9
+    ! Thermodynamical model
+    choice_thermo_model_config                   = 'none'                           ! Choice of thermodynamical model: "none", "3D_heat_equation"
+    dt_thermodynamics_config                     = 1.0                              ! [yr] Time step for the thermodynamical model
+    Hi_min_thermo_config                         = 10.0                             ! [m]  Ice thinner than this is assumed to have a temperature equal to the annual mean surface temperature throughout the vertical column
+    choice_GL_temperature_BC_config              = 'grounded'                       ! Choice of basal boundary condition at grounding lines: 'grounded', 'subgrid', 'pmp'
+    choice_ice_heat_capacity_config              = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Pounder1965"
+    uniform_ice_heat_capacity_config             = 2009.0                           ! Uniform ice heat capacity (applied when choice_ice_heat_capacity_config = "uniform")
+    choice_ice_thermal_conductivity_config       = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Ritz1987"
+    uniform_ice_thermal_conductivity_config      = 6.626958E7                       ! Uniform ice thermal conductivity (applied when choice_ice_thermal_conductivity_config = "uniform")
+
+  ! == Rheology and flow law
+  ! =========================
+
+    ! Flow law
+    choice_flow_law_config                       = 'Glen'                           ! Choice of flow law, relating effective viscosity to effective strain rate
+    Glens_flow_law_exponent_config               = 3.0                              ! Exponent in Glen`s flow law
+    Glens_flow_law_epsilon_sq_0_config           = 1E-8                             ! Normalisation term so that zero strain rates produce a high but finite viscosity
+
+    ! Rheology
+    choice_ice_rheology_Glen_config              = 'uniform'                        ! Choice of ice rheology model for Glen`s flow law: "uniform", "Huybrechts1992", "MISMIP_mod"
+    uniform_Glens_flow_factor_config             = 1.156E-17                        ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
+
+    ! Enhancement factors
+    choice_enhancement_factor_transition_config  = 'separate'                       ! Choice of treatment of enhancement factors at transition zones: "separate", "interp"
+    m_enh_sheet_config                           = 1.0                              ! Ice flow enhancement factor for grounded ice
+    m_enh_shelf_config                           = 1.0                              ! Ice flow enhancement factor for floating ice
+
+  ! == Climate
+  ! ==========
+
+    ! Time step
+    do_asynchronous_climate_config               = .TRUE.                           ! Whether or not the climate should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_climate_config                            = 10.0                             ! [yr] Time step for calculating climate
+
+    ! Choice of climate model
+    choice_climate_model_NAM_config              = 'none'
+    choice_climate_model_EAS_config              = 'none'
+    choice_climate_model_GRL_config              = 'none'
+    choice_climate_model_ANT_config              = 'none'
+
+    ! Choice of idealised climate model
+    choice_climate_model_idealised_config        = ''
+
+    ! Choice of realistic climate model
+    choice_climate_model_realistic_config        = ''
+
+    filename_climate_snapshot_NAM_config         = ''
+    filename_climate_snapshot_EAS_config         = ''
+    filename_climate_snapshot_GRL_config         = ''
+    filename_climate_snapshot_ANT_config         = ''
+
+  ! == Ocean
+  ! ========
+
+    ! Time step
+    do_asynchronous_ocean_config                 = .TRUE.                           ! Whether or not the ocean should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_ocean_config                              = 10.0                             ! [yr] Time step for calculating ocean
+
+    ! Vertical grid
+    ocean_vertical_grid_max_depth_config         = 1500.0                           ! Maximum depth of the ocean submodel
+    ocean_vertical_grid_dz_config                = 100.0                            ! Vertical distance between ocean layers
+
+    ! Choice of ocean model
+    choice_ocean_model_NAM_config                = 'none'
+    choice_ocean_model_EAS_config                = 'none'
+    choice_ocean_model_GRL_config                = 'none'
+    choice_ocean_model_ANT_config                = 'none'
+
+    ! Choice of idealised ocean model
+    choice_ocean_model_idealised_config          = ''
+
+    ! Choice of realistic ocean model
+    choice_ocean_model_realistic_config          = ''
+
+    filename_ocean_snapshot_NAM_config           = ''
+    filename_ocean_snapshot_EAS_config           = ''
+    filename_ocean_snapshot_GRL_config           = ''
+    filename_ocean_snapshot_ANT_config           = ''
+
+  ! == Surface mass balance
+  ! =======================
+
+    ! Time step
+    do_asynchronous_SMB_config                   = .TRUE.                           ! Whether or not the SMB should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_SMB_config                                = 10.0                             ! [yr] Time step for calculating SMB
+
+    ! Choice of SMB model
+    choice_SMB_model_NAM_config                  = 'uniform'
+    choice_SMB_model_EAS_config                  = 'uniform'
+    choice_SMB_model_GRL_config                  = 'uniform'
+    choice_SMB_model_ANT_config                  = 'idealised'
+
+    ! Choice of idealised SMB model
+    choice_SMB_model_idealised_config            = 'uniform'
+
+    ! Value to be used for uniform SMB (no regional variants, only used for idealised-geometry experiments)
+    uniform_SMB_config                           = 0.3
+
+    ! Prescribed SMB forcing
+    choice_SMB_prescribed_NAM_config             = ''
+    choice_SMB_prescribed_EAS_config             = ''
+    choice_SMB_prescribed_GRL_config             = ''
+    choice_SMB_prescribed_ANT_config             = ''
+
+    ! Files containing prescribed SMB forcing
+    filename_SMB_prescribed_NAM_config           = ''
+    filename_SMB_prescribed_EAS_config           = ''
+    filename_SMB_prescribed_GRL_config           = ''
+    filename_SMB_prescribed_ANT_config           = ''
+
+    ! Timeframes for reading prescribed SMB forcing from file (set to 1E9 if the file has no time dimension)
+    timeframe_SMB_prescribed_NAM_config          = 1E9
+    timeframe_SMB_prescribed_EAS_config          = 1E9
+    timeframe_SMB_prescribed_GRL_config          = 1E9
+    timeframe_SMB_prescribed_ANT_config          = 1E9
+
+  ! == Basal mass balance
+  ! =====================
+
+    ! Time step
+    do_asynchronous_BMB_config                   = .TRUE.                           ! Whether or not the BMB should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_BMB_config                                = 10.0                             ! [yr] Time step for calculating BMB
+
+    ! Grounding line treatment
+    choice_BMB_subgrid_config                    = 'NMP'                               ! Choice of sub-grid BMB scheme: "FCMP", "PMP" (following Leguy et al., 2021)
+
+    ! Choice of BMB model
+    choice_BMB_model_NAM_config                  = 'uniform'
+    choice_BMB_model_EAS_config                  = 'uniform'
+    choice_BMB_model_GRL_config                  = 'uniform'
+    choice_BMB_model_ANT_config                  = 'uniform'
+
+    ! Choice of idealised BMB model
+    choice_BMB_model_idealised_config            = ''
+
+    ! Choice of parameterised BMB model
+    choice_BMB_model_parameterised_config        = 'Favier2019'
+
+    ! "uniform"
+    uniform_BMB_config                           = 0.0
+
+    ! "parameterised"
+    BMB_Favier2019_gamma_config                  = 99.32E-5
+
+  ! == Lateral mass balance
+  ! =======================
+
+    ! Time step
+    dt_LMB_config                                = 5.0                              ! [yr] Time step for calculating LMB [not implemented yet]
+
+    ! Choice of LMB model
+    choice_LMB_model_NAM_config                  = 'uniform'
+    choice_LMB_model_EAS_config                  = 'uniform'
+    choice_LMB_model_GRL_config                  = 'uniform'
+    choice_LMB_model_ANT_config                  = 'uniform'
+
+    ! "uniform"
+    uniform_LMB_config                           = 0.0
+
+  ! == Glacial isostatic adjustment
+  ! ===============================
+
+    ! General settings
+    choice_GIA_model_config                      = 'none'
+    dt_GIA_config                                = 100.0                            ! [yr] GIA model time step
+    dx_GIA_config                                = 2000.0                           ! [m]  GIA model square grid resolution
+
+  ! == Sea level
+  ! ============
+
+    choice_sealevel_model_config                 = 'fixed'                          !     Can be "fixed", "prescribed", "eustatic", or "SELEN"
+    fixed_sealevel_config                        = 0.0                              ! [m] Fixed sea level value for the "fixed" choice
+
+  ! == SELEN
+  ! ========
+
+    SELEN_run_at_t_start_config                  = .FALSE.                          ! Whether or not to run SELEN in the first coupling loop (needed for some benchmark experiments)
+    SELEN_n_TDOF_iterations_config               = 1                                ! Number of Time-Dependent Ocean Function iterations
+    SELEN_n_recursion_iterations_config          = 1                                ! Number of recursion iterations
+    SELEN_use_rotational_feedback_config         = .FALSE.                          ! If TRUE, rotational feedback is included
+    SELEN_n_harmonics_config                     = 128                              ! Maximum number of harmonic degrees
+    SELEN_display_progress_config                = .FALSE.                          ! Whether or not to display the progress of the big loops to the screen
+
+    SELEN_dir_config                             = 'external/data/SELEN'                     ! Directory where SELEN initial files and spherical harmonics are stored
+    SELEN_global_topo_filename_config            = 'SELEN_global_topography.nc'     ! Filename for the SELEN global topography file (located in SELEN_dir)
+    SELEN_TABOO_init_filename_config             = 'SELEN_TABOO_initial_file.dat'   ! Filename for the TABOO initial file           (idem                )
+    SELEN_LMJ_VALUES_filename_config             = 'SELEN_lmj_values.bin'           ! Filename for the LJ and MJ values file        (idem                )
+
+    SELEN_irreg_time_n_config                    = 15                               ! Number of entries in the irregular moving time window
+    SELEN_irreg_time_window_config               = 20.0  , 20.0  , 20.0  , 5.0  , 5.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 0.0  ,  0.0  ,  0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  ,  0.0  ,  0.0  ,  0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  ,  0.0  ,  0.0  , 0.0  , 0.0
+
+    SELEN_lith_thickness_config                  = 100.0                            ! Thickness of the elastic lithosphere [km]
+    SELEN_visc_n_config                          = 3                                ! Number      of viscous asthenosphere layers
+    SELEN_visc_prof_config                       = 3.0  , 0.6   , 0.3               ! Viscosities of viscous asthenosphere layers [?]
+
+    ! Settings for the TABOO Earth deformation model
+    SELEN_TABOO_CDE_config                       = 0                                !     code of the model (see taboo for explanation)
+    SELEN_TABOO_TLOVE_config                     = 1                                !     Tidal love numbers yes/no
+    SELEN_TABOO_DEG1_config                      = 1                                !     Tidal love numbers degree
+    SELEN_TABOO_RCMB_config                      = 3480.0                           ! [m] Radius of CMB
+
+  ! == Output
+  ! =========
+
+    ! Basic settings
+    do_create_netcdf_output_config               = .TRUE.                           !     Whether or not NetCDF output files should be created at all
+    dt_output_config                             = 100.0                            !     Time step for writing output
+    dt_output_restart_config                     = 30000.0                          !     Time step for writing restart output
+    dt_output_grid_config                        = 5000.0                           !     Time step for writing gridded output
+    dx_output_grid_NAM_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for North America
+    dx_output_grid_EAS_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for Eurasia
+    dx_output_grid_GRL_config                    = 20E3                             ! [m] Horizontal resolution for the square grid used for output for Greenland
+    dx_output_grid_ANT_config                    = 2e3                              ! [m] Horizontal resolution for the square grid used for output for Antarctica
+    dx_output_grid_ROI_NAM_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for North America
+    dx_output_grid_ROI_EAS_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Eurasia
+    dx_output_grid_ROI_GRL_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Greenland
+    dx_output_grid_ROI_ANT_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Antarctica
+
+    ! Transects
+    transects_NAM_config                         = ''                              ! List of transects to use for North America
+    transects_EAS_config                         = ''                              ! List of transects to use for Eurasia
+    transects_GRL_config                         = ''                              ! List of transects to use for Greenland
+    transects_ANT_config                         = 'westeast,dx=1e3'                              ! List of transects to use for Antarctica
+
+    ! Which data fields we want to write to the main NetCDF output files
+    choice_output_field_01_config                = 'mask'
+    choice_output_field_02_config                = 'Hi'
+    choice_output_field_03_config                = 'Hb'
+    choice_output_field_04_config                = 'Hs'
+    choice_output_field_05_config                = 'u_vav'
+    choice_output_field_06_config                = 'v_vav'
+    choice_output_field_07_config                = 'uabs_vav'
+    choice_output_field_08_config                = 'fraction_gr'
+    choice_output_field_09_config                = 'fraction_gr_b'
+    choice_output_field_10_config                = 'basal_friction_coefficient'
+    choice_output_field_11_config                = 'pc_truncation_error'
+    choice_output_field_12_config                = 'SMB'
+    choice_output_field_13_config                = 'dHi_dt'
+    choice_output_field_14_config                = 'divQ'
+    choice_output_field_15_config                = 'BMB'
+    choice_output_field_16_config                = 'R_shear'
+    choice_output_field_17_config                = 'grounding_line'
+    choice_output_field_18_config                = 'calving_front'
+    choice_output_field_19_config                = 'ice_margin'
+    choice_output_field_20_config                = 'coastline'
+    choice_output_field_21_config                = 'none'
+    choice_output_field_22_config                = 'none'
+    choice_output_field_23_config                = 'none'
+    choice_output_field_24_config                = 'none'
+    choice_output_field_25_config                = 'none'
+    choice_output_field_26_config                = 'none'
+    choice_output_field_27_config                = 'none'
+    choice_output_field_28_config                = 'none'
+    choice_output_field_29_config                = 'none'
+    choice_output_field_30_config                = 'none'
+    choice_output_field_31_config                = 'none'
+    choice_output_field_32_config                = 'none'
+    choice_output_field_33_config                = 'none'
+    choice_output_field_34_config                = 'none'
+    choice_output_field_35_config                = 'none'
+    choice_output_field_36_config                = 'none'
+    choice_output_field_37_config                = 'none'
+    choice_output_field_38_config                = 'none'
+    choice_output_field_39_config                = 'none'
+    choice_output_field_40_config                = 'none'
+    choice_output_field_41_config                = 'none'
+    choice_output_field_42_config                = 'none'
+    choice_output_field_43_config                = 'none'
+    choice_output_field_44_config                = 'none'
+    choice_output_field_45_config                = 'none'
+    choice_output_field_46_config                = 'none'
+    choice_output_field_47_config                = 'none'
+    choice_output_field_48_config                = 'none'
+    choice_output_field_49_config                = 'none'
+    choice_output_field_50_config                = 'none'
+
+/

--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_02_5km_spinup.cfg
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_02_5km_spinup.cfg
@@ -90,7 +90,7 @@
     filename_refgeo_init_NAM_config              = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
     filename_refgeo_init_EAS_config              = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
     filename_refgeo_init_GRL_config              = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
-    filename_refgeo_init_ANT_config              = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup_part0/main_output_ANT_LAST.nc'
+    filename_refgeo_init_ANT_config              = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_5km_spinup_part0/main_output_ANT_LAST.nc'
     ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
     timeframe_refgeo_init_NAM_config             = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
     timeframe_refgeo_init_EAS_config             = 1E9
@@ -539,7 +539,7 @@
 
     ! Rheology
     choice_ice_rheology_Glen_config              = 'uniform'                        ! Choice of ice rheology model for Glen`s flow law: "uniform", "Huybrechts1992", "MISMIP_mod"
-    uniform_Glens_flow_factor_config             = 1.3313399224193791E-017          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
+    uniform_Glens_flow_factor_config             = 9.7894081093118906E-018          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
 
     ! Enhancement factors
     choice_enhancement_factor_transition_config  = 'separate'                       ! Choice of treatment of enhancement factors at transition zones: "separate", "interp"

--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_02_5km_spinup.cfg
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_02_5km_spinup.cfg
@@ -1,0 +1,798 @@
+&CONFIG
+
+  ! General model instructions
+  ! ==========================
+
+    ! Output directory
+    create_procedural_output_dir_config          = .FALSE.                          ! Automatically create an output directory with a procedural name (e.g. results_20210720_001/)
+    fixed_output_dir_config                      = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_5km_spinup' ! If not, create a directory with this name instead (stops the program if this directory already exists)
+
+    ! Debugging
+    do_benchmarks_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
+    do_unit_tests_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
+    do_check_for_NaN_config                      = .FALSE.                          ! Whether or not fields should be checked for NaN values
+    do_time_display_config                       = .false.                           ! Print current model time to screen
+
+  ! == Time of simulation
+  ! =====================
+
+    start_time_of_run_config                     = 0.0                              ! [yr] Start time of the simulation
+    end_time_of_run_config                       = 5000.0                           ! [yr] End   time of the simulation
+
+  ! == Which model regions to simulate
+  ! ==================================
+
+    dt_coupling_config                           = 100.0                            ! [yr] Interval of coupling between the different model regions
+    do_NAM_config                                = .FALSE.
+    do_EAS_config                                = .FALSE.
+    do_GRL_config                                = .FALSE.
+    do_ANT_config                                = .TRUE.
+
+  ! == The four model regions
+  ! =========================
+
+    ! North America
+    lambda_M_NAM_config                          = 265.0                            ! [degrees east]  [default: 265.0]   Longitude of the pole of the stereographic projection for the North America domain
+    phi_M_NAM_config                             =  62.0                            ! [degrees north] [default:  62.0]   Latitude  of the pole of the stereographic projection for the North America domain
+    beta_stereo_NAM_config                       =  71.0                            ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the North America domain
+    xmin_NAM_config                              = -3600000.0                       ! [m]             [default: -3600E3] Western  boundary     of the North America domain
+    xmax_NAM_config                              =  3600000.0                       ! [m]             [default:  3600E3] Eastern  boundary     of the North America domain
+    ymin_NAM_config                              = -2400000.0                       ! [m]             [default: -2400E3] Southern boundary     of the North America domain
+    ymax_NAM_config                              =  2400000.0                       ! [m]             [default:  2400E3] Northern boundary     of the North America domain
+
+    ! Eurasia
+    lambda_M_EAS_config                          = 40.0                             ! [degrees east]  [default:  40.0]   Longitude of the pole of the stereographic projection for the Eurasia domain
+    phi_M_EAS_config                             = 70.0                             ! [degrees north] [default:  70.0]   Latitude  of the pole of the stereographic projection for the Eurasia domain
+    beta_stereo_EAS_config                       = 71.0                             ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the Eurasia domain
+    xmin_EAS_config                              = -3400000.0                       ! [m]             [default: -3400E3] Western  boundary     of the Eurasia domain
+    xmax_EAS_config                              =  3400000.0                       ! [m]             [default:  3400E3] Eastern  boundary     of the Eurasia domain
+    ymin_EAS_config                              = -2080000.0                       ! [m]             [default: -2080E3] Southern boundary     of the Eurasia domain
+    ymax_EAS_config                              =  2080000.0                       ! [m]             [default:  2080E3] Northern boundary     of the Eurasia domain
+
+    ! Greenland
+    lambda_M_GRL_config                          = -45.0                            ! [degrees east]  [default: -45.0]   Longitude of the pole of the stereographic projection for the Greenland domain
+    phi_M_GRL_config                             = 90.0                             ! [degrees north] [default:  90.0]   Latitude  of the pole of the stereographic projection for the Greenland domain
+    beta_stereo_GRL_config                       = 70.0                             ! [degrees]       [default:  70.0]   Standard parallel     of the stereographic projection for the Greenland domain
+    xmin_GRL_config                              =  -720000.0                       ! [m]             [default:  -720E3] Western  boundary     of the Greenland domain [m]
+    xmax_GRL_config                              =   960000.0                       ! [m]             [default:   960E3] Eastern  boundary     of the Greenland domain [m]
+    ymin_GRL_config                              = -3450000.0                       ! [m]             [default: -3450E3] Southern boundary     of the Greenland domain [m]
+    ymax_GRL_config                              =  -570000.0                       ! [m]             [default:  -570E3] Northern boundary     of the Greenland domain [m]
+
+    ! Antarctica
+    lambda_M_ANT_config                          = 0.0                              ! [degrees east]  [default:   0.0]   Longitude of the pole of the stereographic projection for the Antarctica domain
+    phi_M_ANT_config                             = -90.0                            ! [degrees north] [default: -90.0]   Latitude  of the pole of the stereographic projection for the Antarctica domain
+    beta_stereo_ANT_config                       = 71.0                             ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the Antarctica domain
+    xmin_ANT_config                              = 0.0                              ! [m]             [default: -3040E3] Western  boundary     of the Antarctica domain [m]
+    xmax_ANT_config                              = 800000.0                         ! [m]             [default:  3040E3] Eastern  boundary     of the Antarctica domain [m]
+    ymin_ANT_config                              = -40000.0                         ! [m]             [default: -3040E3] Southern boundary     of the Antarctica domain [m]
+    ymax_ANT_config                              =  40000.0                         ! [m]             [default:  3040E3] Northern boundary     of the Antarctica domain [m]
+
+  ! == Reference geometries (initial, present-day, and GIA equilibrium)
+  ! ===================================================================
+
+    ! Some pre-processing stuff for reference ice geometry
+    refgeo_Hi_min_config                         = 2.0                              ! [m]             [default: 2.0]     Remove ice thinner than this value in the reference ice geometry. Particularly useful for BedMachine Greenland, which somehow covers the entire tundra with half a meter of ice...
+    do_smooth_geometry_config                    = .FALSE                           ! Whether or not to smooth the reference bedrock
+    r_smooth_geometry_config                     = 0.5                              ! [m]             Geometry smoothing radius
+    remove_Lake_Vostok_config                    = .FALSE.                          ! Whether or not to replace subglacial Lake Vostok in Antarctica with ice (recommended to set to TRUE, otherwise it will really slow down your model for the first few hundred years...)
+
+    ! == Initial geometry
+    ! ===================
+
+    choice_refgeo_init_NAM_config                = 'read_from_file'                 ! Choice of initial geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_init_EAS_config                = 'read_from_file'                 ! Choice of initial geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_init_GRL_config                = 'read_from_file'                 ! Choice of initial geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_init_ANT_config                = 'read_from_file'                 ! Choice of initial geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_init == 'idealised'
+    choice_refgeo_init_idealised_config          = 'MISMIPplus'                        ! Choice of idealised initial geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_init_idealised_config              = 1000.0                           ! Resolution of square grid used for idealised initial geometry
+    ! Path to file containing initial geometry when choice_refgeo_init == 'read_from_file'
+    filename_refgeo_init_NAM_config              = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_init_EAS_config              = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_init_GRL_config              = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_init_ANT_config              = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup_part0/main_output_ANT_LAST.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_init_NAM_config             = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_init_EAS_config             = 1E9
+    timeframe_refgeo_init_GRL_config             = 1E9
+    timeframe_refgeo_init_ANT_config             = 1e9
+
+    ! == Present-day geometry
+    ! =======================
+
+    choice_refgeo_PD_NAM_config                  = 'read_from_file'                 ! Choice of present-day geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_EAS_config                  = 'read_from_file'                 ! Choice of present-day geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_GRL_config                  = 'read_from_file'                 ! Choice of present-day geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_ANT_config                  = 'idealised'                      ! Choice of present-day geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_PD == 'idealised'
+    choice_refgeo_PD_idealised_config            = 'MISMIPplus'                        ! Choice of idealised present-day geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_PD_idealised_config                = 1000.0                           ! Resolution of square grid used for idealised present-day geometry
+    ! Path to file containing present-day geometry when choice_refgeo_PD == 'read_from_file'
+    filename_refgeo_PD_NAM_config                = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_PD_EAS_config                = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_PD_GRL_config                = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_PD_ANT_config                = 'external/data/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_PD_NAM_config               = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_PD_EAS_config               = 1E9
+    timeframe_refgeo_PD_GRL_config               = 1E9
+    timeframe_refgeo_PD_ANT_config               = 1E9
+
+    ! == GIA equilibrium geometry
+    ! ===========================
+
+    choice_refgeo_GIAeq_NAM_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_EAS_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_GRL_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_ANT_config               = 'idealised'                      ! Choice of GIA equilibrium reference geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_GIAeq == 'idealised'
+    choice_refgeo_GIAeq_idealised_config         = 'MISMIPplus'                        ! Choice of idealised GIA equilibrium reference geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_GIAeq_idealised_config             = 1000.0                           ! Resolution of square grid used for idealised GIA equilibrium reference geometry
+    ! Path to file containing GIA equilibrium reference geometry when choice_refgeo_GIAeq == 'read_from_file'
+    filename_refgeo_GIAeq_NAM_config             = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_GIAeq_EAS_config             = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_GIAeq_GRL_config             = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_GIAeq_ANT_config             = 'external/data/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_GIAeq_NAM_config            = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_GIAeq_EAS_config            = 1E9
+    timeframe_refgeo_GIAeq_GRL_config            = 1E9
+    timeframe_refgeo_GIAeq_ANT_config            = 1E9
+
+    ! == Parameters for idealised geometries
+    ! ======================================
+
+    refgeo_idealised_slabonaslope_Hi_config      = 0.0                              ! Suggested value: 2000 m
+    refgeo_idealised_slabonaslope_dhdx_config    = 1.0                              ! Suggested value: -0.001
+    refgeo_idealised_Halfar_H0_config            = 0.0                              ! Suggested value: 3000 m
+    refgeo_idealised_Halfar_R0_config            = 0.0                              ! Suggested value: 500E3 m
+    refgeo_idealised_Bueler_H0_config            = 0.0                              ! Suggested value: 3000 m
+    refgeo_idealised_Bueler_R0_config            = 0.0                              ! Suggested value: 500E3 m
+    refgeo_idealised_Bueler_lambda_config        = 0.0                              ! Suggested value: 5.0
+    refgeo_idealised_SSA_icestream_Hi_config     = -1.0                             ! Suggested value: 2000 m
+    refgeo_idealised_SSA_icestream_dhdx_config   = 1.0                              ! Suggested value: -0.0003
+    refgeo_idealised_SSA_icestream_L_config      = 0.0                              ! Suggested value: 150 km
+    refgeo_idealised_SSA_icestream_m_config      = 0.0                              ! Suggested value: 1.0
+    refgeo_idealised_MISMIP_mod_Hi_init_config   = -1.0                             ! Suggested value: 100 m
+    refgeo_idealised_ISMIP_HOM_L_config          = 0.0                              ! Suggested value: 5E3 - 160E3 m
+    refgeo_idealised_MISMIPplus_Hi_init_config   = 100.0                            ! Suggested value: 100 m
+    refgeo_idealised_MISMIPplus_tune_A_config    = .TRUE.                           ! If so, the uniform flow factor A is tuned to achieve a steady-state mid-stream grounding-line position at x = 450 km
+
+  ! == Mesh generation
+  ! ==================
+
+    ! How to set up the initial mesh
+    choice_initial_mesh_NAM_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_EAS_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_GRL_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_ANT_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+
+    ! Paths to files containing initial meshes, if choice_initial_mesh == 'read_from_file'
+    filename_initial_mesh_NAM_config             = ''
+    filename_initial_mesh_EAS_config             = ''
+    filename_initial_mesh_GRL_config             = ''
+    filename_initial_mesh_ANT_config             = ''
+
+    ! Resolutions for different parts of the ice sheet
+    maximum_resolution_uniform_config            = 10e3                             ! [m]          Maximum resolution for the entire domain
+    maximum_resolution_grounded_ice_config       = 8e3                              ! [m]          Maximum resolution for grounded ice
+    maximum_resolution_floating_ice_config       = 5e3                              ! [m]          Maximum resolution for floating ice
+    maximum_resolution_grounding_line_config     = 5e3                              ! [m]          Maximum resolution for the grounding line
+    maximum_resolution_calving_front_config      = 5e3                              ! [m]          Maximum resolution for the calving front
+    maximum_resolution_ice_front_config          = 20e3                             ! [m]          Maximum resolution for the ice front
+    maximum_resolution_coastline_config          = 1000e3                           ! [m]          Maximum resolution for the coastline
+
+    ! Widths for each resolution band
+    grounding_line_width_config                  = 2.5e3                            ! [m]          Width of the band around the grounding line that should get this resolution
+    calving_front_width_config                   = 2.5e3                            ! [m]          Width of the band around the calving front that should get this resolution
+    ice_front_width_config                       = 10e3                             ! [m]          Width of the band around the ice front that should get this resolution
+    coastline_width_config                       = 1000e3                           ! [m]          Width of the band around the coastline that should get this resolution
+
+    ! Regions of interest
+    choice_regions_of_interest_config            = ''                               ! Regions of interest where other (higher) resolutions apply. Separated by double vertical bars "||", e.g. "PineIsland||Thwaites"
+    ROI_maximum_resolution_uniform_config        = 100e3                            ! [m]          Maximum resolution for the entire domain
+    ROI_maximum_resolution_grounded_ice_config   = 50e3                             ! [m]          Maximum resolution for grounded ice
+    ROI_maximum_resolution_floating_ice_config   = 20e3                             ! [m]          Maximum resolution for floating ice
+    ROI_maximum_resolution_grounding_line_config = 5e3                              ! [m]          Maximum resolution for the grounding line
+    ROI_maximum_resolution_calving_front_config  = 10e3                             ! [m]          Maximum resolution for the calving front
+    ROI_maximum_resolution_ice_front_config      = 20e3                             ! [m]          Maximum resolution for the ice front
+    ROI_maximum_resolution_coastline_config      = 50e3                             ! [m]          Maximum resolution for the coastline
+
+    ! Widths for each resolution band
+    ROI_grounding_line_width_config              = 2e3                              ! [m]          Width of the band around the grounding line that should get this resolution
+    ROI_calving_front_width_config               = 10e3                             ! [m]          Width of the band around the calving front that should get this resolution
+    ROI_ice_front_width_config                   = 20e3                             ! [m]          Width of the band around the ice front that should get this resolution
+    ROI_coastline_width_config                   = 50e3                             ! [m]          Width of the band around the coastline that should get this resolution
+
+    ! Mesh update settings
+    allow_mesh_updates_config                    = .TRUE.                           ! [-]          Whether or not mesh updates are allowed
+    dt_mesh_update_min_config                    = 50.0                             ! [yr]         Minimum amount of time between mesh updates
+    minimum_mesh_fitness_coefficient_config      = 0.95                             ! [-]          If the mesh fitness drops below this threshold, trigger a mesh update
+    do_out_of_time_calving_front_relax_config    = .TRUE.                           !              Whether or not to step out of time and relax the calving front for a few iterations after a mesh update
+
+    ! Advanced geometry parameters
+    do_singlecore_mesh_creation_config           = .TRUE.                           !              Whether or not to use only a single core for mesh generation (for better reproducibility)
+    alpha_min_config                             = 0.4363                           ! [radians]    Smallest allowed internal triangle angle (recommended value: 25 degrees = 0.4363)
+    nit_Lloyds_algorithm_config                  = 3                                ! [-]          Number of iterations of Lloyds algorithm to be applied after refinement
+    mesh_resolution_tolerance_config             = 1.25                             ! [-]          Factors the target resolution for trangle-size requirement. 1=strict, use >1 to avoid unnecesarily high resolution
+
+    ! Square grid used for smoothing
+    dx_square_grid_smooth_NAM_config             = 2000.0
+    dx_square_grid_smooth_EAS_config             = 2000.0
+    dx_square_grid_smooth_GRL_config             = 2000.0
+    dx_square_grid_smooth_ANT_config             = 2000.0
+
+  ! == The scaled vertical coordinate zeta
+  ! ======================================
+
+    choice_zeta_grid_config                      = 'regular'                        ! The type of vertical grid to use; can be "regular", "irregular_log", "old_15_layer_zeta"
+    nz_config                                    = 12                               ! The number of vertical layers to use
+    zeta_irregular_log_R_config                  = 10.0                             ! Ratio between surface and base layer spacings
+
+  ! == Ice dynamics - velocity
+  ! ==========================
+
+    ! General
+    choice_stress_balance_approximation_config   = 'DIVA'                           ! Choice of stress balance approximation: "none" (= no flow, though geometry can still change due to mass balance), "SIA", "SSA", "SIA/SSA", "DIVA", "BPA"
+    choice_hybrid_SIASSA_scheme_config           = 'add'                            ! Choice of scheme for combining SIA and SSA velocities in the hybrid approach
+    do_include_SSADIVA_crossterms_config         = .TRUE.                           ! Whether or not to include the gradients of the effective viscosity (the "cross-terms") in the solution of the SSA/DIVA
+
+    ! Hybrid DIVA/BPA
+    choice_hybrid_DIVA_BPA_mask_NAM_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for North America
+    choice_hybrid_DIVA_BPA_mask_EAS_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Eurasia
+    choice_hybrid_DIVA_BPA_mask_GRL_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Greenland
+    choice_hybrid_DIVA_BPA_mask_ANT_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Antarctica
+
+    filename_hybrid_DIVA_BPA_mask_NAM_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for North America
+    filename_hybrid_DIVA_BPA_mask_EAS_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Eurasia
+    filename_hybrid_DIVA_BPA_mask_GRL_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Greenland
+    filename_hybrid_DIVA_BPA_mask_ANT_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Antarctica
+
+    ! Initialisation
+    choice_initial_velocity_NAM_config           = 'zero'                           ! Can be 'zero', 'read_from_file'
+    choice_initial_velocity_EAS_config           = 'zero'
+    choice_initial_velocity_GRL_config           = 'zero'
+    choice_initial_velocity_ANT_config           = 'zero'
+    ! Paths to files containing initial velocity fields
+    filename_initial_velocity_NAM_config         = ''
+    filename_initial_velocity_EAS_config         = ''
+    filename_initial_velocity_GRL_config         = ''
+    filename_initial_velocity_ANT_config         = ''
+    ! Timeframes to read from the initial velocity files (set to 1E9    if the file has no time dimension)
+    timeframe_initial_velocity_NAM_config        = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_initial_velocity_EAS_config        = 1E9
+    timeframe_initial_velocity_GRL_config        = 1E9
+    timeframe_initial_velocity_ANT_config        = 1E9
+
+    ! Some parameters for numerically solving the stress balance
+    SIA_maximum_diffusivity_config               = 1E5                              ! Limit the diffusivity in the SIA to this value
+    visc_it_norm_dUV_tol_config                  = 5E-5                             ! Stop criterion for the viscosity iteration: the L2-norm of successive velocity solutions should be smaller than this number
+    visc_it_nit_config                           = 50                               ! Maximum number of effective viscosity iterations
+    visc_it_relax_config                         = 0.2                              ! Relaxation parameter for subsequent viscosity iterations (for improved stability)
+    visc_eff_min_config                          = 1E4                              ! Minimum value for effective viscosity
+    vel_max_config                               = 5000.0                           ! Velocities are limited to this value
+    stress_balance_PETSc_rtol_config             = 1E-7                             ! PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
+    stress_balance_PETSc_abstol_config           = 1E-5                             ! PETSc solver - stop criterion, absolute difference
+
+    ! Boundary conditions
+    BC_u_west_config                             = 'zero'                           ! Boundary conditions for the ice velocity field at the domain border
+    BC_u_east_config                             = 'infinite'                       ! Allowed choices: "infinite", "zero", "periodic_ISMIP-HOM"
+    BC_u_south_config                            = 'infinite'
+    BC_u_north_config                            = 'infinite'
+    BC_v_west_config                             = 'zero'
+    BC_v_east_config                             = 'zero'
+    BC_v_south_config                            = 'zero'
+    BC_v_north_config                            = 'zero'
+
+  ! == Ice dynamics - sliding
+  ! =========================
+
+    ! General
+    choice_sliding_law_config                    = 'Schoof2005'                     ! Choice of sliding law: "no_sliding", "idealised", "Coulomb", "Budd", "Weertman", "Tsai2015", "Schoof2005", "Zoet-Iverson"
+    choice_idealised_sliding_law_config          = ''                               ! "ISMIP_HOM_C", "ISMIP_HOM_D", "ISMIP_HOM_E", "ISMIP_HOM_F"
+
+    ! Parameters for different sliding laws
+    slid_Weertman_m_config                       = 3.0                              ! Exponent in Weertman sliding law
+    slid_Budd_q_plastic_config                   = 0.3                              ! Scaling exponent in Budd sliding law
+    slid_Budd_u_threshold_config                 = 100.0                            ! Threshold velocity in Budd sliding law
+    slid_ZI_p_config                             = 5.0                              ! Velocity exponent used in the Zoet-Iverson sliding law
+    slid_ZI_ut_config                            = 200.0                            ! (uniform) transition velocity used in the Zoet-Iverson sliding law [m/yr]
+
+    ! Sub-grid scaling of basal friction
+    do_GL_subgrid_friction_config                = .TRUE.                           ! Whether or not to scale basal friction with the sub-grid grounded fraction (needed to get proper GL migration; only turn this off for showing the effect on the MISMIP_mod results!)
+    choice_subgrid_grounded_fraction_config      = 'bilin_interp_TAF+bedrock_CDF'   ! Choice of scheme to calculate the sub-grid grounded fractions: 'trilin', 'bedrock_CDF'
+    do_read_bedrock_cdf_from_file_config         = .FALSE.                          ! Whether or not to read the bedrock CDF from the initial mesh file. Requires choice_initial_mesh_XXX_config =  'read_from_file'!
+    subgrid_bedrock_cdf_nbins_config             = 11                               ! Number of bins to be used for sub-grid bedrock cumulative density functions
+    do_subgrid_friction_on_A_grid_config         = .FALSE.                          ! Whether or not to apply a preliminary scaling to basal hydrology and bed roughness on the A grid, before the final scaling of beta on the b grid. The exponent of this scaling is computed based on ice thickness.
+    subgrid_friction_exponent_on_B_grid_config   = 2.0                              ! Exponent to which f_grnd should be raised before being used to scale beta
+
+    ! Stability
+    slid_beta_max_config                         = 1E20                             ! Maximum value for basal friction coefficient
+    slid_delta_v_config                          = 1.0E-3                           ! Normalisation parameter to prevent errors when velocity is zero
+
+  ! == Ice dynamics - ice thickness calculation
+  ! ===========================================
+
+    ! Calculation of dH/dt
+    choice_ice_integration_method_config         = 'semi-implicit'                  ! Choice of ice thickness integration scheme: "none" (i.e. unchanging geometry), "explicit", "semi-implicit"
+    dHi_semiimplicit_fs_config                   = 1.5                              ! Factor for the semi-implicit ice thickness solver (0 = explicit, 0<f<1 = semi-implicit, 1 = implicit, >1 = over-implicit)
+    dHi_PETSc_rtol_config                        = 1E-8                             ! dHi PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
+    dHi_PETSc_abstol_config                      = 1E-6                             ! dHi PETSc solver - stop criterion, absolute difference
+
+    ! Boundary conditions
+    BC_H_west_config                             = 'infinite'                       ! Boundary conditions for ice thickness at the domain boundary
+    BC_H_east_config                             = 'zero'                           ! Allowed choices:  "infinite", "zero", "ISMIP_HOM_F"
+    BC_H_south_config                            = 'infinite'
+    BC_H_north_config                            = 'infinite'
+
+  ! == Ice dynamics - target quantities
+  ! ===================================
+
+    ! Target dHi_dt
+    do_target_dHi_dt_config                      = .FALSE.                          ! Whether or not to use a target dHi_dt field from an external file to alter the modelled one
+    do_limit_target_dHi_dt_to_SMB_config         = .TRUE.                           ! Whether or not to limit a target dHi_dt field to available SMB in that area, so it does not melt all ice there
+    target_dHi_dt_t_end_config                   = 9.9e9                            ! End time of target dHi_dt application
+
+    ! Files containing a target dHi_dt for inversions
+    filename_dHi_dt_target_NAM_config            = ''
+    filename_dHi_dt_target_EAS_config            = ''
+    filename_dHi_dt_target_GRL_config            = ''
+    filename_dHi_dt_target_ANT_config            = ''
+
+    ! Timeframes for reading target dHi_dt from file (set to 1E9_dp if the file has no time dimension)
+    timeframe_dHi_dt_target_NAM_config           = 1E9
+    timeframe_dHi_dt_target_EAS_config           = 1E9
+    timeframe_dHi_dt_target_GRL_config           = 1E9
+    timeframe_dHi_dt_target_ANT_config           = 1E9
+
+  ! == Ice dynamics - time stepping
+  ! ===============================
+
+    ! Time stepping
+    choice_timestepping_config                   = 'pc'                             ! Choice of timestepping method: "direct", "pc" (NOTE: 'direct' does not work with DIVA ice dynamcis!)
+    dt_ice_max_config                            = 10.0                             ! [yr] Maximum time step of the ice dynamics model
+    dt_ice_min_config                            = 0.5                              ! [yr] Minimum time step of the ice dynamics model
+    dt_ice_startup_phase_config                  = 0.0                              ! [yr] Length of time window after start_time and before end_time when dt = dt_min, to ensure smooth restarts
+    do_grounded_only_adv_dt_config               = .FALSE.                          ! If .TRUE., only grounded ice is used in the computation of the advective time step limit (CFL condition)
+
+    ! Predictor-corrector ice-thickness update
+    pc_epsilon_config                            = 0.005                            ! Target truncation error in dHi_dt [m/yr] (epsilon in Robinson et al., 2020, Eq. 33)
+    pc_k_I_config                                = 0.2                              ! Exponent k_I in  Robinson et al., 2020, Eq. 33
+    pc_k_p_config                                = 0.2                              ! Exponent k_p in  Robinson et al., 2020, Eq. 33
+    pc_eta_min_config                            = 1E-8                             ! Normalisation term in estimation of the truncation error (Robinson et al., Eq. 32)
+    pc_max_time_step_increase_config             = 1.1                              ! Each new time step is only allowed to be this much larger than the previous one
+    pc_nit_max_config                            = 50                               ! Maximum number of times a PC timestep can be repeated with reduced dt
+    pc_guilty_max_config                         = 0.0                              ! [%] Maximum percentage of grounded vertices allowed to have a truncation error larger than the tolerance pc_epsilon
+
+    ! Initialisation of the predictor-corrector ice-thickness update
+    pc_choice_initialise_NAM_config              = 'zero'                           ! How to initialise the p/c scheme: 'zero', 'read_from_file'
+    pc_choice_initialise_EAS_config              = 'zero'
+    pc_choice_initialise_GRL_config              = 'zero'
+    pc_choice_initialise_ANT_config              = 'zero'
+    ! Paths to files containing initial fields & values for the p/c scheme
+    filename_pc_initialise_NAM_config            = ''
+    filename_pc_initialise_EAS_config            = ''
+    filename_pc_initialise_GRL_config            = ''
+    filename_pc_initialise_ANT_config            = ''
+    ! Timeframes to read from the p/c scheme initial file (set to 1E9    if the file has no time dimension)
+    timeframe_pc_initialise_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_pc_initialise_EAS_config           = 1E9
+    timeframe_pc_initialise_GRL_config           = 1E9
+    timeframe_pc_initialise_ANT_config           = 1E9
+
+  ! == Ice dynamics - calving
+  ! =========================
+
+    choice_calving_law_config                    = 'none'                           ! Choice of calving law: "none", "threshold_thickness"
+    calving_threshold_thickness_shelf_config     = 100.0                            ! Threshold ice thickness for ice shelf calving front in the "threshold_thickness" calving law
+    calving_threshold_thickness_sheet_config     = 0.0                              ! Threshold ice thickness for ice sheet calving front in the "threshold_thickness" calving law
+    max_calving_rounds_config                    = 20                               ! Maximum number of calving loops during chain reaction
+    do_remove_shelves_config                     = .FALSE.                          ! If set to TRUE, all floating ice is always instantly removed (used in the ABUMIP-ABUK experiment)
+    remove_shelves_larger_than_PD_config         = .FALSE.                          ! If set to TRUE, all floating ice beyond the present-day calving front is removed (used for some Antarctic spin-ups)
+    continental_shelf_calving_config             = .FALSE.                          ! If set to TRUE, all ice beyond the continental shelf edge (set by a maximum depth) is removed
+    continental_shelf_min_height_config          = -2000.0                          ! Maximum depth of the continental shelf
+
+  ! == Ice dynamics - stabilisation
+  ! ===============================
+
+    choice_mask_noice_config                     = 'MISMIP+'                        ! Choice of mask_noice configuration
+    Hi_min_config                                = 0.0                              ! [m] Minimum ice thickness: thinner ice gets temporarily added to the no-ice mask and eventually removed
+    Hi_thin_config                               = 0.0                              ! [m] Thin-ice thickness threshold: thinner ice is considered dynamically unreliable (e.g. over steep slopes)
+    remove_ice_absent_at_PD_config               = .FALSE.                          ! If set to TRUE, all ice not present in PD data is always instantly removed
+
+    ! Geometry relaxation
+    geometry_relaxation_t_years_config           = 0.0                              ! [yr] Amount of years (out-of-time) during which the geometry will relaxed during initialisation: no mass balance, thickness alterations, inversions, or target thinning rates will be applied during this time
+
+    ! Mask conservation
+    do_protect_grounded_mask_config              = .FALSE.                          ! If set to TRUE, grounded ice will not be allowed to cross the floatation threshold and will stay minimally grounded.
+    protect_grounded_mask_t_end_config           = 20000.0                          ! End time of grounded mask protection. After this time, it will be allowed to thin and become afloat
+
+    ! Fix/delay ice thickness evolution
+    do_fixiness_before_start_config              = .TRUE.                           ! Whether or not to apply fixiness values before fixiness_t_start
+    fixiness_t_start_config                      = -9.9E9                           ! Start time of linear transition between fixed/delayed and free evolution
+    fixiness_t_end_config                        = -8.8E8                           ! End   time of linear transition between fixed/delayed and free evolution
+    fixiness_H_gl_gr_config                      = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_gl_fl_config                      = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_grounded_config                   = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_floating_config                   = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_freeland_config                   = .FALSE.                          ! Fix (.TRUE.) ice-free vertices between fixiness_t_start and fixiness_t_end
+    fixiness_H_freeocean_config                  = .FALSE.                          ! Fix (.TRUE.) ice-free vertices between fixiness_t_start and fixiness_t_end
+
+    ! Limit ice thickness evolution
+    do_limitness_before_start_config             = .TRUE.                           ! Whether or not to apply limitness values before limitness_t_start
+    limitness_t_start_config                     = -9.9E9                           ! Start time of linear transition between limited and free evolution
+    limitness_t_end_config                       = -8.8E8                           ! End   time of linear transition between limited and free evolution
+    limitness_H_gl_gr_config                     = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_gl_fl_config                     = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_grounded_config                  = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_floating_config                  = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    modiness_H_style_config                      = 'none'                           ! Dynamic "modiness" limitness-like term: "none", "Ti_hom", "Ti_hom_up", "Ti_hom_down"
+    modiness_T_hom_ref_config                    = 5.0                              ! Reference Ti_hom for the modiness cold exponential style
+
+  ! == Basal hydrology
+  ! ==================
+
+    ! Basal hydrology
+    choice_basal_hydrology_model_config          = 'Martin2011'                     ! Choice of basal hydrology model: "saturated", "Martin2011"
+    Martin2011_hydro_Hb_min_config               = 0.0                              ! Martin et al. (2011) basal hydrology model: low-end  Hb  value of bedrock-dependent pore-water pressure
+    Martin2011_hydro_Hb_max_config               = 1000.0                           ! Martin et al. (2011) basal hydrology model: high-end Hb  value of bedrock-dependent pore-water pressure
+
+  ! == Bed roughness
+  ! ================
+
+    choice_bed_roughness_config                  = 'parameterised'                  ! Choice of source for friction coefficients: "uniform", "parameterised", "read_from_file"
+    choice_bed_roughness_parameterised_config    = 'MISMIPplus'                        ! "Martin2011", "SSA_icestream", "MISMIPplus", "BIVMIP_A", "BIVMIP_B", "BIVMIP_C"
+    ! Paths to files containing bed roughness fields for the chosen sliding law
+    filename_bed_roughness_NAM_config            = ''
+    filename_bed_roughness_EAS_config            = ''
+    filename_bed_roughness_GRL_config            = ''
+    filename_bed_roughness_ANT_config            = ''
+    ! Timeframes to read from the bed roughness file (set to 1E9    if the file has no time dimension)
+    timeframe_bed_roughness_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_bed_roughness_EAS_config           = 1E9
+    timeframe_bed_roughness_GRL_config           = 1E9
+    timeframe_bed_roughness_ANT_config           = 1E9
+    ! Values for uniform bed roughness
+    slid_Weertman_beta_sq_uniform_config         = 1.0E4                            ! Uniform value for beta_sq  in Weertman sliding law
+    slid_Coulomb_phi_fric_uniform_config         = 15.0                             ! Uniform value for phi_fric in Coulomb sliding law
+    slid_Budd_phi_fric_uniform_config            = 15.0                             ! Uniform value for phi_fric in Budd sliding law
+    slid_Tsai2015_alpha_sq_uniform_config        = 0.5                              ! Uniform value for alpha_sq in the Tsai2015 sliding law
+    slid_Tsai2015_beta_sq_uniform_config         = 1.0E4                            ! Uniform value for beta_sq  in the Tsai2015 sliding law
+    slid_Schoof2005_alpha_sq_uniform_config      = 0.5                              ! Uniform value for alpha_sq in the Schoof2005 sliding law
+    slid_Schoof2005_beta_sq_uniform_config       = 1.0E4                            ! Uniform value for beta_sq  in the Schoof2005 sliding law
+    slid_ZI_phi_fric_uniform_config              = 10.0                             ! Uniform value for phi_fric in the Zoet-Iverson sliding law
+    ! Parameters for bed roughness parameterisations
+    Martin2011till_phi_Hb_min_config             = -1000.0                          ! Martin et al. (2011) bed roughness parameterisation: low-end  Hb  value of bedrock-dependent till friction angle
+    Martin2011till_phi_Hb_max_config             = 0.0                              ! Martin et al. (2011) bed roughness parameterisation: high-end Hb  value of bedrock-dependent till friction angle
+    Martin2011till_phi_min_config                = 5.0                              ! Martin et al. (2011) bed roughness parameterisation: low-end  phi value of bedrock-dependent till friction angle
+    Martin2011till_phi_max_config                = 20.0                             ! Martin et al. (2011) bed roughness parameterisation: high-end phi value of bedrock-dependent till friction angle
+
+  ! == Bed roughness inversion by nudging
+  ! =====================================
+
+    ! General
+    do_bed_roughness_nudging_config              = .FALSE.                          !           Whether or not to nudge the basal roughness
+    choice_bed_roughness_nudging_method_config   = ''                               !           Choice of bed roughness nudging method
+    choice_inversion_target_geometry_config      = ''                               !           Which reference geometry to use as the target geometry (can be "init" or "PD")
+    bed_roughness_nudging_dt_config              = 5.0                              ! [yr]      Time step for bed roughness updates
+    bed_roughness_nudging_t_start_config         = -9.9E9                           ! [yr]      Earliest model time when nudging is allowed
+    bed_roughness_nudging_t_end_config           = +9.9E9                           ! [yr]      Latest   model time when nudging is allowed
+    generic_bed_roughness_min_config             = 0.1                              ! [?]       Smallest allowed value for the first  inverted bed roughness field
+    generic_bed_roughness_max_config             = 30.0                             ! [?]       Largest  allowed value for the first  inverted bed roughness field
+
+    ! Basal inversion model based on flowline-averaged values of H and dH/dt
+    bednudge_H_dHdt_flowline_t_scale_config      = 100.0                            ! [yr]      Timescale
+    bednudge_H_dHdt_flowline_dH0_config          = 100.0                            ! [m]       Ice thickness error scale
+    bednudge_H_dHdt_flowline_dHdt0_config        = 0.6                              ! [m yr^-1] Thinning rate scale
+    bednudge_H_dHdt_flowline_Hi_scale_config     = 300.0                            ! [m]       Ice thickness weight scale
+    bednudge_H_dHdt_flowline_u_scale_config      = 3000.0                           ! [m yr^-1] Ice velocity  weight scale
+    bednudge_H_dHdt_flowline_r_smooth_config     = 2500.0                           ! [m]       Radius for Gaussian filter used to smooth dC/dt as regularisation
+    bednudge_H_dHdt_flowline_w_smooth_config     = 0.5                              ! [-]       Relative contribution of smoothed dC/dt in regularisation
+
+  ! == Geothermal heat flux
+  ! =======================
+
+    choice_geothermal_heat_flux_config           = 'uniform'                        ! Choice of geothermal heat flux; can be 'uniform' or 'read_from_file'
+    uniform_geothermal_heat_flux_config          = 1.72E06                          ! Value when choice_geothermal_heat_flux == 'uniform' (1.72E06 J m^-2 yr^-1 according to Sclater et al. (1980))
+    filename_geothermal_heat_flux_config         = 'external/data/GHF/geothermal_heatflux_ShapiroRitzwoller2004_global_1x1_deg.nc'
+
+  ! == Thermodynamics
+  ! =================
+
+    ! Initial temperature profile
+    choice_initial_ice_temperature_NAM_config    = 'Robin'                          ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "read_from_file"
+    choice_initial_ice_temperature_EAS_config    = 'Robin'
+    choice_initial_ice_temperature_GRL_config    = 'Robin'
+    choice_initial_ice_temperature_ANT_config    = 'uniform'
+    ! Uniform initial ice temperature, if choice_initial_ice_temperature == 'uniform'
+    uniform_initial_ice_temperature_NAM_config   = 270.0                            ! Uniform ice temperature (applied when choice_initial_ice_temperature_config = "uniform")
+    uniform_initial_ice_temperature_EAS_config   = 270.0
+    uniform_initial_ice_temperature_GRL_config   = 270.0
+    uniform_initial_ice_temperature_ANT_config   = 270.0
+    ! Paths to files containing initial temperature fields, if
+    filename_initial_ice_temperature_NAM_config  = ''
+    filename_initial_ice_temperature_EAS_config  = ''
+    filename_initial_ice_temperature_GRL_config  = ''
+    filename_initial_ice_temperature_ANT_config  = ''
+    ! Timeframes to read from the bed roughness file (set to 1E9    if the file has no time dimension)
+    timeframe_initial_ice_temperature_NAM_config = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_initial_ice_temperature_EAS_config = 1E9
+    timeframe_initial_ice_temperature_GRL_config = 1E9
+    timeframe_initial_ice_temperature_ANT_config = 1E9
+    ! Thermodynamical model
+    choice_thermo_model_config                   = 'none'                           ! Choice of thermodynamical model: "none", "3D_heat_equation"
+    dt_thermodynamics_config                     = 1.0                              ! [yr] Time step for the thermodynamical model
+    Hi_min_thermo_config                         = 10.0                             ! [m]  Ice thinner than this is assumed to have a temperature equal to the annual mean surface temperature throughout the vertical column
+    choice_GL_temperature_BC_config              = 'grounded'                       ! Choice of basal boundary condition at grounding lines: 'grounded', 'subgrid', 'pmp'
+    choice_ice_heat_capacity_config              = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Pounder1965"
+    uniform_ice_heat_capacity_config             = 2009.0                           ! Uniform ice heat capacity (applied when choice_ice_heat_capacity_config = "uniform")
+    choice_ice_thermal_conductivity_config       = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Ritz1987"
+    uniform_ice_thermal_conductivity_config      = 6.626958E7                       ! Uniform ice thermal conductivity (applied when choice_ice_thermal_conductivity_config = "uniform")
+
+  ! == Rheology and flow law
+  ! =========================
+
+    ! Flow law
+    choice_flow_law_config                       = 'Glen'                           ! Choice of flow law, relating effective viscosity to effective strain rate
+    Glens_flow_law_exponent_config               = 3.0                              ! Exponent in Glen`s flow law
+    Glens_flow_law_epsilon_sq_0_config           = 1E-8                             ! Normalisation term so that zero strain rates produce a high but finite viscosity
+
+    ! Rheology
+    choice_ice_rheology_Glen_config              = 'uniform'                        ! Choice of ice rheology model for Glen`s flow law: "uniform", "Huybrechts1992", "MISMIP_mod"
+    uniform_Glens_flow_factor_config             = 1.3313399224193791E-017          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
+
+    ! Enhancement factors
+    choice_enhancement_factor_transition_config  = 'separate'                       ! Choice of treatment of enhancement factors at transition zones: "separate", "interp"
+    m_enh_sheet_config                           = 1.0                              ! Ice flow enhancement factor for grounded ice
+    m_enh_shelf_config                           = 1.0                              ! Ice flow enhancement factor for floating ice
+
+  ! == Climate
+  ! ==========
+
+    ! Time step
+    do_asynchronous_climate_config               = .TRUE.                           ! Whether or not the climate should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_climate_config                            = 10.0                             ! [yr] Time step for calculating climate
+
+    ! Choice of climate model
+    choice_climate_model_NAM_config              = 'none'
+    choice_climate_model_EAS_config              = 'none'
+    choice_climate_model_GRL_config              = 'none'
+    choice_climate_model_ANT_config              = 'none'
+
+    ! Choice of idealised climate model
+    choice_climate_model_idealised_config        = ''
+
+    ! Choice of realistic climate model
+    choice_climate_model_realistic_config        = ''
+
+    filename_climate_snapshot_NAM_config         = ''
+    filename_climate_snapshot_EAS_config         = ''
+    filename_climate_snapshot_GRL_config         = ''
+    filename_climate_snapshot_ANT_config         = ''
+
+  ! == Ocean
+  ! ========
+
+    ! Time step
+    do_asynchronous_ocean_config                 = .TRUE.                           ! Whether or not the ocean should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_ocean_config                              = 10.0                             ! [yr] Time step for calculating ocean
+
+    ! Vertical grid
+    ocean_vertical_grid_max_depth_config         = 1500.0                           ! Maximum depth of the ocean submodel
+    ocean_vertical_grid_dz_config                = 100.0                            ! Vertical distance between ocean layers
+
+    ! Choice of ocean model
+    choice_ocean_model_NAM_config                = 'none'
+    choice_ocean_model_EAS_config                = 'none'
+    choice_ocean_model_GRL_config                = 'none'
+    choice_ocean_model_ANT_config                = 'none'
+
+    ! Choice of idealised ocean model
+    choice_ocean_model_idealised_config          = ''
+
+    ! Choice of realistic ocean model
+    choice_ocean_model_realistic_config          = ''
+
+    filename_ocean_snapshot_NAM_config           = ''
+    filename_ocean_snapshot_EAS_config           = ''
+    filename_ocean_snapshot_GRL_config           = ''
+    filename_ocean_snapshot_ANT_config           = ''
+
+  ! == Surface mass balance
+  ! =======================
+
+    ! Time step
+    do_asynchronous_SMB_config                   = .TRUE.                           ! Whether or not the SMB should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_SMB_config                                = 10.0                             ! [yr] Time step for calculating SMB
+
+    ! Choice of SMB model
+    choice_SMB_model_NAM_config                  = 'uniform'
+    choice_SMB_model_EAS_config                  = 'uniform'
+    choice_SMB_model_GRL_config                  = 'uniform'
+    choice_SMB_model_ANT_config                  = 'idealised'
+
+    ! Choice of idealised SMB model
+    choice_SMB_model_idealised_config            = 'uniform'
+
+    ! Value to be used for uniform SMB (no regional variants, only used for idealised-geometry experiments)
+    uniform_SMB_config                           = 0.3
+
+    ! Prescribed SMB forcing
+    choice_SMB_prescribed_NAM_config             = ''
+    choice_SMB_prescribed_EAS_config             = ''
+    choice_SMB_prescribed_GRL_config             = ''
+    choice_SMB_prescribed_ANT_config             = ''
+
+    ! Files containing prescribed SMB forcing
+    filename_SMB_prescribed_NAM_config           = ''
+    filename_SMB_prescribed_EAS_config           = ''
+    filename_SMB_prescribed_GRL_config           = ''
+    filename_SMB_prescribed_ANT_config           = ''
+
+    ! Timeframes for reading prescribed SMB forcing from file (set to 1E9 if the file has no time dimension)
+    timeframe_SMB_prescribed_NAM_config          = 1E9
+    timeframe_SMB_prescribed_EAS_config          = 1E9
+    timeframe_SMB_prescribed_GRL_config          = 1E9
+    timeframe_SMB_prescribed_ANT_config          = 1E9
+
+  ! == Basal mass balance
+  ! =====================
+
+    ! Time step
+    do_asynchronous_BMB_config                   = .TRUE.                           ! Whether or not the BMB should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_BMB_config                                = 10.0                             ! [yr] Time step for calculating BMB
+
+    ! Grounding line treatment
+    choice_BMB_subgrid_config                    = 'NMP'                               ! Choice of sub-grid BMB scheme: "FCMP", "PMP" (following Leguy et al., 2021)
+
+    ! Choice of BMB model
+    choice_BMB_model_NAM_config                  = 'uniform'
+    choice_BMB_model_EAS_config                  = 'uniform'
+    choice_BMB_model_GRL_config                  = 'uniform'
+    choice_BMB_model_ANT_config                  = 'uniform'
+
+    ! Choice of idealised BMB model
+    choice_BMB_model_idealised_config            = ''
+
+    ! Choice of parameterised BMB model
+    choice_BMB_model_parameterised_config        = 'Favier2019'
+
+    ! "uniform"
+    uniform_BMB_config                           = 0.0
+
+    ! "parameterised"
+    BMB_Favier2019_gamma_config                  = 99.32E-5
+
+  ! == Lateral mass balance
+  ! =======================
+
+    ! Time step
+    dt_LMB_config                                = 5.0                              ! [yr] Time step for calculating LMB [not implemented yet]
+
+    ! Choice of LMB model
+    choice_LMB_model_NAM_config                  = 'uniform'
+    choice_LMB_model_EAS_config                  = 'uniform'
+    choice_LMB_model_GRL_config                  = 'uniform'
+    choice_LMB_model_ANT_config                  = 'uniform'
+
+    ! "uniform"
+    uniform_LMB_config                           = 0.0
+
+  ! == Glacial isostatic adjustment
+  ! ===============================
+
+    ! General settings
+    choice_GIA_model_config                      = 'none'
+    dt_GIA_config                                = 100.0                            ! [yr] GIA model time step
+    dx_GIA_config                                = 2000.0                           ! [m]  GIA model square grid resolution
+
+  ! == Sea level
+  ! ============
+
+    choice_sealevel_model_config                 = 'fixed'                          !     Can be "fixed", "prescribed", "eustatic", or "SELEN"
+    fixed_sealevel_config                        = 0.0                              ! [m] Fixed sea level value for the "fixed" choice
+
+  ! == SELEN
+  ! ========
+
+    SELEN_run_at_t_start_config                  = .FALSE.                          ! Whether or not to run SELEN in the first coupling loop (needed for some benchmark experiments)
+    SELEN_n_TDOF_iterations_config               = 1                                ! Number of Time-Dependent Ocean Function iterations
+    SELEN_n_recursion_iterations_config          = 1                                ! Number of recursion iterations
+    SELEN_use_rotational_feedback_config         = .FALSE.                          ! If TRUE, rotational feedback is included
+    SELEN_n_harmonics_config                     = 128                              ! Maximum number of harmonic degrees
+    SELEN_display_progress_config                = .FALSE.                          ! Whether or not to display the progress of the big loops to the screen
+
+    SELEN_dir_config                             = 'external/data/SELEN'                     ! Directory where SELEN initial files and spherical harmonics are stored
+    SELEN_global_topo_filename_config            = 'SELEN_global_topography.nc'     ! Filename for the SELEN global topography file (located in SELEN_dir)
+    SELEN_TABOO_init_filename_config             = 'SELEN_TABOO_initial_file.dat'   ! Filename for the TABOO initial file           (idem                )
+    SELEN_LMJ_VALUES_filename_config             = 'SELEN_lmj_values.bin'           ! Filename for the LJ and MJ values file        (idem                )
+
+    SELEN_irreg_time_n_config                    = 15                               ! Number of entries in the irregular moving time window
+    SELEN_irreg_time_window_config               = 20.0  , 20.0  , 20.0  , 5.0  , 5.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 0.0  ,  0.0  ,  0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  ,  0.0  ,  0.0  ,  0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  ,  0.0  ,  0.0  , 0.0  , 0.0
+
+    SELEN_lith_thickness_config                  = 100.0                            ! Thickness of the elastic lithosphere [km]
+    SELEN_visc_n_config                          = 3                                ! Number      of viscous asthenosphere layers
+    SELEN_visc_prof_config                       = 3.0  , 0.6   , 0.3               ! Viscosities of viscous asthenosphere layers [?]
+
+    ! Settings for the TABOO Earth deformation model
+    SELEN_TABOO_CDE_config                       = 0                                !     code of the model (see taboo for explanation)
+    SELEN_TABOO_TLOVE_config                     = 1                                !     Tidal love numbers yes/no
+    SELEN_TABOO_DEG1_config                      = 1                                !     Tidal love numbers degree
+    SELEN_TABOO_RCMB_config                      = 3480.0                           ! [m] Radius of CMB
+
+  ! == Output
+  ! =========
+
+    ! Basic settings
+    do_create_netcdf_output_config               = .TRUE.                           !     Whether or not NetCDF output files should be created at all
+    dt_output_config                             = 100.0                            !     Time step for writing output
+    dt_output_restart_config                     = 30000.0                          !     Time step for writing restart output
+    dt_output_grid_config                        = 5000.0                           !     Time step for writing gridded output
+    dx_output_grid_NAM_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for North America
+    dx_output_grid_EAS_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for Eurasia
+    dx_output_grid_GRL_config                    = 20E3                             ! [m] Horizontal resolution for the square grid used for output for Greenland
+    dx_output_grid_ANT_config                    = 2e3                              ! [m] Horizontal resolution for the square grid used for output for Antarctica
+    dx_output_grid_ROI_NAM_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for North America
+    dx_output_grid_ROI_EAS_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Eurasia
+    dx_output_grid_ROI_GRL_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Greenland
+    dx_output_grid_ROI_ANT_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Antarctica
+
+    ! Transects
+    transects_NAM_config                         = ''                              ! List of transects to use for North America
+    transects_EAS_config                         = ''                              ! List of transects to use for Eurasia
+    transects_GRL_config                         = ''                              ! List of transects to use for Greenland
+    transects_ANT_config                         = 'westeast,dx=1e3'                              ! List of transects to use for Antarctica
+
+    ! Which data fields we want to write to the main NetCDF output files
+    choice_output_field_01_config                = 'mask'
+    choice_output_field_02_config                = 'Hi'
+    choice_output_field_03_config                = 'Hb'
+    choice_output_field_04_config                = 'Hs'
+    choice_output_field_05_config                = 'u_vav'
+    choice_output_field_06_config                = 'v_vav'
+    choice_output_field_07_config                = 'uabs_vav'
+    choice_output_field_08_config                = 'fraction_gr'
+    choice_output_field_09_config                = 'fraction_gr_b'
+    choice_output_field_10_config                = 'basal_friction_coefficient'
+    choice_output_field_11_config                = 'pc_truncation_error'
+    choice_output_field_12_config                = 'SMB'
+    choice_output_field_13_config                = 'dHi_dt'
+    choice_output_field_14_config                = 'divQ'
+    choice_output_field_15_config                = 'BMB'
+    choice_output_field_16_config                = 'R_shear'
+    choice_output_field_17_config                = 'grounding_line'
+    choice_output_field_18_config                = 'calving_front'
+    choice_output_field_19_config                = 'ice_margin'
+    choice_output_field_20_config                = 'coastline'
+    choice_output_field_21_config                = 'none'
+    choice_output_field_22_config                = 'none'
+    choice_output_field_23_config                = 'none'
+    choice_output_field_24_config                = 'none'
+    choice_output_field_25_config                = 'none'
+    choice_output_field_26_config                = 'none'
+    choice_output_field_27_config                = 'none'
+    choice_output_field_28_config                = 'none'
+    choice_output_field_29_config                = 'none'
+    choice_output_field_30_config                = 'none'
+    choice_output_field_31_config                = 'none'
+    choice_output_field_32_config                = 'none'
+    choice_output_field_33_config                = 'none'
+    choice_output_field_34_config                = 'none'
+    choice_output_field_35_config                = 'none'
+    choice_output_field_36_config                = 'none'
+    choice_output_field_37_config                = 'none'
+    choice_output_field_38_config                = 'none'
+    choice_output_field_39_config                = 'none'
+    choice_output_field_40_config                = 'none'
+    choice_output_field_41_config                = 'none'
+    choice_output_field_42_config                = 'none'
+    choice_output_field_43_config                = 'none'
+    choice_output_field_44_config                = 'none'
+    choice_output_field_45_config                = 'none'
+    choice_output_field_46_config                = 'none'
+    choice_output_field_47_config                = 'none'
+    choice_output_field_48_config                = 'none'
+    choice_output_field_49_config                = 'none'
+    choice_output_field_50_config                = 'none'
+
+/

--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_03_5km_ice1r.cfg
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_03_5km_ice1r.cfg
@@ -1,0 +1,799 @@
+&CONFIG
+
+  ! General model instructions
+  ! ==========================
+
+    ! Output directory
+    create_procedural_output_dir_config          = .FALSE.                          ! Automatically create an output directory with a procedural name (e.g. results_20210720_001/)
+    fixed_output_dir_config                      = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_5km_ice1r' ! If not, create a directory with this name instead (stops the program if this directory already exists)
+
+    ! Debugging
+    do_benchmarks_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
+    do_unit_tests_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
+    do_check_for_NaN_config                      = .FALSE.                          ! Whether or not fields should be checked for NaN values
+    do_time_display_config                       = .TRUE.                           ! Print current model time to screen
+
+  ! == Time of simulation
+  ! =====================
+
+    start_time_of_run_config                     = 0.0                              ! [yr] Start time of the simulation
+    end_time_of_run_config                       = 100.0                            ! [yr] End   time of the simulation
+
+  ! == Which model regions to simulate
+  ! ==================================
+
+    dt_coupling_config                           = 1000.0                           ! [yr] Interval of coupling between the different model regions
+    do_NAM_config                                = .FALSE.
+    do_EAS_config                                = .FALSE.
+    do_GRL_config                                = .FALSE.
+    do_ANT_config                                = .TRUE.
+
+  ! == The four model regions
+  ! =========================
+
+    ! North America
+    lambda_M_NAM_config                          = 265.0                            ! [degrees east]  [default: 265.0]   Longitude of the pole of the stereographic projection for the North America domain
+    phi_M_NAM_config                             =  62.0                            ! [degrees north] [default:  62.0]   Latitude  of the pole of the stereographic projection for the North America domain
+    beta_stereo_NAM_config                       =  71.0                            ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the North America domain
+    xmin_NAM_config                              = -3600000.0                       ! [m]             [default: -3600E3] Western  boundary     of the North America domain
+    xmax_NAM_config                              =  3600000.0                       ! [m]             [default:  3600E3] Eastern  boundary     of the North America domain
+    ymin_NAM_config                              = -2400000.0                       ! [m]             [default: -2400E3] Southern boundary     of the North America domain
+    ymax_NAM_config                              =  2400000.0                       ! [m]             [default:  2400E3] Northern boundary     of the North America domain
+
+    ! Eurasia
+    lambda_M_EAS_config                          = 40.0                             ! [degrees east]  [default:  40.0]   Longitude of the pole of the stereographic projection for the Eurasia domain
+    phi_M_EAS_config                             = 70.0                             ! [degrees north] [default:  70.0]   Latitude  of the pole of the stereographic projection for the Eurasia domain
+    beta_stereo_EAS_config                       = 71.0                             ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the Eurasia domain
+    xmin_EAS_config                              = -3400000.0                       ! [m]             [default: -3400E3] Western  boundary     of the Eurasia domain
+    xmax_EAS_config                              =  3400000.0                       ! [m]             [default:  3400E3] Eastern  boundary     of the Eurasia domain
+    ymin_EAS_config                              = -2080000.0                       ! [m]             [default: -2080E3] Southern boundary     of the Eurasia domain
+    ymax_EAS_config                              =  2080000.0                       ! [m]             [default:  2080E3] Northern boundary     of the Eurasia domain
+
+    ! Greenland
+    lambda_M_GRL_config                          = -45.0                            ! [degrees east]  [default: -45.0]   Longitude of the pole of the stereographic projection for the Greenland domain
+    phi_M_GRL_config                             = 90.0                             ! [degrees north] [default:  90.0]   Latitude  of the pole of the stereographic projection for the Greenland domain
+    beta_stereo_GRL_config                       = 70.0                             ! [degrees]       [default:  70.0]   Standard parallel     of the stereographic projection for the Greenland domain
+    xmin_GRL_config                              =  -720000.0                       ! [m]             [default:  -720E3] Western  boundary     of the Greenland domain [m]
+    xmax_GRL_config                              =   960000.0                       ! [m]             [default:   960E3] Eastern  boundary     of the Greenland domain [m]
+    ymin_GRL_config                              = -3450000.0                       ! [m]             [default: -3450E3] Southern boundary     of the Greenland domain [m]
+    ymax_GRL_config                              =  -570000.0                       ! [m]             [default:  -570E3] Northern boundary     of the Greenland domain [m]
+
+    ! Antarctica
+    lambda_M_ANT_config                          = 0.0                              ! [degrees east]  [default:   0.0]   Longitude of the pole of the stereographic projection for the Antarctica domain
+    phi_M_ANT_config                             = -90.0                            ! [degrees north] [default: -90.0]   Latitude  of the pole of the stereographic projection for the Antarctica domain
+    beta_stereo_ANT_config                       = 71.0                             ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the Antarctica domain
+    xmin_ANT_config                              = 0.0                              ! [m]             [default: -3040E3] Western  boundary     of the Antarctica domain [m]
+    xmax_ANT_config                              = 800000.0                         ! [m]             [default:  3040E3] Eastern  boundary     of the Antarctica domain [m]
+    ymin_ANT_config                              = -40000.0                         ! [m]             [default: -3040E3] Southern boundary     of the Antarctica domain [m]
+    ymax_ANT_config                              =  40000.0                         ! [m]             [default:  3040E3] Northern boundary     of the Antarctica domain [m]
+
+  ! == Reference geometries (initial, present-day, and GIA equilibrium)
+  ! ===================================================================
+
+    ! Some pre-processing stuff for reference ice geometry
+    refgeo_Hi_min_config                         = 2.0                              ! [m]             [default: 2.0]     Remove ice thinner than this value in the reference ice geometry. Particularly useful for BedMachine Greenland, which somehow covers the entire tundra with half a meter of ice...
+    do_smooth_geometry_config                    = .FALSE                           ! Whether or not to smooth the reference bedrock
+    r_smooth_geometry_config                     = 0.5                              ! [m]             Geometry smoothing radius
+    remove_Lake_Vostok_config                    = .FALSE.                          ! Whether or not to replace subglacial Lake Vostok in Antarctica with ice (recommended to set to TRUE, otherwise it will really slow down your model for the first few hundred years...)
+
+    ! == Initial geometry
+    ! ===================
+
+    choice_refgeo_init_NAM_config                = 'read_from_file'                 ! Choice of initial geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_init_EAS_config                = 'read_from_file'                 ! Choice of initial geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_init_GRL_config                = 'read_from_file'                 ! Choice of initial geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_init_ANT_config                = 'read_from_file'                 ! Choice of initial geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_init == 'idealised'
+    choice_refgeo_init_idealised_config          = 'MISMIPplus'                        ! Choice of idealised initial geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_init_idealised_config              = 1000.0                           ! Resolution of square grid used for idealised initial geometry
+    ! Path to file containing initial geometry when choice_refgeo_init == 'read_from_file'
+    filename_refgeo_init_NAM_config              = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_init_EAS_config              = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_init_GRL_config              = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_init_ANT_config              = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/main_output_ANT_LAST.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_init_NAM_config             = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_init_EAS_config             = 1E9
+    timeframe_refgeo_init_GRL_config             = 1E9
+    timeframe_refgeo_init_ANT_config             = 1e9
+
+    ! == Present-day geometry
+    ! =======================
+
+    choice_refgeo_PD_NAM_config                  = 'read_from_file'                 ! Choice of present-day geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_EAS_config                  = 'read_from_file'                 ! Choice of present-day geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_GRL_config                  = 'read_from_file'                 ! Choice of present-day geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_ANT_config                  = 'idealised'                      ! Choice of present-day geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_PD == 'idealised'
+    choice_refgeo_PD_idealised_config            = 'MISMIPplus'                        ! Choice of idealised present-day geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_PD_idealised_config                = 1000.0                           ! Resolution of square grid used for idealised present-day geometry
+    ! Path to file containing present-day geometry when choice_refgeo_PD == 'read_from_file'
+    filename_refgeo_PD_NAM_config                = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_PD_EAS_config                = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_PD_GRL_config                = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_PD_ANT_config                = 'external/data/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_PD_NAM_config               = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_PD_EAS_config               = 1E9
+    timeframe_refgeo_PD_GRL_config               = 1E9
+    timeframe_refgeo_PD_ANT_config               = 1E9
+
+    ! == GIA equilibrium geometry
+    ! ===========================
+
+    choice_refgeo_GIAeq_NAM_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_EAS_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_GRL_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_ANT_config               = 'idealised'                      ! Choice of GIA equilibrium reference geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_GIAeq == 'idealised'
+    choice_refgeo_GIAeq_idealised_config         = 'MISMIPplus'                        ! Choice of idealised GIA equilibrium reference geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_GIAeq_idealised_config             = 1000.0                           ! Resolution of square grid used for idealised GIA equilibrium reference geometry
+    ! Path to file containing GIA equilibrium reference geometry when choice_refgeo_GIAeq == 'read_from_file'
+    filename_refgeo_GIAeq_NAM_config             = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_GIAeq_EAS_config             = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_GIAeq_GRL_config             = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_GIAeq_ANT_config             = 'external/data/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_GIAeq_NAM_config            = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_GIAeq_EAS_config            = 1E9
+    timeframe_refgeo_GIAeq_GRL_config            = 1E9
+    timeframe_refgeo_GIAeq_ANT_config            = 1E9
+
+    ! == Parameters for idealised geometries
+    ! ======================================
+
+    refgeo_idealised_slabonaslope_Hi_config      = 0.0                              ! Suggested value: 2000 m
+    refgeo_idealised_slabonaslope_dhdx_config    = 1.0                              ! Suggested value: -0.001
+    refgeo_idealised_Halfar_H0_config            = 0.0                              ! Suggested value: 3000 m
+    refgeo_idealised_Halfar_R0_config            = 0.0                              ! Suggested value: 500E3 m
+    refgeo_idealised_Bueler_H0_config            = 0.0                              ! Suggested value: 3000 m
+    refgeo_idealised_Bueler_R0_config            = 0.0                              ! Suggested value: 500E3 m
+    refgeo_idealised_Bueler_lambda_config        = 0.0                              ! Suggested value: 5.0
+    refgeo_idealised_SSA_icestream_Hi_config     = -1.0                             ! Suggested value: 2000 m
+    refgeo_idealised_SSA_icestream_dhdx_config   = 1.0                              ! Suggested value: -0.0003
+    refgeo_idealised_SSA_icestream_L_config      = 0.0                              ! Suggested value: 150 km
+    refgeo_idealised_SSA_icestream_m_config      = 0.0                              ! Suggested value: 1.0
+    refgeo_idealised_MISMIP_mod_Hi_init_config   = -1.0                             ! Suggested value: 100 m
+    refgeo_idealised_ISMIP_HOM_L_config          = 0.0                              ! Suggested value: 5E3 - 160E3 m
+    refgeo_idealised_MISMIPplus_Hi_init_config   = 100.0                            ! Suggested value: 100 m
+    refgeo_idealised_MISMIPplus_tune_A_config    = .FALSE.                          ! If so, the uniform flow factor A is tuned to achieve a steady-state mid-stream grounding-line position at x = 450 km
+
+  ! == Mesh generation
+  ! ==================
+
+    ! How to set up the initial mesh
+    choice_initial_mesh_NAM_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_EAS_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_GRL_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_ANT_config               = 'read_from_file'                 ! Options: 'calc_from_initial_geometry', 'read_from_file'
+
+    ! Paths to files containing initial meshes, if choice_initial_mesh == 'read_from_file'
+    filename_initial_mesh_NAM_config             = ''
+    filename_initial_mesh_EAS_config             = ''
+    filename_initial_mesh_GRL_config             = ''
+    filename_initial_mesh_ANT_config             = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/main_output_ANT_LAST.nc'
+
+    ! Resolutions for different parts of the ice sheet
+    maximum_resolution_uniform_config            = 10e3                             ! [m]          Maximum resolution for the entire domain
+    maximum_resolution_grounded_ice_config       = 8e3                              ! [m]          Maximum resolution for grounded ice
+    maximum_resolution_floating_ice_config       = 5e3                              ! [m]          Maximum resolution for floating ice
+    maximum_resolution_grounding_line_config     = 5e3                              ! [m]          Maximum resolution for the grounding line
+    maximum_resolution_calving_front_config      = 5e3                              ! [m]          Maximum resolution for the calving front
+    maximum_resolution_ice_front_config          = 20e3                             ! [m]          Maximum resolution for the ice front
+    maximum_resolution_coastline_config          = 1000e3                           ! [m]          Maximum resolution for the coastline
+
+    ! Widths for each resolution band
+    grounding_line_width_config                  = 2.5e3                            ! [m]          Width of the band around the grounding line that should get this resolution
+    calving_front_width_config                   = 2.5e3                            ! [m]          Width of the band around the calving front that should get this resolution
+    maximum_resolution_ice_front_config          = 20e3                             ! [m]          Maximum resolution for the ice front
+    ice_front_width_config                       = 10e3                             ! [m]          Width of the band around the ice front that should get this resolution
+    coastline_width_config                       = 1000e3                           ! [m]          Width of the band around the coastline that should get this resolution
+
+    ! Regions of interest
+    choice_regions_of_interest_config            = ''                               ! Regions of interest where other (higher) resolutions apply. Separated by double vertical bars "||", e.g. "PineIsland||Thwaites"
+    ROI_maximum_resolution_uniform_config        = 100e3                            ! [m]          Maximum resolution for the entire domain
+    ROI_maximum_resolution_grounded_ice_config   = 50e3                             ! [m]          Maximum resolution for grounded ice
+    ROI_maximum_resolution_floating_ice_config   = 20e3                             ! [m]          Maximum resolution for floating ice
+    ROI_maximum_resolution_grounding_line_config = 5e3                              ! [m]          Maximum resolution for the grounding line
+    ROI_maximum_resolution_calving_front_config  = 10e3                             ! [m]          Maximum resolution for the calving front
+    ROI_maximum_resolution_ice_front_config      = 20e3                             ! [m]          Maximum resolution for the ice front
+    ROI_maximum_resolution_coastline_config      = 50e3                             ! [m]          Maximum resolution for the coastline
+
+    ! Widths for each resolution band
+    ROI_grounding_line_width_config              = 2e3                              ! [m]          Width of the band around the grounding line that should get this resolution
+    ROI_calving_front_width_config               = 10e3                             ! [m]          Width of the band around the calving front that should get this resolution
+    ROI_ice_front_width_config                   = 20e3                             ! [m]          Width of the band around the ice front that should get this resolution
+    ROI_coastline_width_config                   = 50e3                             ! [m]          Width of the band around the coastline that should get this resolution
+
+    ! Mesh update settings
+    allow_mesh_updates_config                    = .TRUE.                           ! [-]          Whether or not mesh updates are allowed
+    dt_mesh_update_min_config                    = 10.0                             ! [yr]         Minimum amount of time between mesh updates
+    minimum_mesh_fitness_coefficient_config      = 0.97                             ! [-]          If the mesh fitness drops below this threshold, trigger a mesh update
+    do_out_of_time_calving_front_relax_config    = .TRUE.                           !              Whether or not to step out of time and relax the calving front for a few iterations after a mesh update
+
+    ! Advanced geometry parameters
+    do_singlecore_mesh_creation_config           = .TRUE.                           !              Whether or not to use only a single core for mesh generation (for better reproducibility)
+    alpha_min_config                             = 0.4363                           ! [radians]    Smallest allowed internal triangle angle (recommended value: 25 degrees = 0.4363)
+    nit_Lloyds_algorithm_config                  = 3                                ! [-]          Number of iterations of Lloyds algorithm to be applied after refinement
+    mesh_resolution_tolerance_config             = 1.25                             ! [-]          Factors the target resolution for trangle-size requirement. 1=strict, use >1 to avoid unnecesarily high resolution
+
+    ! Square grid used for smoothing
+    dx_square_grid_smooth_NAM_config             = 2000.0
+    dx_square_grid_smooth_EAS_config             = 2000.0
+    dx_square_grid_smooth_GRL_config             = 2000.0
+    dx_square_grid_smooth_ANT_config             = 2000.0
+
+  ! == The scaled vertical coordinate zeta
+  ! ======================================
+
+    choice_zeta_grid_config                      = 'regular'                        ! The type of vertical grid to use; can be "regular", "irregular_log", "old_15_layer_zeta"
+    nz_config                                    = 12                               ! The number of vertical layers to use
+    zeta_irregular_log_R_config                  = 10.0                             ! Ratio between surface and base layer spacings
+
+  ! == Ice dynamics - velocity
+  ! ==========================
+
+    ! General
+    choice_stress_balance_approximation_config   = 'DIVA'                           ! Choice of stress balance approximation: "none" (= no flow, though geometry can still change due to mass balance), "SIA", "SSA", "SIA/SSA", "DIVA", "BPA"
+    choice_hybrid_SIASSA_scheme_config           = 'add'                            ! Choice of scheme for combining SIA and SSA velocities in the hybrid approach
+    do_include_SSADIVA_crossterms_config         = .TRUE.                           ! Whether or not to include the gradients of the effective viscosity (the "cross-terms") in the solution of the SSA/DIVA
+
+    ! Hybrid DIVA/BPA
+    choice_hybrid_DIVA_BPA_mask_NAM_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for North America
+    choice_hybrid_DIVA_BPA_mask_EAS_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Eurasia
+    choice_hybrid_DIVA_BPA_mask_GRL_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Greenland
+    choice_hybrid_DIVA_BPA_mask_ANT_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Antarctica
+
+    filename_hybrid_DIVA_BPA_mask_NAM_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for North America
+    filename_hybrid_DIVA_BPA_mask_EAS_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Eurasia
+    filename_hybrid_DIVA_BPA_mask_GRL_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Greenland
+    filename_hybrid_DIVA_BPA_mask_ANT_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Antarctica
+
+    ! Initialisation
+    choice_initial_velocity_NAM_config           = 'zero'                           ! Can be 'zero', 'read_from_file'
+    choice_initial_velocity_EAS_config           = 'zero'
+    choice_initial_velocity_GRL_config           = 'zero'
+    choice_initial_velocity_ANT_config           = 'read_from_file'
+    ! Paths to files containing initial velocity fields
+    filename_initial_velocity_NAM_config         = ''
+    filename_initial_velocity_EAS_config         = ''
+    filename_initial_velocity_GRL_config         = ''
+    filename_initial_velocity_ANT_config         = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/restart_ice_velocity_DIVA_LAST.nc'
+    ! Timeframes to read from the initial velocity files (set to 1E9    if the file has no time dimension)
+    timeframe_initial_velocity_NAM_config        = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_initial_velocity_EAS_config        = 1E9
+    timeframe_initial_velocity_GRL_config        = 1E9
+    timeframe_initial_velocity_ANT_config        = 1e9
+
+    ! Some parameters for numerically solving the stress balance
+    SIA_maximum_diffusivity_config               = 1E5                              ! Limit the diffusivity in the SIA to this value
+    visc_it_norm_dUV_tol_config                  = 5E-5                             ! Stop criterion for the viscosity iteration: the L2-norm of successive velocity solutions should be smaller than this number
+    visc_it_nit_config                           = 50                               ! Maximum number of effective viscosity iterations
+    visc_it_relax_config                         = 0.2                              ! Relaxation parameter for subsequent viscosity iterations (for improved stability)
+    visc_eff_min_config                          = 1E4                              ! Minimum value for effective viscosity
+    vel_max_config                               = 5000.0                           ! Velocities are limited to this value
+    stress_balance_PETSc_rtol_config             = 1E-7                             ! PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
+    stress_balance_PETSc_abstol_config           = 1E-5                             ! PETSc solver - stop criterion, absolute difference
+
+    ! Boundary conditions
+    BC_u_west_config                             = 'zero'                           ! Boundary conditions for the ice velocity field at the domain border
+    BC_u_east_config                             = 'infinite'                       ! Allowed choices: "infinite", "zero", "periodic_ISMIP-HOM"
+    BC_u_south_config                            = 'infinite'
+    BC_u_north_config                            = 'infinite'
+    BC_v_west_config                             = 'zero'
+    BC_v_east_config                             = 'zero'
+    BC_v_south_config                            = 'zero'
+    BC_v_north_config                            = 'zero'
+
+  ! == Ice dynamics - sliding
+  ! =========================
+
+    ! General
+    choice_sliding_law_config                    = 'Schoof2005'                     ! Choice of sliding law: "no_sliding", "idealised", "Coulomb", "Budd", "Weertman", "Tsai2015", "Schoof2005", "Zoet-Iverson"
+    choice_idealised_sliding_law_config          = ''                               ! "ISMIP_HOM_C", "ISMIP_HOM_D", "ISMIP_HOM_E", "ISMIP_HOM_F"
+
+    ! Parameters for different sliding laws
+    slid_Weertman_m_config                       = 3.0                              ! Exponent in Weertman sliding law
+    slid_Budd_q_plastic_config                   = 0.3                              ! Scaling exponent in Budd sliding law
+    slid_Budd_u_threshold_config                 = 100.0                            ! Threshold velocity in Budd sliding law
+    slid_ZI_p_config                             = 5.0                              ! Velocity exponent used in the Zoet-Iverson sliding law
+    slid_ZI_ut_config                            = 200.0                            ! (uniform) transition velocity used in the Zoet-Iverson sliding law [m/yr]
+
+    ! Sub-grid scaling of basal friction
+    do_GL_subgrid_friction_config                = .TRUE.                           ! Whether or not to scale basal friction with the sub-grid grounded fraction (needed to get proper GL migration; only turn this off for showing the effect on the MISMIP_mod results!)
+    choice_subgrid_grounded_fraction_config      = 'bilin_interp_TAF+bedrock_CDF'                    ! Choice of scheme to calculate the sub-grid grounded fractions: 'trilin', 'bedrock_CDF'
+    do_read_bedrock_cdf_from_file_config         = .FALSE.                          ! Whether or not to read the bedrock CDF from the initial mesh file. Requires choice_initial_mesh_XXX_config =  'read_from_file'!
+    subgrid_bedrock_cdf_nbins_config             = 11                               ! Number of bins to be used for sub-grid bedrock cumulative density functions
+    do_subgrid_friction_on_A_grid_config         = .FALSE.                          ! Whether or not to apply a preliminary scaling to basal hydrology and bed roughness on the A grid, before the final scaling of beta on the b grid. The exponent of this scaling is computed based on ice thickness.
+    subgrid_friction_exponent_on_B_grid_config   = 2.0                              ! Exponent to which f_grnd should be raised before being used to scale beta
+
+    ! Stability
+    slid_beta_max_config                         = 1E20                             ! Maximum value for basal friction coefficient
+    slid_delta_v_config                          = 1.0E-3                           ! Normalisation parameter to prevent errors when velocity is zero
+
+  ! == Ice dynamics - ice thickness calculation
+  ! ===========================================
+
+    ! Calculation of dH/dt
+    choice_ice_integration_method_config         = 'semi-implicit'                  ! Choice of ice thickness integration scheme: "none" (i.e. unchanging geometry), "explicit", "semi-implicit"
+    dHi_semiimplicit_fs_config                   = 1.5                              ! Factor for the semi-implicit ice thickness solver (0 = explicit, 0<f<1 = semi-implicit, 1 = implicit, >1 = over-implicit)
+    dHi_PETSc_rtol_config                        = 1E-8                             ! dHi PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
+    dHi_PETSc_abstol_config                      = 1E-6                             ! dHi PETSc solver - stop criterion, absolute difference
+
+    ! Boundary conditions
+    BC_H_west_config                             = 'infinite'                       ! Boundary conditions for ice thickness at the domain boundary
+    BC_H_east_config                             = 'zero'                           ! Allowed choices:  "infinite", "zero", "ISMIP_HOM_F"
+    BC_H_south_config                            = 'infinite'
+    BC_H_north_config                            = 'infinite'
+
+  ! == Ice dynamics - target quantities
+  ! ===================================
+
+    ! Target dHi_dt
+    do_target_dHi_dt_config                      = .FALSE.                          ! Whether or not to use a target dHi_dt field from an external file to alter the modelled one
+    do_limit_target_dHi_dt_to_SMB_config         = .TRUE.                           ! Whether or not to limit a target dHi_dt field to available SMB in that area, so it does not melt all ice there
+    target_dHi_dt_t_end_config                   = 9.9e9                            ! End time of target dHi_dt application
+
+    ! Files containing a target dHi_dt for inversions
+    filename_dHi_dt_target_NAM_config            = ''
+    filename_dHi_dt_target_EAS_config            = ''
+    filename_dHi_dt_target_GRL_config            = ''
+    filename_dHi_dt_target_ANT_config            = ''
+
+    ! Timeframes for reading target dHi_dt from file (set to 1E9_dp if the file has no time dimension)
+    timeframe_dHi_dt_target_NAM_config           = 1E9
+    timeframe_dHi_dt_target_EAS_config           = 1E9
+    timeframe_dHi_dt_target_GRL_config           = 1E9
+    timeframe_dHi_dt_target_ANT_config           = 1E9
+
+  ! == Ice dynamics - time stepping
+  ! ===============================
+
+    ! Time stepping
+    choice_timestepping_config                   = 'pc'                             ! Choice of timestepping method: "direct", "pc" (NOTE: 'direct' does not work with DIVA ice dynamcis!)
+    dt_ice_max_config                            = 10.0                             ! [yr] Maximum time step of the ice dynamics model
+    dt_ice_min_config                            = 0.1                              ! [yr] Minimum time step of the ice dynamics model
+    dt_ice_startup_phase_config                  = 0.0                              ! [yr] Length of time window after start_time and before end_time when dt = dt_min, to ensure smooth restarts
+    do_grounded_only_adv_dt_config               = .FALSE.                          ! If .TRUE., only grounded ice is used in the computation of the advective time step limit (CFL condition)
+
+    ! Predictor-corrector ice-thickness update
+    pc_epsilon_config                            = 0.005                            ! Target truncation error in dHi_dt [m/yr] (epsilon in Robinson et al., 2020, Eq. 33)
+    pc_k_I_config                                = 0.2                              ! Exponent k_I in  Robinson et al., 2020, Eq. 33
+    pc_k_p_config                                = 0.2                              ! Exponent k_p in  Robinson et al., 2020, Eq. 33
+    pc_eta_min_config                            = 1E-8                             ! Normalisation term in estimation of the truncation error (Robinson et al., Eq. 32)
+    pc_max_time_step_increase_config             = 1.1                              ! Each new time step is only allowed to be this much larger than the previous one
+    pc_nit_max_config                            = 50                               ! Maximum number of times a PC timestep can be repeated with reduced dt
+    pc_guilty_max_config                         = 0.0                              ! [%] Maximum percentage of grounded vertices allowed to have a truncation error larger than the tolerance pc_epsilon
+
+    ! Initialisation of the predictor-corrector ice-thickness update
+    pc_choice_initialise_NAM_config              = 'zero'                           ! How to initialise the p/c scheme: 'zero', 'read_from_file'
+    pc_choice_initialise_EAS_config              = 'zero'
+    pc_choice_initialise_GRL_config              = 'zero'
+    pc_choice_initialise_ANT_config              = 'read_from_file'
+    ! Paths to files containing initial fields & values for the p/c scheme
+    filename_pc_initialise_NAM_config            = ''
+    filename_pc_initialise_EAS_config            = ''
+    filename_pc_initialise_GRL_config            = ''
+    filename_pc_initialise_ANT_config            = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/restart_pc_scheme_LAST.nc'
+    ! Timeframes to read from the p/c scheme initial file (set to 1E9    if the file has no time dimension)
+    timeframe_pc_initialise_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_pc_initialise_EAS_config           = 1E9
+    timeframe_pc_initialise_GRL_config           = 1E9
+    timeframe_pc_initialise_ANT_config           = 1e9
+
+  ! == Ice dynamics - calving
+  ! =========================
+
+    choice_calving_law_config                    = 'none'                           ! Choice of calving law: "none", "threshold_thickness"
+    calving_threshold_thickness_shelf_config     = 100.0                            ! Threshold ice thickness for ice shelf calving front in the "threshold_thickness" calving law
+    calving_threshold_thickness_sheet_config     = 0.0                              ! Threshold ice thickness for ice sheet calving front in the "threshold_thickness" calving law
+    max_calving_rounds_config                    = 20                               ! Maximum number of calving loops during chain reaction
+    do_remove_shelves_config                     = .FALSE.                          ! If set to TRUE, all floating ice is always instantly removed (used in the ABUMIP-ABUK experiment)
+    remove_shelves_larger_than_PD_config         = .FALSE.                          ! If set to TRUE, all floating ice beyond the present-day calving front is removed (used for some Antarctic spin-ups)
+    continental_shelf_calving_config             = .FALSE.                          ! If set to TRUE, all ice beyond the continental shelf edge (set by a maximum depth) is removed
+    continental_shelf_min_height_config          = -2000.0                          ! Maximum depth of the continental shelf
+
+  ! == Ice dynamics - stabilisation
+  ! ===============================
+
+    choice_mask_noice_config                     = 'MISMIP+'                        ! Choice of mask_noice configuration
+    Hi_min_config                                = 0.0                              ! [m] Minimum ice thickness: thinner ice gets temporarily added to the no-ice mask and eventually removed
+    Hi_thin_config                               = 0.0                              ! [m] Thin-ice thickness threshold: thinner ice is considered dynamically unreliable (e.g. over steep slopes)
+    remove_ice_absent_at_PD_config               = .FALSE.                          ! If set to TRUE, all ice not present in PD data is always instantly removed
+
+    ! Geometry relaxation
+    geometry_relaxation_t_years_config           = 0.0                              ! [yr] Amount of years (out-of-time) during which the geometry will relaxed during initialisation: no mass balance, thickness alterations, inversions, or target thinning rates will be applied during this time
+
+    ! Mask conservation
+    do_protect_grounded_mask_config              = .FALSE.                          ! If set to TRUE, grounded ice will not be allowed to cross the floatation threshold and will stay minimally grounded.
+    protect_grounded_mask_t_end_config           = 20000.0                          ! End time of grounded mask protection. After this time, it will be allowed to thin and become afloat
+
+    ! Fix/delay ice thickness evolution
+    do_fixiness_before_start_config              = .TRUE.                           ! Whether or not to apply fixiness values before fixiness_t_start
+    fixiness_t_start_config                      = -9.9E9                           ! Start time of linear transition between fixed/delayed and free evolution
+    fixiness_t_end_config                        = -8.8E8                           ! End   time of linear transition between fixed/delayed and free evolution
+    fixiness_H_gl_gr_config                      = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_gl_fl_config                      = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_grounded_config                   = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_floating_config                   = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_freeland_config                   = .FALSE.                          ! Fix (.TRUE.) ice-free vertices between fixiness_t_start and fixiness_t_end
+    fixiness_H_freeocean_config                  = .FALSE.                          ! Fix (.TRUE.) ice-free vertices between fixiness_t_start and fixiness_t_end
+
+    ! Limit ice thickness evolution
+    do_limitness_before_start_config             = .TRUE.                           ! Whether or not to apply limitness values before limitness_t_start
+    limitness_t_start_config                     = -9.9E9                           ! Start time of linear transition between limited and free evolution
+    limitness_t_end_config                       = -8.8E8                           ! End   time of linear transition between limited and free evolution
+    limitness_H_gl_gr_config                     = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_gl_fl_config                     = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_grounded_config                  = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_floating_config                  = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    modiness_H_style_config                      = 'none'                           ! Dynamic "modiness" limitness-like term: "none", "Ti_hom", "Ti_hom_up", "Ti_hom_down"
+    modiness_T_hom_ref_config                    = 5.0                              ! Reference Ti_hom for the modiness cold exponential style
+
+  ! == Basal hydrology
+  ! ==================
+
+    ! Basal hydrology
+    choice_basal_hydrology_model_config          = 'Martin2011'                     ! Choice of basal hydrology model: "saturated", "Martin2011"
+    Martin2011_hydro_Hb_min_config               = 0.0                              ! Martin et al. (2011) basal hydrology model: low-end  Hb  value of bedrock-dependent pore-water pressure
+    Martin2011_hydro_Hb_max_config               = 1000.0                           ! Martin et al. (2011) basal hydrology model: high-end Hb  value of bedrock-dependent pore-water pressure
+
+  ! == Bed roughness
+  ! ================
+
+    choice_bed_roughness_config                  = 'parameterised'                  ! Choice of source for friction coefficients: "uniform", "parameterised", "read_from_file"
+    choice_bed_roughness_parameterised_config    = 'MISMIPplus'                        ! "Martin2011", "SSA_icestream", "MISMIPplus", "BIVMIP_A", "BIVMIP_B", "BIVMIP_C"
+    ! Paths to files containing bed roughness fields for the chosen sliding law
+    filename_bed_roughness_NAM_config            = ''
+    filename_bed_roughness_EAS_config            = ''
+    filename_bed_roughness_GRL_config            = ''
+    filename_bed_roughness_ANT_config            = ''
+    ! Timeframes to read from the bed roughness file (set to 1E9    if the file has no time dimension)
+    timeframe_bed_roughness_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_bed_roughness_EAS_config           = 1E9
+    timeframe_bed_roughness_GRL_config           = 1E9
+    timeframe_bed_roughness_ANT_config           = 1E9
+    ! Values for uniform bed roughness
+    slid_Weertman_beta_sq_uniform_config         = 1.0E4                            ! Uniform value for beta_sq  in Weertman sliding law
+    slid_Coulomb_phi_fric_uniform_config         = 15.0                             ! Uniform value for phi_fric in Coulomb sliding law
+    slid_Budd_phi_fric_uniform_config            = 15.0                             ! Uniform value for phi_fric in Budd sliding law
+    slid_Tsai2015_alpha_sq_uniform_config        = 0.5                              ! Uniform value for alpha_sq in the Tsai2015 sliding law
+    slid_Tsai2015_beta_sq_uniform_config         = 1.0E4                            ! Uniform value for beta_sq  in the Tsai2015 sliding law
+    slid_Schoof2005_alpha_sq_uniform_config      = 0.5                              ! Uniform value for alpha_sq in the Schoof2005 sliding law
+    slid_Schoof2005_beta_sq_uniform_config       = 1.0E4                            ! Uniform value for beta_sq  in the Schoof2005 sliding law
+    slid_ZI_phi_fric_uniform_config              = 10.0                             ! Uniform value for phi_fric in the Zoet-Iverson sliding law
+    ! Parameters for bed roughness parameterisations
+    Martin2011till_phi_Hb_min_config             = -1000.0                          ! Martin et al. (2011) bed roughness parameterisation: low-end  Hb  value of bedrock-dependent till friction angle
+    Martin2011till_phi_Hb_max_config             = 0.0                              ! Martin et al. (2011) bed roughness parameterisation: high-end Hb  value of bedrock-dependent till friction angle
+    Martin2011till_phi_min_config                = 5.0                              ! Martin et al. (2011) bed roughness parameterisation: low-end  phi value of bedrock-dependent till friction angle
+    Martin2011till_phi_max_config                = 20.0                             ! Martin et al. (2011) bed roughness parameterisation: high-end phi value of bedrock-dependent till friction angle
+
+  ! == Bed roughness inversion by nudging
+  ! =====================================
+
+    ! General
+    do_bed_roughness_nudging_config              = .FALSE.                          !           Whether or not to nudge the basal roughness
+    choice_bed_roughness_nudging_method_config   = ''                               !           Choice of bed roughness nudging method
+    choice_inversion_target_geometry_config      = ''                               !           Which reference geometry to use as the target geometry (can be "init" or "PD")
+    bed_roughness_nudging_dt_config              = 5.0                              ! [yr]      Time step for bed roughness updates
+    bed_roughness_nudging_t_start_config         = -9.9E9                           ! [yr]      Earliest model time when nudging is allowed
+    bed_roughness_nudging_t_end_config           = +9.9E9                           ! [yr]      Latest   model time when nudging is allowed
+    generic_bed_roughness_min_config             = 0.1                              ! [?]       Smallest allowed value for the first  inverted bed roughness field
+    generic_bed_roughness_max_config             = 30.0                             ! [?]       Largest  allowed value for the first  inverted bed roughness field
+
+    ! Basal inversion model based on flowline-averaged values of H and dH/dt
+    bednudge_H_dHdt_flowline_t_scale_config      = 100.0                            ! [yr]      Timescale
+    bednudge_H_dHdt_flowline_dH0_config          = 100.0                            ! [m]       Ice thickness error scale
+    bednudge_H_dHdt_flowline_dHdt0_config        = 0.6                              ! [m yr^-1] Thinning rate scale
+    bednudge_H_dHdt_flowline_Hi_scale_config     = 300.0                            ! [m]       Ice thickness weight scale
+    bednudge_H_dHdt_flowline_u_scale_config      = 3000.0                           ! [m yr^-1] Ice velocity  weight scale
+    bednudge_H_dHdt_flowline_r_smooth_config     = 2500.0                           ! [m]       Radius for Gaussian filter used to smooth dC/dt as regularisation
+    bednudge_H_dHdt_flowline_w_smooth_config     = 0.5                              ! [-]       Relative contribution of smoothed dC/dt in regularisation
+
+  ! == Geothermal heat flux
+  ! =======================
+
+    choice_geothermal_heat_flux_config           = 'uniform'                        ! Choice of geothermal heat flux; can be 'uniform' or 'read_from_file'
+    uniform_geothermal_heat_flux_config          = 1.72E06                          ! Value when choice_geothermal_heat_flux == 'uniform' (1.72E06 J m^-2 yr^-1 according to Sclater et al. (1980))
+    filename_geothermal_heat_flux_config         = 'external/data/GHF/geothermal_heatflux_ShapiroRitzwoller2004_global_1x1_deg.nc'
+
+  ! == Thermodynamics
+  ! =================
+
+    ! Initial temperature profile
+    choice_initial_ice_temperature_NAM_config    = 'Robin'                          ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "read_from_file"
+    choice_initial_ice_temperature_EAS_config    = 'Robin'
+    choice_initial_ice_temperature_GRL_config    = 'Robin'
+    choice_initial_ice_temperature_ANT_config    = 'uniform'
+    ! Uniform initial ice temperature, if choice_initial_ice_temperature == 'uniform'
+    uniform_initial_ice_temperature_NAM_config   = 270.0                            ! Uniform ice temperature (applied when choice_initial_ice_temperature_config = "uniform")
+    uniform_initial_ice_temperature_EAS_config   = 270.0
+    uniform_initial_ice_temperature_GRL_config   = 270.0
+    uniform_initial_ice_temperature_ANT_config   = 270.0
+    ! Paths to files containing initial temperature fields, if
+    filename_initial_ice_temperature_NAM_config  = ''
+    filename_initial_ice_temperature_EAS_config  = ''
+    filename_initial_ice_temperature_GRL_config  = ''
+    filename_initial_ice_temperature_ANT_config  = ''
+    ! Timeframes to read from the bed roughness file (set to 1E9    if the file has no time dimension)
+    timeframe_initial_ice_temperature_NAM_config = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_initial_ice_temperature_EAS_config = 1E9
+    timeframe_initial_ice_temperature_GRL_config = 1E9
+    timeframe_initial_ice_temperature_ANT_config = 1E9
+    ! Thermodynamical model
+    choice_thermo_model_config                   = 'none'                           ! Choice of thermodynamical model: "none", "3D_heat_equation"
+    dt_thermodynamics_config                     = 1.0                              ! [yr] Time step for the thermodynamical model
+    Hi_min_thermo_config                         = 10.0                             ! [m]  Ice thinner than this is assumed to have a temperature equal to the annual mean surface temperature throughout the vertical column
+    choice_GL_temperature_BC_config              = 'grounded'                       ! Choice of basal boundary condition at grounding lines: 'grounded', 'subgrid', 'pmp'
+    choice_ice_heat_capacity_config              = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Pounder1965"
+    uniform_ice_heat_capacity_config             = 2009.0                           ! Uniform ice heat capacity (applied when choice_ice_heat_capacity_config = "uniform")
+    choice_ice_thermal_conductivity_config       = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Ritz1987"
+    uniform_ice_thermal_conductivity_config      = 6.626958E7                       ! Uniform ice thermal conductivity (applied when choice_ice_thermal_conductivity_config = "uniform")
+
+  ! == Rheology and flow law
+  ! =========================
+
+    ! Flow law
+    choice_flow_law_config                       = 'Glen'                           ! Choice of flow law, relating effective viscosity to effective strain rate
+    Glens_flow_law_exponent_config               = 3.0                              ! Exponent in Glen`s flow law
+    Glens_flow_law_epsilon_sq_0_config           = 1E-8                             ! Normalisation term so that zero strain rates produce a high but finite viscosity
+
+    ! Rheology
+    choice_ice_rheology_Glen_config              = 'uniform'                        ! Choice of ice rheology model for Glen`s flow law: "uniform", "Huybrechts1992", "MISMIP_mod"
+    uniform_Glens_flow_factor_config             = 1.1187297124212972E-017          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
+
+    ! Enhancement factors
+    choice_enhancement_factor_transition_config  = 'separate'                       ! Choice of treatment of enhancement factors at transition zones: "separate", "interp"
+    m_enh_sheet_config                           = 1.0                              ! Ice flow enhancement factor for grounded ice
+    m_enh_shelf_config                           = 1.0                              ! Ice flow enhancement factor for floating ice
+
+  ! == Climate
+  ! ==========
+
+    ! Time step
+    do_asynchronous_climate_config               = .TRUE.                           ! Whether or not the climate should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_climate_config                            = 10.0                             ! [yr] Time step for calculating climate
+
+    ! Choice of climate model
+    choice_climate_model_NAM_config              = 'none'
+    choice_climate_model_EAS_config              = 'none'
+    choice_climate_model_GRL_config              = 'none'
+    choice_climate_model_ANT_config              = 'none'
+
+    ! Choice of idealised climate model
+    choice_climate_model_idealised_config        = ''
+
+    ! Choice of realistic climate model
+    choice_climate_model_realistic_config        = ''
+
+    filename_climate_snapshot_NAM_config         = ''
+    filename_climate_snapshot_EAS_config         = ''
+    filename_climate_snapshot_GRL_config         = ''
+    filename_climate_snapshot_ANT_config         = ''
+
+  ! == Ocean
+  ! ========
+
+    ! Time step
+    do_asynchronous_ocean_config                 = .TRUE.                           ! Whether or not the ocean should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_ocean_config                              = 10.0                             ! [yr] Time step for calculating ocean
+
+    ! Vertical grid
+    ocean_vertical_grid_max_depth_config         = 1500.0                           ! Maximum depth of the ocean submodel
+    ocean_vertical_grid_dz_config                = 100.0                            ! Vertical distance between ocean layers
+
+    ! Choice of ocean model
+    choice_ocean_model_NAM_config                = 'none'
+    choice_ocean_model_EAS_config                = 'none'
+    choice_ocean_model_GRL_config                = 'none'
+    choice_ocean_model_ANT_config                = 'none'
+
+    ! Choice of idealised ocean model
+    choice_ocean_model_idealised_config          = ''
+
+    ! Choice of realistic ocean model
+    choice_ocean_model_realistic_config          = ''
+
+    filename_ocean_snapshot_NAM_config           = ''
+    filename_ocean_snapshot_EAS_config           = ''
+    filename_ocean_snapshot_GRL_config           = ''
+    filename_ocean_snapshot_ANT_config           = ''
+
+  ! == Surface mass balance
+  ! =======================
+
+    ! Time step
+    do_asynchronous_SMB_config                   = .TRUE.                           ! Whether or not the SMB should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_SMB_config                                = 10.0                             ! [yr] Time step for calculating SMB
+
+    ! Choice of SMB model
+    choice_SMB_model_NAM_config                  = 'uniform'
+    choice_SMB_model_EAS_config                  = 'uniform'
+    choice_SMB_model_GRL_config                  = 'uniform'
+    choice_SMB_model_ANT_config                  = 'idealised'
+
+    ! Choice of idealised SMB model
+    choice_SMB_model_idealised_config            = 'uniform'
+
+    ! Value to be used for uniform SMB (no regional variants, only used for idealised-geometry experiments)
+    uniform_SMB_config                           = 0.3
+
+    ! Prescribed SMB forcing
+    choice_SMB_prescribed_NAM_config             = ''
+    choice_SMB_prescribed_EAS_config             = ''
+    choice_SMB_prescribed_GRL_config             = ''
+    choice_SMB_prescribed_ANT_config             = ''
+
+    ! Files containing prescribed SMB forcing
+    filename_SMB_prescribed_NAM_config           = ''
+    filename_SMB_prescribed_EAS_config           = ''
+    filename_SMB_prescribed_GRL_config           = ''
+    filename_SMB_prescribed_ANT_config           = ''
+
+    ! Timeframes for reading prescribed SMB forcing from file (set to 1E9 if the file has no time dimension)
+    timeframe_SMB_prescribed_NAM_config          = 1E9
+    timeframe_SMB_prescribed_EAS_config          = 1E9
+    timeframe_SMB_prescribed_GRL_config          = 1E9
+    timeframe_SMB_prescribed_ANT_config          = 1E9
+
+  ! == Basal mass balance
+  ! =====================
+
+    ! Time step
+    do_asynchronous_BMB_config                   = .FALSE.                          ! Whether or not the BMB should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_BMB_config                                = 10.0                             ! [yr] Time step for calculating BMB
+
+    ! Grounding line treatment
+    choice_BMB_subgrid_config                    = 'NMP'                               ! Choice of sub-grid BMB scheme: "FCMP", "PMP" (following Leguy et al., 2021)
+
+    ! Choice of BMB model
+    choice_BMB_model_NAM_config                  = 'uniform'
+    choice_BMB_model_EAS_config                  = 'uniform'
+    choice_BMB_model_GRL_config                  = 'uniform'
+    choice_BMB_model_ANT_config                  = 'idealised'
+
+    ! Choice of idealised BMB model
+    choice_BMB_model_idealised_config            = 'MISMIP+'
+
+    ! Choice of parameterised BMB model
+    choice_BMB_model_parameterised_config        = 'Favier2019'
+
+    ! "uniform"
+    uniform_BMB_config                           = 0.0
+
+    ! "parameterised"
+    BMB_Favier2019_gamma_config                  = 99.32E-5
+
+  ! == Lateral mass balance
+  ! =======================
+
+    ! Time step
+    dt_LMB_config                                = 5.0                              ! [yr] Time step for calculating LMB [not implemented yet]
+
+    ! Choice of LMB model
+    choice_LMB_model_NAM_config                  = 'uniform'
+    choice_LMB_model_EAS_config                  = 'uniform'
+    choice_LMB_model_GRL_config                  = 'uniform'
+    choice_LMB_model_ANT_config                  = 'uniform'
+
+    ! "uniform"
+    uniform_LMB_config                           = 0.0
+
+  ! == Glacial isostatic adjustment
+  ! ===============================
+
+    ! General settings
+    choice_GIA_model_config                      = 'none'
+    dt_GIA_config                                = 100.0                            ! [yr] GIA model time step
+    dx_GIA_config                                = 2000.0                           ! [m]  GIA model square grid resolution
+
+  ! == Sea level
+  ! ============
+
+    choice_sealevel_model_config                 = 'fixed'                          !     Can be "fixed", "prescribed", "eustatic", or "SELEN"
+    fixed_sealevel_config                        = 0.0                              ! [m] Fixed sea level value for the "fixed" choice
+
+  ! == SELEN
+  ! ========
+
+    SELEN_run_at_t_start_config                  = .FALSE.                          ! Whether or not to run SELEN in the first coupling loop (needed for some benchmark experiments)
+    SELEN_n_TDOF_iterations_config               = 1                                ! Number of Time-Dependent Ocean Function iterations
+    SELEN_n_recursion_iterations_config          = 1                                ! Number of recursion iterations
+    SELEN_use_rotational_feedback_config         = .FALSE.                          ! If TRUE, rotational feedback is included
+    SELEN_n_harmonics_config                     = 128                              ! Maximum number of harmonic degrees
+    SELEN_display_progress_config                = .FALSE.                          ! Whether or not to display the progress of the big loops to the screen
+
+    SELEN_dir_config                             = 'external/data/SELEN'                     ! Directory where SELEN initial files and spherical harmonics are stored
+    SELEN_global_topo_filename_config            = 'SELEN_global_topography.nc'     ! Filename for the SELEN global topography file (located in SELEN_dir)
+    SELEN_TABOO_init_filename_config             = 'SELEN_TABOO_initial_file.dat'   ! Filename for the TABOO initial file           (idem                )
+    SELEN_LMJ_VALUES_filename_config             = 'SELEN_lmj_values.bin'           ! Filename for the LJ and MJ values file        (idem                )
+
+    SELEN_irreg_time_n_config                    = 15                               ! Number of entries in the irregular moving time window
+    SELEN_irreg_time_window_config               = 20.0  , 20.0  , 20.0  , 5.0  , 5.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 0.0  ,  0.0  ,  0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  ,  0.0  ,  0.0  ,  0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  ,  0.0  ,  0.0  , 0.0  , 0.0
+
+    SELEN_lith_thickness_config                  = 100.0                            ! Thickness of the elastic lithosphere [km]
+    SELEN_visc_n_config                          = 3                                ! Number      of viscous asthenosphere layers
+    SELEN_visc_prof_config                       = 3.0  , 0.6   , 0.3               ! Viscosities of viscous asthenosphere layers [?]
+
+    ! Settings for the TABOO Earth deformation model
+    SELEN_TABOO_CDE_config                       = 0                                !     code of the model (see taboo for explanation)
+    SELEN_TABOO_TLOVE_config                     = 1                                !     Tidal love numbers yes/no
+    SELEN_TABOO_DEG1_config                      = 1                                !     Tidal love numbers degree
+    SELEN_TABOO_RCMB_config                      = 3480.0                           ! [m] Radius of CMB
+
+  ! == Output
+  ! =========
+
+    ! Basic settings
+    do_create_netcdf_output_config               = .TRUE.                           !     Whether or not NetCDF output files should be created at all
+    dt_output_config                             = 1.0                              !     Time step for writing output
+    dt_output_restart_config                     = 30000.0                          !     Time step for writing restart output
+    dt_output_grid_config                        = 5000.0                           !     Time step for writing gridded output
+    dx_output_grid_NAM_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for North America
+    dx_output_grid_EAS_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for Eurasia
+    dx_output_grid_GRL_config                    = 20E3                             ! [m] Horizontal resolution for the square grid used for output for Greenland
+    dx_output_grid_ANT_config                    = 2e3                              ! [m] Horizontal resolution for the square grid used for output for Antarctica
+    dx_output_grid_ROI_NAM_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for North America
+    dx_output_grid_ROI_EAS_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Eurasia
+    dx_output_grid_ROI_GRL_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Greenland
+    dx_output_grid_ROI_ANT_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Antarctica
+
+    ! Transects
+    transects_NAM_config                         = ''                              ! List of transects to use for North America
+    transects_EAS_config                         = ''                              ! List of transects to use for Eurasia
+    transects_GRL_config                         = ''                              ! List of transects to use for Greenland
+    transects_ANT_config                         = 'westeast,dx=1e3'                              ! List of transects to use for Antarctica
+
+    ! Which data fields we want to write to the main NetCDF output files
+    choice_output_field_01_config                = 'mask'
+    choice_output_field_02_config                = 'Hi'
+    choice_output_field_03_config                = 'Hb'
+    choice_output_field_04_config                = 'Hs'
+    choice_output_field_05_config                = 'u_vav'
+    choice_output_field_06_config                = 'v_vav'
+    choice_output_field_07_config                = 'uabs_vav'
+    choice_output_field_08_config                = 'fraction_gr'
+    choice_output_field_09_config                = 'fraction_gr_b'
+    choice_output_field_10_config                = 'basal_friction_coefficient'
+    choice_output_field_11_config                = 'pc_truncation_error'
+    choice_output_field_12_config                = 'SMB'
+    choice_output_field_13_config                = 'dHi_dt'
+    choice_output_field_14_config                = 'divQ'
+    choice_output_field_15_config                = 'BMB'
+    choice_output_field_16_config                = 'R_shear'
+    choice_output_field_17_config                = 'grounding_line'
+    choice_output_field_18_config                = 'calving_front'
+    choice_output_field_19_config                = 'ice_margin'
+    choice_output_field_20_config                = 'coastline'
+    choice_output_field_21_config                = 'none'
+    choice_output_field_22_config                = 'none'
+    choice_output_field_23_config                = 'none'
+    choice_output_field_24_config                = 'none'
+    choice_output_field_25_config                = 'none'
+    choice_output_field_26_config                = 'none'
+    choice_output_field_27_config                = 'none'
+    choice_output_field_28_config                = 'none'
+    choice_output_field_29_config                = 'none'
+    choice_output_field_30_config                = 'none'
+    choice_output_field_31_config                = 'none'
+    choice_output_field_32_config                = 'none'
+    choice_output_field_33_config                = 'none'
+    choice_output_field_34_config                = 'none'
+    choice_output_field_35_config                = 'none'
+    choice_output_field_36_config                = 'none'
+    choice_output_field_37_config                = 'none'
+    choice_output_field_38_config                = 'none'
+    choice_output_field_39_config                = 'none'
+    choice_output_field_40_config                = 'none'
+    choice_output_field_41_config                = 'none'
+    choice_output_field_42_config                = 'none'
+    choice_output_field_43_config                = 'none'
+    choice_output_field_44_config                = 'none'
+    choice_output_field_45_config                = 'none'
+    choice_output_field_46_config                = 'none'
+    choice_output_field_47_config                = 'none'
+    choice_output_field_48_config                = 'none'
+    choice_output_field_49_config                = 'none'
+    choice_output_field_50_config                = 'none'
+
+/

--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_03_5km_ice1r.cfg
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_03_5km_ice1r.cfg
@@ -90,7 +90,7 @@
     filename_refgeo_init_NAM_config              = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
     filename_refgeo_init_EAS_config              = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
     filename_refgeo_init_GRL_config              = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
-    filename_refgeo_init_ANT_config              = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/main_output_ANT_LAST.nc'
+    filename_refgeo_init_ANT_config              = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_5km_spinup/main_output_ANT_LAST.nc'
     ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
     timeframe_refgeo_init_NAM_config             = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
     timeframe_refgeo_init_EAS_config             = 1E9
@@ -171,7 +171,7 @@
     filename_initial_mesh_NAM_config             = ''
     filename_initial_mesh_EAS_config             = ''
     filename_initial_mesh_GRL_config             = ''
-    filename_initial_mesh_ANT_config             = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/main_output_ANT_LAST.nc'
+    filename_initial_mesh_ANT_config             = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_5km_spinup/main_output_ANT_LAST.nc'
 
     ! Resolutions for different parts of the ice sheet
     maximum_resolution_uniform_config            = 10e3                             ! [m]          Maximum resolution for the entire domain
@@ -258,7 +258,7 @@
     filename_initial_velocity_NAM_config         = ''
     filename_initial_velocity_EAS_config         = ''
     filename_initial_velocity_GRL_config         = ''
-    filename_initial_velocity_ANT_config         = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/restart_ice_velocity_DIVA_LAST.nc'
+    filename_initial_velocity_ANT_config         = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_5km_spinup/restart_ice_velocity_DIVA_LAST.nc'
     ! Timeframes to read from the initial velocity files (set to 1E9    if the file has no time dimension)
     timeframe_initial_velocity_NAM_config        = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
     timeframe_initial_velocity_EAS_config        = 1E9
@@ -374,7 +374,7 @@
     filename_pc_initialise_NAM_config            = ''
     filename_pc_initialise_EAS_config            = ''
     filename_pc_initialise_GRL_config            = ''
-    filename_pc_initialise_ANT_config            = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/restart_pc_scheme_LAST.nc'
+    filename_pc_initialise_ANT_config            = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_5km_spinup/restart_pc_scheme_LAST.nc'
     ! Timeframes to read from the p/c scheme initial file (set to 1E9    if the file has no time dimension)
     timeframe_pc_initialise_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
     timeframe_pc_initialise_EAS_config           = 1E9
@@ -540,7 +540,7 @@
 
     ! Rheology
     choice_ice_rheology_Glen_config              = 'uniform'                        ! Choice of ice rheology model for Glen`s flow law: "uniform", "Huybrechts1992", "MISMIP_mod"
-    uniform_Glens_flow_factor_config             = 1.1187297124212972E-017          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
+    uniform_Glens_flow_factor_config             = 1.5316211550125102E-017          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
 
     ! Enhancement factors
     choice_enhancement_factor_transition_config  = 'separate'                       ! Choice of treatment of enhancement factors at transition zones: "separate", "interp"
@@ -727,8 +727,8 @@
     ! Basic settings
     do_create_netcdf_output_config               = .TRUE.                           !     Whether or not NetCDF output files should be created at all
     dt_output_config                             = 1.0                              !     Time step for writing output
-    dt_output_restart_config                     = 30000.0                          !     Time step for writing restart output
-    dt_output_grid_config                        = 5000.0                           !     Time step for writing gridded output
+    dt_output_restart_config                     = 1.0                          !     Time step for writing restart output
+    dt_output_grid_config                        = 1.0                           !     Time step for writing gridded output
     dx_output_grid_NAM_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for North America
     dx_output_grid_EAS_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for Eurasia
     dx_output_grid_GRL_config                    = 20E3                             ! [m] Horizontal resolution for the square grid used for output for Greenland

--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_04_4km_spinup.cfg
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_04_4km_spinup.cfg
@@ -90,7 +90,7 @@
     filename_refgeo_init_NAM_config              = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
     filename_refgeo_init_EAS_config              = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
     filename_refgeo_init_GRL_config              = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
-    filename_refgeo_init_ANT_config              = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/main_output_ANT_LAST.nc'
+    filename_refgeo_init_ANT_config              = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_5km_spinup/main_output_ANT_LAST.nc'
     ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
     timeframe_refgeo_init_NAM_config             = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
     timeframe_refgeo_init_EAS_config             = 1E9
@@ -539,7 +539,7 @@
 
     ! Rheology
     choice_ice_rheology_Glen_config              = 'uniform'                        ! Choice of ice rheology model for Glen`s flow law: "uniform", "Huybrechts1992", "MISMIP_mod"
-    uniform_Glens_flow_factor_config             = 1.1187297124212972E-017          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
+    uniform_Glens_flow_factor_config             = 1.5316211550125102E-017          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
 
     ! Enhancement factors
     choice_enhancement_factor_transition_config  = 'separate'                       ! Choice of treatment of enhancement factors at transition zones: "separate", "interp"

--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_04_4km_spinup.cfg
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_04_4km_spinup.cfg
@@ -1,0 +1,798 @@
+&CONFIG
+
+  ! General model instructions
+  ! ==========================
+
+    ! Output directory
+    create_procedural_output_dir_config          = .FALSE.                          ! Automatically create an output directory with a procedural name (e.g. results_20210720_001/)
+    fixed_output_dir_config                      = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_4km_spinup' ! If not, create a directory with this name instead (stops the program if this directory already exists)
+
+    ! Debugging
+    do_benchmarks_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
+    do_unit_tests_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
+    do_check_for_NaN_config                      = .FALSE.                          ! Whether or not fields should be checked for NaN values
+    do_time_display_config                       = .false.                           ! Print current model time to screen
+
+  ! == Time of simulation
+  ! =====================
+
+    start_time_of_run_config                     = 0.0                              ! [yr] Start time of the simulation
+    end_time_of_run_config                       = 5000.0                           ! [yr] End   time of the simulation
+
+  ! == Which model regions to simulate
+  ! ==================================
+
+    dt_coupling_config                           = 100.0                            ! [yr] Interval of coupling between the different model regions
+    do_NAM_config                                = .FALSE.
+    do_EAS_config                                = .FALSE.
+    do_GRL_config                                = .FALSE.
+    do_ANT_config                                = .TRUE.
+
+  ! == The four model regions
+  ! =========================
+
+    ! North America
+    lambda_M_NAM_config                          = 265.0                            ! [degrees east]  [default: 265.0]   Longitude of the pole of the stereographic projection for the North America domain
+    phi_M_NAM_config                             =  62.0                            ! [degrees north] [default:  62.0]   Latitude  of the pole of the stereographic projection for the North America domain
+    beta_stereo_NAM_config                       =  71.0                            ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the North America domain
+    xmin_NAM_config                              = -3600000.0                       ! [m]             [default: -3600E3] Western  boundary     of the North America domain
+    xmax_NAM_config                              =  3600000.0                       ! [m]             [default:  3600E3] Eastern  boundary     of the North America domain
+    ymin_NAM_config                              = -2400000.0                       ! [m]             [default: -2400E3] Southern boundary     of the North America domain
+    ymax_NAM_config                              =  2400000.0                       ! [m]             [default:  2400E3] Northern boundary     of the North America domain
+
+    ! Eurasia
+    lambda_M_EAS_config                          = 40.0                             ! [degrees east]  [default:  40.0]   Longitude of the pole of the stereographic projection for the Eurasia domain
+    phi_M_EAS_config                             = 70.0                             ! [degrees north] [default:  70.0]   Latitude  of the pole of the stereographic projection for the Eurasia domain
+    beta_stereo_EAS_config                       = 71.0                             ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the Eurasia domain
+    xmin_EAS_config                              = -3400000.0                       ! [m]             [default: -3400E3] Western  boundary     of the Eurasia domain
+    xmax_EAS_config                              =  3400000.0                       ! [m]             [default:  3400E3] Eastern  boundary     of the Eurasia domain
+    ymin_EAS_config                              = -2080000.0                       ! [m]             [default: -2080E3] Southern boundary     of the Eurasia domain
+    ymax_EAS_config                              =  2080000.0                       ! [m]             [default:  2080E3] Northern boundary     of the Eurasia domain
+
+    ! Greenland
+    lambda_M_GRL_config                          = -45.0                            ! [degrees east]  [default: -45.0]   Longitude of the pole of the stereographic projection for the Greenland domain
+    phi_M_GRL_config                             = 90.0                             ! [degrees north] [default:  90.0]   Latitude  of the pole of the stereographic projection for the Greenland domain
+    beta_stereo_GRL_config                       = 70.0                             ! [degrees]       [default:  70.0]   Standard parallel     of the stereographic projection for the Greenland domain
+    xmin_GRL_config                              =  -720000.0                       ! [m]             [default:  -720E3] Western  boundary     of the Greenland domain [m]
+    xmax_GRL_config                              =   960000.0                       ! [m]             [default:   960E3] Eastern  boundary     of the Greenland domain [m]
+    ymin_GRL_config                              = -3450000.0                       ! [m]             [default: -3450E3] Southern boundary     of the Greenland domain [m]
+    ymax_GRL_config                              =  -570000.0                       ! [m]             [default:  -570E3] Northern boundary     of the Greenland domain [m]
+
+    ! Antarctica
+    lambda_M_ANT_config                          = 0.0                              ! [degrees east]  [default:   0.0]   Longitude of the pole of the stereographic projection for the Antarctica domain
+    phi_M_ANT_config                             = -90.0                            ! [degrees north] [default: -90.0]   Latitude  of the pole of the stereographic projection for the Antarctica domain
+    beta_stereo_ANT_config                       = 71.0                             ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the Antarctica domain
+    xmin_ANT_config                              = 0.0                              ! [m]             [default: -3040E3] Western  boundary     of the Antarctica domain [m]
+    xmax_ANT_config                              = 800000.0                         ! [m]             [default:  3040E3] Eastern  boundary     of the Antarctica domain [m]
+    ymin_ANT_config                              = -40000.0                         ! [m]             [default: -3040E3] Southern boundary     of the Antarctica domain [m]
+    ymax_ANT_config                              =  40000.0                         ! [m]             [default:  3040E3] Northern boundary     of the Antarctica domain [m]
+
+  ! == Reference geometries (initial, present-day, and GIA equilibrium)
+  ! ===================================================================
+
+    ! Some pre-processing stuff for reference ice geometry
+    refgeo_Hi_min_config                         = 2.0                              ! [m]             [default: 2.0]     Remove ice thinner than this value in the reference ice geometry. Particularly useful for BedMachine Greenland, which somehow covers the entire tundra with half a meter of ice...
+    do_smooth_geometry_config                    = .FALSE                           ! Whether or not to smooth the reference bedrock
+    r_smooth_geometry_config                     = 0.5                              ! [m]             Geometry smoothing radius
+    remove_Lake_Vostok_config                    = .FALSE.                          ! Whether or not to replace subglacial Lake Vostok in Antarctica with ice (recommended to set to TRUE, otherwise it will really slow down your model for the first few hundred years...)
+
+    ! == Initial geometry
+    ! ===================
+
+    choice_refgeo_init_NAM_config                = 'read_from_file'                 ! Choice of initial geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_init_EAS_config                = 'read_from_file'                 ! Choice of initial geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_init_GRL_config                = 'read_from_file'                 ! Choice of initial geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_init_ANT_config                = 'read_from_file'                 ! Choice of initial geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_init == 'idealised'
+    choice_refgeo_init_idealised_config          = 'MISMIPplus'                        ! Choice of idealised initial geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_init_idealised_config              = 1000.0                           ! Resolution of square grid used for idealised initial geometry
+    ! Path to file containing initial geometry when choice_refgeo_init == 'read_from_file'
+    filename_refgeo_init_NAM_config              = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_init_EAS_config              = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_init_GRL_config              = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_init_ANT_config              = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/main_output_ANT_LAST.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_init_NAM_config             = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_init_EAS_config             = 1E9
+    timeframe_refgeo_init_GRL_config             = 1E9
+    timeframe_refgeo_init_ANT_config             = 1e9
+
+    ! == Present-day geometry
+    ! =======================
+
+    choice_refgeo_PD_NAM_config                  = 'read_from_file'                 ! Choice of present-day geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_EAS_config                  = 'read_from_file'                 ! Choice of present-day geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_GRL_config                  = 'read_from_file'                 ! Choice of present-day geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_ANT_config                  = 'idealised'                      ! Choice of present-day geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_PD == 'idealised'
+    choice_refgeo_PD_idealised_config            = 'MISMIPplus'                        ! Choice of idealised present-day geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_PD_idealised_config                = 1000.0                           ! Resolution of square grid used for idealised present-day geometry
+    ! Path to file containing present-day geometry when choice_refgeo_PD == 'read_from_file'
+    filename_refgeo_PD_NAM_config                = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_PD_EAS_config                = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_PD_GRL_config                = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_PD_ANT_config                = 'external/data/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_PD_NAM_config               = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_PD_EAS_config               = 1E9
+    timeframe_refgeo_PD_GRL_config               = 1E9
+    timeframe_refgeo_PD_ANT_config               = 1E9
+
+    ! == GIA equilibrium geometry
+    ! ===========================
+
+    choice_refgeo_GIAeq_NAM_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_EAS_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_GRL_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_ANT_config               = 'idealised'                      ! Choice of GIA equilibrium reference geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_GIAeq == 'idealised'
+    choice_refgeo_GIAeq_idealised_config         = 'MISMIPplus'                        ! Choice of idealised GIA equilibrium reference geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_GIAeq_idealised_config             = 1000.0                           ! Resolution of square grid used for idealised GIA equilibrium reference geometry
+    ! Path to file containing GIA equilibrium reference geometry when choice_refgeo_GIAeq == 'read_from_file'
+    filename_refgeo_GIAeq_NAM_config             = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_GIAeq_EAS_config             = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_GIAeq_GRL_config             = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_GIAeq_ANT_config             = 'external/data/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_GIAeq_NAM_config            = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_GIAeq_EAS_config            = 1E9
+    timeframe_refgeo_GIAeq_GRL_config            = 1E9
+    timeframe_refgeo_GIAeq_ANT_config            = 1E9
+
+    ! == Parameters for idealised geometries
+    ! ======================================
+
+    refgeo_idealised_slabonaslope_Hi_config      = 0.0                              ! Suggested value: 2000 m
+    refgeo_idealised_slabonaslope_dhdx_config    = 1.0                              ! Suggested value: -0.001
+    refgeo_idealised_Halfar_H0_config            = 0.0                              ! Suggested value: 3000 m
+    refgeo_idealised_Halfar_R0_config            = 0.0                              ! Suggested value: 500E3 m
+    refgeo_idealised_Bueler_H0_config            = 0.0                              ! Suggested value: 3000 m
+    refgeo_idealised_Bueler_R0_config            = 0.0                              ! Suggested value: 500E3 m
+    refgeo_idealised_Bueler_lambda_config        = 0.0                              ! Suggested value: 5.0
+    refgeo_idealised_SSA_icestream_Hi_config     = -1.0                             ! Suggested value: 2000 m
+    refgeo_idealised_SSA_icestream_dhdx_config   = 1.0                              ! Suggested value: -0.0003
+    refgeo_idealised_SSA_icestream_L_config      = 0.0                              ! Suggested value: 150 km
+    refgeo_idealised_SSA_icestream_m_config      = 0.0                              ! Suggested value: 1.0
+    refgeo_idealised_MISMIP_mod_Hi_init_config   = -1.0                             ! Suggested value: 100 m
+    refgeo_idealised_ISMIP_HOM_L_config          = 0.0                              ! Suggested value: 5E3 - 160E3 m
+    refgeo_idealised_MISMIPplus_Hi_init_config   = 100.0                            ! Suggested value: 100 m
+    refgeo_idealised_MISMIPplus_tune_A_config    = .TRUE.                           ! If so, the uniform flow factor A is tuned to achieve a steady-state mid-stream grounding-line position at x = 450 km
+
+  ! == Mesh generation
+  ! ==================
+
+    ! How to set up the initial mesh
+    choice_initial_mesh_NAM_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_EAS_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_GRL_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_ANT_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+
+    ! Paths to files containing initial meshes, if choice_initial_mesh == 'read_from_file'
+    filename_initial_mesh_NAM_config             = ''
+    filename_initial_mesh_EAS_config             = ''
+    filename_initial_mesh_GRL_config             = ''
+    filename_initial_mesh_ANT_config             = ''
+
+    ! Resolutions for different parts of the ice sheet
+    maximum_resolution_uniform_config            = 10e3                             ! [m]          Maximum resolution for the entire domain
+    maximum_resolution_grounded_ice_config       = 8e3                              ! [m]          Maximum resolution for grounded ice
+    maximum_resolution_floating_ice_config       = 5e3                              ! [m]          Maximum resolution for floating ice
+    maximum_resolution_grounding_line_config     = 4e3                              ! [m]          Maximum resolution for the grounding line
+    maximum_resolution_calving_front_config      = 5e3                              ! [m]          Maximum resolution for the calving front
+    maximum_resolution_ice_front_config          = 20e3                             ! [m]          Maximum resolution for the ice front
+    maximum_resolution_coastline_config          = 1000e3                           ! [m]          Maximum resolution for the coastline
+
+    ! Widths for each resolution band
+    grounding_line_width_config                  = 2.0e3                            ! [m]          Width of the band around the grounding line that should get this resolution
+    calving_front_width_config                   = 2.5e3                            ! [m]          Width of the band around the calving front that should get this resolution
+    ice_front_width_config                       = 10e3                             ! [m]          Width of the band around the ice front that should get this resolution
+    coastline_width_config                       = 1000e3                           ! [m]          Width of the band around the coastline that should get this resolution
+
+    ! Regions of interest
+    choice_regions_of_interest_config            = ''                               ! Regions of interest where other (higher) resolutions apply. Separated by double vertical bars "||", e.g. "PineIsland||Thwaites"
+    ROI_maximum_resolution_uniform_config        = 100e3                            ! [m]          Maximum resolution for the entire domain
+    ROI_maximum_resolution_grounded_ice_config   = 50e3                             ! [m]          Maximum resolution for grounded ice
+    ROI_maximum_resolution_floating_ice_config   = 20e3                             ! [m]          Maximum resolution for floating ice
+    ROI_maximum_resolution_grounding_line_config = 5e3                              ! [m]          Maximum resolution for the grounding line
+    ROI_maximum_resolution_calving_front_config  = 10e3                             ! [m]          Maximum resolution for the calving front
+    ROI_maximum_resolution_ice_front_config      = 20e3                             ! [m]          Maximum resolution for the ice front
+    ROI_maximum_resolution_coastline_config      = 50e3                             ! [m]          Maximum resolution for the coastline
+
+    ! Widths for each resolution band
+    ROI_grounding_line_width_config              = 2e3                              ! [m]          Width of the band around the grounding line that should get this resolution
+    ROI_calving_front_width_config               = 10e3                             ! [m]          Width of the band around the calving front that should get this resolution
+    ROI_ice_front_width_config                   = 20e3                             ! [m]          Width of the band around the ice front that should get this resolution
+    ROI_coastline_width_config                   = 50e3                             ! [m]          Width of the band around the coastline that should get this resolution
+
+    ! Mesh update settings
+    allow_mesh_updates_config                    = .TRUE.                           ! [-]          Whether or not mesh updates are allowed
+    dt_mesh_update_min_config                    = 50.0                             ! [yr]         Minimum amount of time between mesh updates
+    minimum_mesh_fitness_coefficient_config      = 0.95                             ! [-]          If the mesh fitness drops below this threshold, trigger a mesh update
+    do_out_of_time_calving_front_relax_config    = .TRUE.                           !              Whether or not to step out of time and relax the calving front for a few iterations after a mesh update
+
+    ! Advanced geometry parameters
+    do_singlecore_mesh_creation_config           = .TRUE.                           !              Whether or not to use only a single core for mesh generation (for better reproducibility)
+    alpha_min_config                             = 0.4363                           ! [radians]    Smallest allowed internal triangle angle (recommended value: 25 degrees = 0.4363)
+    nit_Lloyds_algorithm_config                  = 3                                ! [-]          Number of iterations of Lloyds algorithm to be applied after refinement
+    mesh_resolution_tolerance_config             = 1.25                             ! [-]          Factors the target resolution for trangle-size requirement. 1=strict, use >1 to avoid unnecesarily high resolution
+
+    ! Square grid used for smoothing
+    dx_square_grid_smooth_NAM_config             = 2000.0
+    dx_square_grid_smooth_EAS_config             = 2000.0
+    dx_square_grid_smooth_GRL_config             = 2000.0
+    dx_square_grid_smooth_ANT_config             = 2000.0
+
+  ! == The scaled vertical coordinate zeta
+  ! ======================================
+
+    choice_zeta_grid_config                      = 'regular'                        ! The type of vertical grid to use; can be "regular", "irregular_log", "old_15_layer_zeta"
+    nz_config                                    = 12                               ! The number of vertical layers to use
+    zeta_irregular_log_R_config                  = 10.0                             ! Ratio between surface and base layer spacings
+
+  ! == Ice dynamics - velocity
+  ! ==========================
+
+    ! General
+    choice_stress_balance_approximation_config   = 'DIVA'                           ! Choice of stress balance approximation: "none" (= no flow, though geometry can still change due to mass balance), "SIA", "SSA", "SIA/SSA", "DIVA", "BPA"
+    choice_hybrid_SIASSA_scheme_config           = 'add'                            ! Choice of scheme for combining SIA and SSA velocities in the hybrid approach
+    do_include_SSADIVA_crossterms_config         = .TRUE.                           ! Whether or not to include the gradients of the effective viscosity (the "cross-terms") in the solution of the SSA/DIVA
+
+    ! Hybrid DIVA/BPA
+    choice_hybrid_DIVA_BPA_mask_NAM_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for North America
+    choice_hybrid_DIVA_BPA_mask_EAS_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Eurasia
+    choice_hybrid_DIVA_BPA_mask_GRL_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Greenland
+    choice_hybrid_DIVA_BPA_mask_ANT_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Antarctica
+
+    filename_hybrid_DIVA_BPA_mask_NAM_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for North America
+    filename_hybrid_DIVA_BPA_mask_EAS_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Eurasia
+    filename_hybrid_DIVA_BPA_mask_GRL_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Greenland
+    filename_hybrid_DIVA_BPA_mask_ANT_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Antarctica
+
+    ! Initialisation
+    choice_initial_velocity_NAM_config           = 'zero'                           ! Can be 'zero', 'read_from_file'
+    choice_initial_velocity_EAS_config           = 'zero'
+    choice_initial_velocity_GRL_config           = 'zero'
+    choice_initial_velocity_ANT_config           = 'zero'
+    ! Paths to files containing initial velocity fields
+    filename_initial_velocity_NAM_config         = ''
+    filename_initial_velocity_EAS_config         = ''
+    filename_initial_velocity_GRL_config         = ''
+    filename_initial_velocity_ANT_config         = ''
+    ! Timeframes to read from the initial velocity files (set to 1E9    if the file has no time dimension)
+    timeframe_initial_velocity_NAM_config        = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_initial_velocity_EAS_config        = 1E9
+    timeframe_initial_velocity_GRL_config        = 1E9
+    timeframe_initial_velocity_ANT_config        = 1E9
+
+    ! Some parameters for numerically solving the stress balance
+    SIA_maximum_diffusivity_config               = 1E5                              ! Limit the diffusivity in the SIA to this value
+    visc_it_norm_dUV_tol_config                  = 5E-5                             ! Stop criterion for the viscosity iteration: the L2-norm of successive velocity solutions should be smaller than this number
+    visc_it_nit_config                           = 50                               ! Maximum number of effective viscosity iterations
+    visc_it_relax_config                         = 0.2                              ! Relaxation parameter for subsequent viscosity iterations (for improved stability)
+    visc_eff_min_config                          = 1E4                              ! Minimum value for effective viscosity
+    vel_max_config                               = 5000.0                           ! Velocities are limited to this value
+    stress_balance_PETSc_rtol_config             = 1E-7                             ! PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
+    stress_balance_PETSc_abstol_config           = 1E-5                             ! PETSc solver - stop criterion, absolute difference
+
+    ! Boundary conditions
+    BC_u_west_config                             = 'zero'                           ! Boundary conditions for the ice velocity field at the domain border
+    BC_u_east_config                             = 'infinite'                       ! Allowed choices: "infinite", "zero", "periodic_ISMIP-HOM"
+    BC_u_south_config                            = 'infinite'
+    BC_u_north_config                            = 'infinite'
+    BC_v_west_config                             = 'zero'
+    BC_v_east_config                             = 'zero'
+    BC_v_south_config                            = 'zero'
+    BC_v_north_config                            = 'zero'
+
+  ! == Ice dynamics - sliding
+  ! =========================
+
+    ! General
+    choice_sliding_law_config                    = 'Schoof2005'                     ! Choice of sliding law: "no_sliding", "idealised", "Coulomb", "Budd", "Weertman", "Tsai2015", "Schoof2005", "Zoet-Iverson"
+    choice_idealised_sliding_law_config          = ''                               ! "ISMIP_HOM_C", "ISMIP_HOM_D", "ISMIP_HOM_E", "ISMIP_HOM_F"
+
+    ! Parameters for different sliding laws
+    slid_Weertman_m_config                       = 3.0                              ! Exponent in Weertman sliding law
+    slid_Budd_q_plastic_config                   = 0.3                              ! Scaling exponent in Budd sliding law
+    slid_Budd_u_threshold_config                 = 100.0                            ! Threshold velocity in Budd sliding law
+    slid_ZI_p_config                             = 5.0                              ! Velocity exponent used in the Zoet-Iverson sliding law
+    slid_ZI_ut_config                            = 200.0                            ! (uniform) transition velocity used in the Zoet-Iverson sliding law [m/yr]
+
+    ! Sub-grid scaling of basal friction
+    do_GL_subgrid_friction_config                = .TRUE.                           ! Whether or not to scale basal friction with the sub-grid grounded fraction (needed to get proper GL migration; only turn this off for showing the effect on the MISMIP_mod results!)
+    choice_subgrid_grounded_fraction_config      = 'bilin_interp_TAF+bedrock_CDF'   ! Choice of scheme to calculate the sub-grid grounded fractions: 'trilin', 'bedrock_CDF'
+    do_read_bedrock_cdf_from_file_config         = .FALSE.                          ! Whether or not to read the bedrock CDF from the initial mesh file. Requires choice_initial_mesh_XXX_config =  'read_from_file'!
+    subgrid_bedrock_cdf_nbins_config             = 11                               ! Number of bins to be used for sub-grid bedrock cumulative density functions
+    do_subgrid_friction_on_A_grid_config         = .FALSE.                          ! Whether or not to apply a preliminary scaling to basal hydrology and bed roughness on the A grid, before the final scaling of beta on the b grid. The exponent of this scaling is computed based on ice thickness.
+    subgrid_friction_exponent_on_B_grid_config   = 2.0                              ! Exponent to which f_grnd should be raised before being used to scale beta
+
+    ! Stability
+    slid_beta_max_config                         = 1E20                             ! Maximum value for basal friction coefficient
+    slid_delta_v_config                          = 1.0E-3                           ! Normalisation parameter to prevent errors when velocity is zero
+
+  ! == Ice dynamics - ice thickness calculation
+  ! ===========================================
+
+    ! Calculation of dH/dt
+    choice_ice_integration_method_config         = 'semi-implicit'                  ! Choice of ice thickness integration scheme: "none" (i.e. unchanging geometry), "explicit", "semi-implicit"
+    dHi_semiimplicit_fs_config                   = 1.5                              ! Factor for the semi-implicit ice thickness solver (0 = explicit, 0<f<1 = semi-implicit, 1 = implicit, >1 = over-implicit)
+    dHi_PETSc_rtol_config                        = 1E-8                             ! dHi PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
+    dHi_PETSc_abstol_config                      = 1E-6                             ! dHi PETSc solver - stop criterion, absolute difference
+
+    ! Boundary conditions
+    BC_H_west_config                             = 'infinite'                       ! Boundary conditions for ice thickness at the domain boundary
+    BC_H_east_config                             = 'zero'                           ! Allowed choices:  "infinite", "zero", "ISMIP_HOM_F"
+    BC_H_south_config                            = 'infinite'
+    BC_H_north_config                            = 'infinite'
+
+  ! == Ice dynamics - target quantities
+  ! ===================================
+
+    ! Target dHi_dt
+    do_target_dHi_dt_config                      = .FALSE.                          ! Whether or not to use a target dHi_dt field from an external file to alter the modelled one
+    do_limit_target_dHi_dt_to_SMB_config         = .TRUE.                           ! Whether or not to limit a target dHi_dt field to available SMB in that area, so it does not melt all ice there
+    target_dHi_dt_t_end_config                   = 9.9e9                            ! End time of target dHi_dt application
+
+    ! Files containing a target dHi_dt for inversions
+    filename_dHi_dt_target_NAM_config            = ''
+    filename_dHi_dt_target_EAS_config            = ''
+    filename_dHi_dt_target_GRL_config            = ''
+    filename_dHi_dt_target_ANT_config            = ''
+
+    ! Timeframes for reading target dHi_dt from file (set to 1E9_dp if the file has no time dimension)
+    timeframe_dHi_dt_target_NAM_config           = 1E9
+    timeframe_dHi_dt_target_EAS_config           = 1E9
+    timeframe_dHi_dt_target_GRL_config           = 1E9
+    timeframe_dHi_dt_target_ANT_config           = 1E9
+
+  ! == Ice dynamics - time stepping
+  ! ===============================
+
+    ! Time stepping
+    choice_timestepping_config                   = 'pc'                             ! Choice of timestepping method: "direct", "pc" (NOTE: 'direct' does not work with DIVA ice dynamcis!)
+    dt_ice_max_config                            = 10.0                             ! [yr] Maximum time step of the ice dynamics model
+    dt_ice_min_config                            = 0.5                              ! [yr] Minimum time step of the ice dynamics model
+    dt_ice_startup_phase_config                  = 0.0                              ! [yr] Length of time window after start_time and before end_time when dt = dt_min, to ensure smooth restarts
+    do_grounded_only_adv_dt_config               = .FALSE.                          ! If .TRUE., only grounded ice is used in the computation of the advective time step limit (CFL condition)
+
+    ! Predictor-corrector ice-thickness update
+    pc_epsilon_config                            = 0.005                            ! Target truncation error in dHi_dt [m/yr] (epsilon in Robinson et al., 2020, Eq. 33)
+    pc_k_I_config                                = 0.2                              ! Exponent k_I in  Robinson et al., 2020, Eq. 33
+    pc_k_p_config                                = 0.2                              ! Exponent k_p in  Robinson et al., 2020, Eq. 33
+    pc_eta_min_config                            = 1E-8                             ! Normalisation term in estimation of the truncation error (Robinson et al., Eq. 32)
+    pc_max_time_step_increase_config             = 1.1                              ! Each new time step is only allowed to be this much larger than the previous one
+    pc_nit_max_config                            = 50                               ! Maximum number of times a PC timestep can be repeated with reduced dt
+    pc_guilty_max_config                         = 0.0                              ! [%] Maximum percentage of grounded vertices allowed to have a truncation error larger than the tolerance pc_epsilon
+
+    ! Initialisation of the predictor-corrector ice-thickness update
+    pc_choice_initialise_NAM_config              = 'zero'                           ! How to initialise the p/c scheme: 'zero', 'read_from_file'
+    pc_choice_initialise_EAS_config              = 'zero'
+    pc_choice_initialise_GRL_config              = 'zero'
+    pc_choice_initialise_ANT_config              = 'zero'
+    ! Paths to files containing initial fields & values for the p/c scheme
+    filename_pc_initialise_NAM_config            = ''
+    filename_pc_initialise_EAS_config            = ''
+    filename_pc_initialise_GRL_config            = ''
+    filename_pc_initialise_ANT_config            = ''
+    ! Timeframes to read from the p/c scheme initial file (set to 1E9    if the file has no time dimension)
+    timeframe_pc_initialise_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_pc_initialise_EAS_config           = 1E9
+    timeframe_pc_initialise_GRL_config           = 1E9
+    timeframe_pc_initialise_ANT_config           = 1E9
+
+  ! == Ice dynamics - calving
+  ! =========================
+
+    choice_calving_law_config                    = 'none'                           ! Choice of calving law: "none", "threshold_thickness"
+    calving_threshold_thickness_shelf_config     = 100.0                            ! Threshold ice thickness for ice shelf calving front in the "threshold_thickness" calving law
+    calving_threshold_thickness_sheet_config     = 0.0                              ! Threshold ice thickness for ice sheet calving front in the "threshold_thickness" calving law
+    max_calving_rounds_config                    = 20                               ! Maximum number of calving loops during chain reaction
+    do_remove_shelves_config                     = .FALSE.                          ! If set to TRUE, all floating ice is always instantly removed (used in the ABUMIP-ABUK experiment)
+    remove_shelves_larger_than_PD_config         = .FALSE.                          ! If set to TRUE, all floating ice beyond the present-day calving front is removed (used for some Antarctic spin-ups)
+    continental_shelf_calving_config             = .FALSE.                          ! If set to TRUE, all ice beyond the continental shelf edge (set by a maximum depth) is removed
+    continental_shelf_min_height_config          = -2000.0                          ! Maximum depth of the continental shelf
+
+  ! == Ice dynamics - stabilisation
+  ! ===============================
+
+    choice_mask_noice_config                     = 'MISMIP+'                        ! Choice of mask_noice configuration
+    Hi_min_config                                = 0.0                              ! [m] Minimum ice thickness: thinner ice gets temporarily added to the no-ice mask and eventually removed
+    Hi_thin_config                               = 0.0                              ! [m] Thin-ice thickness threshold: thinner ice is considered dynamically unreliable (e.g. over steep slopes)
+    remove_ice_absent_at_PD_config               = .FALSE.                          ! If set to TRUE, all ice not present in PD data is always instantly removed
+
+    ! Geometry relaxation
+    geometry_relaxation_t_years_config           = 0.0                              ! [yr] Amount of years (out-of-time) during which the geometry will relaxed during initialisation: no mass balance, thickness alterations, inversions, or target thinning rates will be applied during this time
+
+    ! Mask conservation
+    do_protect_grounded_mask_config              = .FALSE.                          ! If set to TRUE, grounded ice will not be allowed to cross the floatation threshold and will stay minimally grounded.
+    protect_grounded_mask_t_end_config           = 20000.0                          ! End time of grounded mask protection. After this time, it will be allowed to thin and become afloat
+
+    ! Fix/delay ice thickness evolution
+    do_fixiness_before_start_config              = .TRUE.                           ! Whether or not to apply fixiness values before fixiness_t_start
+    fixiness_t_start_config                      = -9.9E9                           ! Start time of linear transition between fixed/delayed and free evolution
+    fixiness_t_end_config                        = -8.8E8                           ! End   time of linear transition between fixed/delayed and free evolution
+    fixiness_H_gl_gr_config                      = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_gl_fl_config                      = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_grounded_config                   = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_floating_config                   = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_freeland_config                   = .FALSE.                          ! Fix (.TRUE.) ice-free vertices between fixiness_t_start and fixiness_t_end
+    fixiness_H_freeocean_config                  = .FALSE.                          ! Fix (.TRUE.) ice-free vertices between fixiness_t_start and fixiness_t_end
+
+    ! Limit ice thickness evolution
+    do_limitness_before_start_config             = .TRUE.                           ! Whether or not to apply limitness values before limitness_t_start
+    limitness_t_start_config                     = -9.9E9                           ! Start time of linear transition between limited and free evolution
+    limitness_t_end_config                       = -8.8E8                           ! End   time of linear transition between limited and free evolution
+    limitness_H_gl_gr_config                     = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_gl_fl_config                     = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_grounded_config                  = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_floating_config                  = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    modiness_H_style_config                      = 'none'                           ! Dynamic "modiness" limitness-like term: "none", "Ti_hom", "Ti_hom_up", "Ti_hom_down"
+    modiness_T_hom_ref_config                    = 5.0                              ! Reference Ti_hom for the modiness cold exponential style
+
+  ! == Basal hydrology
+  ! ==================
+
+    ! Basal hydrology
+    choice_basal_hydrology_model_config          = 'Martin2011'                     ! Choice of basal hydrology model: "saturated", "Martin2011"
+    Martin2011_hydro_Hb_min_config               = 0.0                              ! Martin et al. (2011) basal hydrology model: low-end  Hb  value of bedrock-dependent pore-water pressure
+    Martin2011_hydro_Hb_max_config               = 1000.0                           ! Martin et al. (2011) basal hydrology model: high-end Hb  value of bedrock-dependent pore-water pressure
+
+  ! == Bed roughness
+  ! ================
+
+    choice_bed_roughness_config                  = 'parameterised'                  ! Choice of source for friction coefficients: "uniform", "parameterised", "read_from_file"
+    choice_bed_roughness_parameterised_config    = 'MISMIPplus'                        ! "Martin2011", "SSA_icestream", "MISMIPplus", "BIVMIP_A", "BIVMIP_B", "BIVMIP_C"
+    ! Paths to files containing bed roughness fields for the chosen sliding law
+    filename_bed_roughness_NAM_config            = ''
+    filename_bed_roughness_EAS_config            = ''
+    filename_bed_roughness_GRL_config            = ''
+    filename_bed_roughness_ANT_config            = ''
+    ! Timeframes to read from the bed roughness file (set to 1E9    if the file has no time dimension)
+    timeframe_bed_roughness_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_bed_roughness_EAS_config           = 1E9
+    timeframe_bed_roughness_GRL_config           = 1E9
+    timeframe_bed_roughness_ANT_config           = 1E9
+    ! Values for uniform bed roughness
+    slid_Weertman_beta_sq_uniform_config         = 1.0E4                            ! Uniform value for beta_sq  in Weertman sliding law
+    slid_Coulomb_phi_fric_uniform_config         = 15.0                             ! Uniform value for phi_fric in Coulomb sliding law
+    slid_Budd_phi_fric_uniform_config            = 15.0                             ! Uniform value for phi_fric in Budd sliding law
+    slid_Tsai2015_alpha_sq_uniform_config        = 0.5                              ! Uniform value for alpha_sq in the Tsai2015 sliding law
+    slid_Tsai2015_beta_sq_uniform_config         = 1.0E4                            ! Uniform value for beta_sq  in the Tsai2015 sliding law
+    slid_Schoof2005_alpha_sq_uniform_config      = 0.5                              ! Uniform value for alpha_sq in the Schoof2005 sliding law
+    slid_Schoof2005_beta_sq_uniform_config       = 1.0E4                            ! Uniform value for beta_sq  in the Schoof2005 sliding law
+    slid_ZI_phi_fric_uniform_config              = 10.0                             ! Uniform value for phi_fric in the Zoet-Iverson sliding law
+    ! Parameters for bed roughness parameterisations
+    Martin2011till_phi_Hb_min_config             = -1000.0                          ! Martin et al. (2011) bed roughness parameterisation: low-end  Hb  value of bedrock-dependent till friction angle
+    Martin2011till_phi_Hb_max_config             = 0.0                              ! Martin et al. (2011) bed roughness parameterisation: high-end Hb  value of bedrock-dependent till friction angle
+    Martin2011till_phi_min_config                = 5.0                              ! Martin et al. (2011) bed roughness parameterisation: low-end  phi value of bedrock-dependent till friction angle
+    Martin2011till_phi_max_config                = 20.0                             ! Martin et al. (2011) bed roughness parameterisation: high-end phi value of bedrock-dependent till friction angle
+
+  ! == Bed roughness inversion by nudging
+  ! =====================================
+
+    ! General
+    do_bed_roughness_nudging_config              = .FALSE.                          !           Whether or not to nudge the basal roughness
+    choice_bed_roughness_nudging_method_config   = ''                               !           Choice of bed roughness nudging method
+    choice_inversion_target_geometry_config      = ''                               !           Which reference geometry to use as the target geometry (can be "init" or "PD")
+    bed_roughness_nudging_dt_config              = 5.0                              ! [yr]      Time step for bed roughness updates
+    bed_roughness_nudging_t_start_config         = -9.9E9                           ! [yr]      Earliest model time when nudging is allowed
+    bed_roughness_nudging_t_end_config           = +9.9E9                           ! [yr]      Latest   model time when nudging is allowed
+    generic_bed_roughness_min_config             = 0.1                              ! [?]       Smallest allowed value for the first  inverted bed roughness field
+    generic_bed_roughness_max_config             = 30.0                             ! [?]       Largest  allowed value for the first  inverted bed roughness field
+
+    ! Basal inversion model based on flowline-averaged values of H and dH/dt
+    bednudge_H_dHdt_flowline_t_scale_config      = 100.0                            ! [yr]      Timescale
+    bednudge_H_dHdt_flowline_dH0_config          = 100.0                            ! [m]       Ice thickness error scale
+    bednudge_H_dHdt_flowline_dHdt0_config        = 0.6                              ! [m yr^-1] Thinning rate scale
+    bednudge_H_dHdt_flowline_Hi_scale_config     = 300.0                            ! [m]       Ice thickness weight scale
+    bednudge_H_dHdt_flowline_u_scale_config      = 3000.0                           ! [m yr^-1] Ice velocity  weight scale
+    bednudge_H_dHdt_flowline_r_smooth_config     = 2500.0                           ! [m]       Radius for Gaussian filter used to smooth dC/dt as regularisation
+    bednudge_H_dHdt_flowline_w_smooth_config     = 0.5                              ! [-]       Relative contribution of smoothed dC/dt in regularisation
+
+  ! == Geothermal heat flux
+  ! =======================
+
+    choice_geothermal_heat_flux_config           = 'uniform'                        ! Choice of geothermal heat flux; can be 'uniform' or 'read_from_file'
+    uniform_geothermal_heat_flux_config          = 1.72E06                          ! Value when choice_geothermal_heat_flux == 'uniform' (1.72E06 J m^-2 yr^-1 according to Sclater et al. (1980))
+    filename_geothermal_heat_flux_config         = 'external/data/GHF/geothermal_heatflux_ShapiroRitzwoller2004_global_1x1_deg.nc'
+
+  ! == Thermodynamics
+  ! =================
+
+    ! Initial temperature profile
+    choice_initial_ice_temperature_NAM_config    = 'Robin'                          ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "read_from_file"
+    choice_initial_ice_temperature_EAS_config    = 'Robin'
+    choice_initial_ice_temperature_GRL_config    = 'Robin'
+    choice_initial_ice_temperature_ANT_config    = 'uniform'
+    ! Uniform initial ice temperature, if choice_initial_ice_temperature == 'uniform'
+    uniform_initial_ice_temperature_NAM_config   = 270.0                            ! Uniform ice temperature (applied when choice_initial_ice_temperature_config = "uniform")
+    uniform_initial_ice_temperature_EAS_config   = 270.0
+    uniform_initial_ice_temperature_GRL_config   = 270.0
+    uniform_initial_ice_temperature_ANT_config   = 270.0
+    ! Paths to files containing initial temperature fields, if
+    filename_initial_ice_temperature_NAM_config  = ''
+    filename_initial_ice_temperature_EAS_config  = ''
+    filename_initial_ice_temperature_GRL_config  = ''
+    filename_initial_ice_temperature_ANT_config  = ''
+    ! Timeframes to read from the bed roughness file (set to 1E9    if the file has no time dimension)
+    timeframe_initial_ice_temperature_NAM_config = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_initial_ice_temperature_EAS_config = 1E9
+    timeframe_initial_ice_temperature_GRL_config = 1E9
+    timeframe_initial_ice_temperature_ANT_config = 1E9
+    ! Thermodynamical model
+    choice_thermo_model_config                   = 'none'                           ! Choice of thermodynamical model: "none", "3D_heat_equation"
+    dt_thermodynamics_config                     = 1.0                              ! [yr] Time step for the thermodynamical model
+    Hi_min_thermo_config                         = 10.0                             ! [m]  Ice thinner than this is assumed to have a temperature equal to the annual mean surface temperature throughout the vertical column
+    choice_GL_temperature_BC_config              = 'grounded'                       ! Choice of basal boundary condition at grounding lines: 'grounded', 'subgrid', 'pmp'
+    choice_ice_heat_capacity_config              = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Pounder1965"
+    uniform_ice_heat_capacity_config             = 2009.0                           ! Uniform ice heat capacity (applied when choice_ice_heat_capacity_config = "uniform")
+    choice_ice_thermal_conductivity_config       = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Ritz1987"
+    uniform_ice_thermal_conductivity_config      = 6.626958E7                       ! Uniform ice thermal conductivity (applied when choice_ice_thermal_conductivity_config = "uniform")
+
+  ! == Rheology and flow law
+  ! =========================
+
+    ! Flow law
+    choice_flow_law_config                       = 'Glen'                           ! Choice of flow law, relating effective viscosity to effective strain rate
+    Glens_flow_law_exponent_config               = 3.0                              ! Exponent in Glen`s flow law
+    Glens_flow_law_epsilon_sq_0_config           = 1E-8                             ! Normalisation term so that zero strain rates produce a high but finite viscosity
+
+    ! Rheology
+    choice_ice_rheology_Glen_config              = 'uniform'                        ! Choice of ice rheology model for Glen`s flow law: "uniform", "Huybrechts1992", "MISMIP_mod"
+    uniform_Glens_flow_factor_config             = 1.1187297124212972E-017          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
+
+    ! Enhancement factors
+    choice_enhancement_factor_transition_config  = 'separate'                       ! Choice of treatment of enhancement factors at transition zones: "separate", "interp"
+    m_enh_sheet_config                           = 1.0                              ! Ice flow enhancement factor for grounded ice
+    m_enh_shelf_config                           = 1.0                              ! Ice flow enhancement factor for floating ice
+
+  ! == Climate
+  ! ==========
+
+    ! Time step
+    do_asynchronous_climate_config               = .TRUE.                           ! Whether or not the climate should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_climate_config                            = 10.0                             ! [yr] Time step for calculating climate
+
+    ! Choice of climate model
+    choice_climate_model_NAM_config              = 'none'
+    choice_climate_model_EAS_config              = 'none'
+    choice_climate_model_GRL_config              = 'none'
+    choice_climate_model_ANT_config              = 'none'
+
+    ! Choice of idealised climate model
+    choice_climate_model_idealised_config        = ''
+
+    ! Choice of realistic climate model
+    choice_climate_model_realistic_config        = ''
+
+    filename_climate_snapshot_NAM_config         = ''
+    filename_climate_snapshot_EAS_config         = ''
+    filename_climate_snapshot_GRL_config         = ''
+    filename_climate_snapshot_ANT_config         = ''
+
+  ! == Ocean
+  ! ========
+
+    ! Time step
+    do_asynchronous_ocean_config                 = .TRUE.                           ! Whether or not the ocean should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_ocean_config                              = 10.0                             ! [yr] Time step for calculating ocean
+
+    ! Vertical grid
+    ocean_vertical_grid_max_depth_config         = 1500.0                           ! Maximum depth of the ocean submodel
+    ocean_vertical_grid_dz_config                = 100.0                            ! Vertical distance between ocean layers
+
+    ! Choice of ocean model
+    choice_ocean_model_NAM_config                = 'none'
+    choice_ocean_model_EAS_config                = 'none'
+    choice_ocean_model_GRL_config                = 'none'
+    choice_ocean_model_ANT_config                = 'none'
+
+    ! Choice of idealised ocean model
+    choice_ocean_model_idealised_config          = ''
+
+    ! Choice of realistic ocean model
+    choice_ocean_model_realistic_config          = ''
+
+    filename_ocean_snapshot_NAM_config           = ''
+    filename_ocean_snapshot_EAS_config           = ''
+    filename_ocean_snapshot_GRL_config           = ''
+    filename_ocean_snapshot_ANT_config           = ''
+
+  ! == Surface mass balance
+  ! =======================
+
+    ! Time step
+    do_asynchronous_SMB_config                   = .TRUE.                           ! Whether or not the SMB should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_SMB_config                                = 10.0                             ! [yr] Time step for calculating SMB
+
+    ! Choice of SMB model
+    choice_SMB_model_NAM_config                  = 'uniform'
+    choice_SMB_model_EAS_config                  = 'uniform'
+    choice_SMB_model_GRL_config                  = 'uniform'
+    choice_SMB_model_ANT_config                  = 'idealised'
+
+    ! Choice of idealised SMB model
+    choice_SMB_model_idealised_config            = 'uniform'
+
+    ! Value to be used for uniform SMB (no regional variants, only used for idealised-geometry experiments)
+    uniform_SMB_config                           = 0.3
+
+    ! Prescribed SMB forcing
+    choice_SMB_prescribed_NAM_config             = ''
+    choice_SMB_prescribed_EAS_config             = ''
+    choice_SMB_prescribed_GRL_config             = ''
+    choice_SMB_prescribed_ANT_config             = ''
+
+    ! Files containing prescribed SMB forcing
+    filename_SMB_prescribed_NAM_config           = ''
+    filename_SMB_prescribed_EAS_config           = ''
+    filename_SMB_prescribed_GRL_config           = ''
+    filename_SMB_prescribed_ANT_config           = ''
+
+    ! Timeframes for reading prescribed SMB forcing from file (set to 1E9 if the file has no time dimension)
+    timeframe_SMB_prescribed_NAM_config          = 1E9
+    timeframe_SMB_prescribed_EAS_config          = 1E9
+    timeframe_SMB_prescribed_GRL_config          = 1E9
+    timeframe_SMB_prescribed_ANT_config          = 1E9
+
+  ! == Basal mass balance
+  ! =====================
+
+    ! Time step
+    do_asynchronous_BMB_config                   = .TRUE.                           ! Whether or not the BMB should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_BMB_config                                = 10.0                             ! [yr] Time step for calculating BMB
+
+    ! Grounding line treatment
+    choice_BMB_subgrid_config                    = 'NMP'                               ! Choice of sub-grid BMB scheme: "FCMP", "PMP" (following Leguy et al., 2021)
+
+    ! Choice of BMB model
+    choice_BMB_model_NAM_config                  = 'uniform'
+    choice_BMB_model_EAS_config                  = 'uniform'
+    choice_BMB_model_GRL_config                  = 'uniform'
+    choice_BMB_model_ANT_config                  = 'uniform'
+
+    ! Choice of idealised BMB model
+    choice_BMB_model_idealised_config            = ''
+
+    ! Choice of parameterised BMB model
+    choice_BMB_model_parameterised_config        = 'Favier2019'
+
+    ! "uniform"
+    uniform_BMB_config                           = 0.0
+
+    ! "parameterised"
+    BMB_Favier2019_gamma_config                  = 99.32E-5
+
+  ! == Lateral mass balance
+  ! =======================
+
+    ! Time step
+    dt_LMB_config                                = 5.0                              ! [yr] Time step for calculating LMB [not implemented yet]
+
+    ! Choice of LMB model
+    choice_LMB_model_NAM_config                  = 'uniform'
+    choice_LMB_model_EAS_config                  = 'uniform'
+    choice_LMB_model_GRL_config                  = 'uniform'
+    choice_LMB_model_ANT_config                  = 'uniform'
+
+    ! "uniform"
+    uniform_LMB_config                           = 0.0
+
+  ! == Glacial isostatic adjustment
+  ! ===============================
+
+    ! General settings
+    choice_GIA_model_config                      = 'none'
+    dt_GIA_config                                = 100.0                            ! [yr] GIA model time step
+    dx_GIA_config                                = 2000.0                           ! [m]  GIA model square grid resolution
+
+  ! == Sea level
+  ! ============
+
+    choice_sealevel_model_config                 = 'fixed'                          !     Can be "fixed", "prescribed", "eustatic", or "SELEN"
+    fixed_sealevel_config                        = 0.0                              ! [m] Fixed sea level value for the "fixed" choice
+
+  ! == SELEN
+  ! ========
+
+    SELEN_run_at_t_start_config                  = .FALSE.                          ! Whether or not to run SELEN in the first coupling loop (needed for some benchmark experiments)
+    SELEN_n_TDOF_iterations_config               = 1                                ! Number of Time-Dependent Ocean Function iterations
+    SELEN_n_recursion_iterations_config          = 1                                ! Number of recursion iterations
+    SELEN_use_rotational_feedback_config         = .FALSE.                          ! If TRUE, rotational feedback is included
+    SELEN_n_harmonics_config                     = 128                              ! Maximum number of harmonic degrees
+    SELEN_display_progress_config                = .FALSE.                          ! Whether or not to display the progress of the big loops to the screen
+
+    SELEN_dir_config                             = 'external/data/SELEN'                     ! Directory where SELEN initial files and spherical harmonics are stored
+    SELEN_global_topo_filename_config            = 'SELEN_global_topography.nc'     ! Filename for the SELEN global topography file (located in SELEN_dir)
+    SELEN_TABOO_init_filename_config             = 'SELEN_TABOO_initial_file.dat'   ! Filename for the TABOO initial file           (idem                )
+    SELEN_LMJ_VALUES_filename_config             = 'SELEN_lmj_values.bin'           ! Filename for the LJ and MJ values file        (idem                )
+
+    SELEN_irreg_time_n_config                    = 15                               ! Number of entries in the irregular moving time window
+    SELEN_irreg_time_window_config               = 20.0  , 20.0  , 20.0  , 5.0  , 5.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 0.0  ,  0.0  ,  0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  ,  0.0  ,  0.0  ,  0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  ,  0.0  ,  0.0  , 0.0  , 0.0
+
+    SELEN_lith_thickness_config                  = 100.0                            ! Thickness of the elastic lithosphere [km]
+    SELEN_visc_n_config                          = 3                                ! Number      of viscous asthenosphere layers
+    SELEN_visc_prof_config                       = 3.0  , 0.6   , 0.3               ! Viscosities of viscous asthenosphere layers [?]
+
+    ! Settings for the TABOO Earth deformation model
+    SELEN_TABOO_CDE_config                       = 0                                !     code of the model (see taboo for explanation)
+    SELEN_TABOO_TLOVE_config                     = 1                                !     Tidal love numbers yes/no
+    SELEN_TABOO_DEG1_config                      = 1                                !     Tidal love numbers degree
+    SELEN_TABOO_RCMB_config                      = 3480.0                           ! [m] Radius of CMB
+
+  ! == Output
+  ! =========
+
+    ! Basic settings
+    do_create_netcdf_output_config               = .TRUE.                           !     Whether or not NetCDF output files should be created at all
+    dt_output_config                             = 100.0                            !     Time step for writing output
+    dt_output_restart_config                     = 30000.0                          !     Time step for writing restart output
+    dt_output_grid_config                        = 5000.0                           !     Time step for writing gridded output
+    dx_output_grid_NAM_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for North America
+    dx_output_grid_EAS_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for Eurasia
+    dx_output_grid_GRL_config                    = 20E3                             ! [m] Horizontal resolution for the square grid used for output for Greenland
+    dx_output_grid_ANT_config                    = 2e3                              ! [m] Horizontal resolution for the square grid used for output for Antarctica
+    dx_output_grid_ROI_NAM_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for North America
+    dx_output_grid_ROI_EAS_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Eurasia
+    dx_output_grid_ROI_GRL_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Greenland
+    dx_output_grid_ROI_ANT_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Antarctica
+
+    ! Transects
+    transects_NAM_config                         = ''                              ! List of transects to use for North America
+    transects_EAS_config                         = ''                              ! List of transects to use for Eurasia
+    transects_GRL_config                         = ''                              ! List of transects to use for Greenland
+    transects_ANT_config                         = 'westeast,dx=1e3'                              ! List of transects to use for Antarctica
+
+    ! Which data fields we want to write to the main NetCDF output files
+    choice_output_field_01_config                = 'mask'
+    choice_output_field_02_config                = 'Hi'
+    choice_output_field_03_config                = 'Hb'
+    choice_output_field_04_config                = 'Hs'
+    choice_output_field_05_config                = 'u_vav'
+    choice_output_field_06_config                = 'v_vav'
+    choice_output_field_07_config                = 'uabs_vav'
+    choice_output_field_08_config                = 'fraction_gr'
+    choice_output_field_09_config                = 'fraction_gr_b'
+    choice_output_field_10_config                = 'basal_friction_coefficient'
+    choice_output_field_11_config                = 'pc_truncation_error'
+    choice_output_field_12_config                = 'SMB'
+    choice_output_field_13_config                = 'dHi_dt'
+    choice_output_field_14_config                = 'divQ'
+    choice_output_field_15_config                = 'BMB'
+    choice_output_field_16_config                = 'R_shear'
+    choice_output_field_17_config                = 'grounding_line'
+    choice_output_field_18_config                = 'calving_front'
+    choice_output_field_19_config                = 'ice_margin'
+    choice_output_field_20_config                = 'coastline'
+    choice_output_field_21_config                = 'none'
+    choice_output_field_22_config                = 'none'
+    choice_output_field_23_config                = 'none'
+    choice_output_field_24_config                = 'none'
+    choice_output_field_25_config                = 'none'
+    choice_output_field_26_config                = 'none'
+    choice_output_field_27_config                = 'none'
+    choice_output_field_28_config                = 'none'
+    choice_output_field_29_config                = 'none'
+    choice_output_field_30_config                = 'none'
+    choice_output_field_31_config                = 'none'
+    choice_output_field_32_config                = 'none'
+    choice_output_field_33_config                = 'none'
+    choice_output_field_34_config                = 'none'
+    choice_output_field_35_config                = 'none'
+    choice_output_field_36_config                = 'none'
+    choice_output_field_37_config                = 'none'
+    choice_output_field_38_config                = 'none'
+    choice_output_field_39_config                = 'none'
+    choice_output_field_40_config                = 'none'
+    choice_output_field_41_config                = 'none'
+    choice_output_field_42_config                = 'none'
+    choice_output_field_43_config                = 'none'
+    choice_output_field_44_config                = 'none'
+    choice_output_field_45_config                = 'none'
+    choice_output_field_46_config                = 'none'
+    choice_output_field_47_config                = 'none'
+    choice_output_field_48_config                = 'none'
+    choice_output_field_49_config                = 'none'
+    choice_output_field_50_config                = 'none'
+
+/

--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_05_4km_ice1r.cfg
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_05_4km_ice1r.cfg
@@ -11,7 +11,7 @@
     do_benchmarks_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
     do_unit_tests_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
     do_check_for_NaN_config                      = .FALSE.                          ! Whether or not fields should be checked for NaN values
-    do_time_display_config                       = .false.                           ! Print current model time to screen
+    do_time_display_config                       = .TRUE.                           ! Print current model time to screen
 
   ! == Time of simulation
   ! =====================
@@ -90,7 +90,7 @@
     filename_refgeo_init_NAM_config              = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
     filename_refgeo_init_EAS_config              = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
     filename_refgeo_init_GRL_config              = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
-    filename_refgeo_init_ANT_config              = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_4km_spinup/main_output_ANT_LAST.nc'
+    filename_refgeo_init_ANT_config              = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_4km_spinup/main_output_ANT_LAST.nc'
     ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
     timeframe_refgeo_init_NAM_config             = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
     timeframe_refgeo_init_EAS_config             = 1E9
@@ -171,7 +171,7 @@
     filename_initial_mesh_NAM_config             = ''
     filename_initial_mesh_EAS_config             = ''
     filename_initial_mesh_GRL_config             = ''
-    filename_initial_mesh_ANT_config             = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_4km_spinup/main_output_ANT_LAST.nc'
+    filename_initial_mesh_ANT_config             = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_4km_spinup/main_output_ANT_LAST.nc'
 
     ! Resolutions for different parts of the ice sheet
     maximum_resolution_uniform_config            = 10e3                             ! [m]          Maximum resolution for the entire domain
@@ -258,7 +258,7 @@
     filename_initial_velocity_NAM_config         = ''
     filename_initial_velocity_EAS_config         = ''
     filename_initial_velocity_GRL_config         = ''
-    filename_initial_velocity_ANT_config         = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_4km_spinup/restart_ice_velocity_DIVA_LAST.nc'
+    filename_initial_velocity_ANT_config         = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_4km_spinup/restart_ice_velocity_DIVA_LAST.nc'
     ! Timeframes to read from the initial velocity files (set to 1E9    if the file has no time dimension)
     timeframe_initial_velocity_NAM_config        = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
     timeframe_initial_velocity_EAS_config        = 1E9
@@ -374,7 +374,7 @@
     filename_pc_initialise_NAM_config            = ''
     filename_pc_initialise_EAS_config            = ''
     filename_pc_initialise_GRL_config            = ''
-    filename_pc_initialise_ANT_config            = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_4km_spinup/restart_pc_scheme_LAST.nc'
+    filename_pc_initialise_ANT_config            = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_4km_spinup/restart_pc_scheme_LAST.nc'
     ! Timeframes to read from the p/c scheme initial file (set to 1E9    if the file has no time dimension)
     timeframe_pc_initialise_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
     timeframe_pc_initialise_EAS_config           = 1E9
@@ -540,7 +540,7 @@
 
     ! Rheology
     choice_ice_rheology_Glen_config              = 'uniform'                        ! Choice of ice rheology model for Glen`s flow law: "uniform", "Huybrechts1992", "MISMIP_mod"
-    uniform_Glens_flow_factor_config             = 1.4053906563768196E-017          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
+    uniform_Glens_flow_factor_config             = 1.6195677490759769E-017          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
 
     ! Enhancement factors
     choice_enhancement_factor_transition_config  = 'separate'                       ! Choice of treatment of enhancement factors at transition zones: "separate", "interp"

--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_05_4km_ice1r.cfg
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_05_4km_ice1r.cfg
@@ -1,0 +1,799 @@
+&CONFIG
+
+  ! General model instructions
+  ! ==========================
+
+    ! Output directory
+    create_procedural_output_dir_config          = .FALSE.                          ! Automatically create an output directory with a procedural name (e.g. results_20210720_001/)
+    fixed_output_dir_config                      = 'automated_testing/UFEMISM/integrated_test_MISMIPplus_full/results_4km_ice1r' ! If not, create a directory with this name instead (stops the program if this directory already exists)
+
+    ! Debugging
+    do_benchmarks_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
+    do_unit_tests_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
+    do_check_for_NaN_config                      = .FALSE.                          ! Whether or not fields should be checked for NaN values
+    do_time_display_config                       = .false.                           ! Print current model time to screen
+
+  ! == Time of simulation
+  ! =====================
+
+    start_time_of_run_config                     = 0.0                              ! [yr] Start time of the simulation
+    end_time_of_run_config                       = 100.0                            ! [yr] End   time of the simulation
+
+  ! == Which model regions to simulate
+  ! ==================================
+
+    dt_coupling_config                           = 1000.0                           ! [yr] Interval of coupling between the different model regions
+    do_NAM_config                                = .FALSE.
+    do_EAS_config                                = .FALSE.
+    do_GRL_config                                = .FALSE.
+    do_ANT_config                                = .TRUE.
+
+  ! == The four model regions
+  ! =========================
+
+    ! North America
+    lambda_M_NAM_config                          = 265.0                            ! [degrees east]  [default: 265.0]   Longitude of the pole of the stereographic projection for the North America domain
+    phi_M_NAM_config                             =  62.0                            ! [degrees north] [default:  62.0]   Latitude  of the pole of the stereographic projection for the North America domain
+    beta_stereo_NAM_config                       =  71.0                            ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the North America domain
+    xmin_NAM_config                              = -3600000.0                       ! [m]             [default: -3600E3] Western  boundary     of the North America domain
+    xmax_NAM_config                              =  3600000.0                       ! [m]             [default:  3600E3] Eastern  boundary     of the North America domain
+    ymin_NAM_config                              = -2400000.0                       ! [m]             [default: -2400E3] Southern boundary     of the North America domain
+    ymax_NAM_config                              =  2400000.0                       ! [m]             [default:  2400E3] Northern boundary     of the North America domain
+
+    ! Eurasia
+    lambda_M_EAS_config                          = 40.0                             ! [degrees east]  [default:  40.0]   Longitude of the pole of the stereographic projection for the Eurasia domain
+    phi_M_EAS_config                             = 70.0                             ! [degrees north] [default:  70.0]   Latitude  of the pole of the stereographic projection for the Eurasia domain
+    beta_stereo_EAS_config                       = 71.0                             ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the Eurasia domain
+    xmin_EAS_config                              = -3400000.0                       ! [m]             [default: -3400E3] Western  boundary     of the Eurasia domain
+    xmax_EAS_config                              =  3400000.0                       ! [m]             [default:  3400E3] Eastern  boundary     of the Eurasia domain
+    ymin_EAS_config                              = -2080000.0                       ! [m]             [default: -2080E3] Southern boundary     of the Eurasia domain
+    ymax_EAS_config                              =  2080000.0                       ! [m]             [default:  2080E3] Northern boundary     of the Eurasia domain
+
+    ! Greenland
+    lambda_M_GRL_config                          = -45.0                            ! [degrees east]  [default: -45.0]   Longitude of the pole of the stereographic projection for the Greenland domain
+    phi_M_GRL_config                             = 90.0                             ! [degrees north] [default:  90.0]   Latitude  of the pole of the stereographic projection for the Greenland domain
+    beta_stereo_GRL_config                       = 70.0                             ! [degrees]       [default:  70.0]   Standard parallel     of the stereographic projection for the Greenland domain
+    xmin_GRL_config                              =  -720000.0                       ! [m]             [default:  -720E3] Western  boundary     of the Greenland domain [m]
+    xmax_GRL_config                              =   960000.0                       ! [m]             [default:   960E3] Eastern  boundary     of the Greenland domain [m]
+    ymin_GRL_config                              = -3450000.0                       ! [m]             [default: -3450E3] Southern boundary     of the Greenland domain [m]
+    ymax_GRL_config                              =  -570000.0                       ! [m]             [default:  -570E3] Northern boundary     of the Greenland domain [m]
+
+    ! Antarctica
+    lambda_M_ANT_config                          = 0.0                              ! [degrees east]  [default:   0.0]   Longitude of the pole of the stereographic projection for the Antarctica domain
+    phi_M_ANT_config                             = -90.0                            ! [degrees north] [default: -90.0]   Latitude  of the pole of the stereographic projection for the Antarctica domain
+    beta_stereo_ANT_config                       = 71.0                             ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the Antarctica domain
+    xmin_ANT_config                              = 0.0                              ! [m]             [default: -3040E3] Western  boundary     of the Antarctica domain [m]
+    xmax_ANT_config                              = 800000.0                         ! [m]             [default:  3040E3] Eastern  boundary     of the Antarctica domain [m]
+    ymin_ANT_config                              = -40000.0                         ! [m]             [default: -3040E3] Southern boundary     of the Antarctica domain [m]
+    ymax_ANT_config                              =  40000.0                         ! [m]             [default:  3040E3] Northern boundary     of the Antarctica domain [m]
+
+  ! == Reference geometries (initial, present-day, and GIA equilibrium)
+  ! ===================================================================
+
+    ! Some pre-processing stuff for reference ice geometry
+    refgeo_Hi_min_config                         = 2.0                              ! [m]             [default: 2.0]     Remove ice thinner than this value in the reference ice geometry. Particularly useful for BedMachine Greenland, which somehow covers the entire tundra with half a meter of ice...
+    do_smooth_geometry_config                    = .FALSE                           ! Whether or not to smooth the reference bedrock
+    r_smooth_geometry_config                     = 0.5                              ! [m]             Geometry smoothing radius
+    remove_Lake_Vostok_config                    = .FALSE.                          ! Whether or not to replace subglacial Lake Vostok in Antarctica with ice (recommended to set to TRUE, otherwise it will really slow down your model for the first few hundred years...)
+
+    ! == Initial geometry
+    ! ===================
+
+    choice_refgeo_init_NAM_config                = 'read_from_file'                 ! Choice of initial geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_init_EAS_config                = 'read_from_file'                 ! Choice of initial geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_init_GRL_config                = 'read_from_file'                 ! Choice of initial geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_init_ANT_config                = 'read_from_file'                 ! Choice of initial geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_init == 'idealised'
+    choice_refgeo_init_idealised_config          = 'MISMIPplus'                        ! Choice of idealised initial geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_init_idealised_config              = 1000.0                           ! Resolution of square grid used for idealised initial geometry
+    ! Path to file containing initial geometry when choice_refgeo_init == 'read_from_file'
+    filename_refgeo_init_NAM_config              = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_init_EAS_config              = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_init_GRL_config              = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_init_ANT_config              = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_4km_spinup/main_output_ANT_LAST.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_init_NAM_config             = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_init_EAS_config             = 1E9
+    timeframe_refgeo_init_GRL_config             = 1E9
+    timeframe_refgeo_init_ANT_config             = 1e9
+
+    ! == Present-day geometry
+    ! =======================
+
+    choice_refgeo_PD_NAM_config                  = 'read_from_file'                 ! Choice of present-day geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_EAS_config                  = 'read_from_file'                 ! Choice of present-day geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_GRL_config                  = 'read_from_file'                 ! Choice of present-day geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_ANT_config                  = 'idealised'                      ! Choice of present-day geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_PD == 'idealised'
+    choice_refgeo_PD_idealised_config            = 'MISMIPplus'                        ! Choice of idealised present-day geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_PD_idealised_config                = 1000.0                           ! Resolution of square grid used for idealised present-day geometry
+    ! Path to file containing present-day geometry when choice_refgeo_PD == 'read_from_file'
+    filename_refgeo_PD_NAM_config                = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_PD_EAS_config                = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_PD_GRL_config                = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_PD_ANT_config                = 'external/data/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_PD_NAM_config               = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_PD_EAS_config               = 1E9
+    timeframe_refgeo_PD_GRL_config               = 1E9
+    timeframe_refgeo_PD_ANT_config               = 1E9
+
+    ! == GIA equilibrium geometry
+    ! ===========================
+
+    choice_refgeo_GIAeq_NAM_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_EAS_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_GRL_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_ANT_config               = 'idealised'                      ! Choice of GIA equilibrium reference geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_GIAeq == 'idealised'
+    choice_refgeo_GIAeq_idealised_config         = 'MISMIPplus'                        ! Choice of idealised GIA equilibrium reference geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_GIAeq_idealised_config             = 1000.0                           ! Resolution of square grid used for idealised GIA equilibrium reference geometry
+    ! Path to file containing GIA equilibrium reference geometry when choice_refgeo_GIAeq == 'read_from_file'
+    filename_refgeo_GIAeq_NAM_config             = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_GIAeq_EAS_config             = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_GIAeq_GRL_config             = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_GIAeq_ANT_config             = 'external/data/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_GIAeq_NAM_config            = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_GIAeq_EAS_config            = 1E9
+    timeframe_refgeo_GIAeq_GRL_config            = 1E9
+    timeframe_refgeo_GIAeq_ANT_config            = 1E9
+
+    ! == Parameters for idealised geometries
+    ! ======================================
+
+    refgeo_idealised_slabonaslope_Hi_config      = 0.0                              ! Suggested value: 2000 m
+    refgeo_idealised_slabonaslope_dhdx_config    = 1.0                              ! Suggested value: -0.001
+    refgeo_idealised_Halfar_H0_config            = 0.0                              ! Suggested value: 3000 m
+    refgeo_idealised_Halfar_R0_config            = 0.0                              ! Suggested value: 500E3 m
+    refgeo_idealised_Bueler_H0_config            = 0.0                              ! Suggested value: 3000 m
+    refgeo_idealised_Bueler_R0_config            = 0.0                              ! Suggested value: 500E3 m
+    refgeo_idealised_Bueler_lambda_config        = 0.0                              ! Suggested value: 5.0
+    refgeo_idealised_SSA_icestream_Hi_config     = -1.0                             ! Suggested value: 2000 m
+    refgeo_idealised_SSA_icestream_dhdx_config   = 1.0                              ! Suggested value: -0.0003
+    refgeo_idealised_SSA_icestream_L_config      = 0.0                              ! Suggested value: 150 km
+    refgeo_idealised_SSA_icestream_m_config      = 0.0                              ! Suggested value: 1.0
+    refgeo_idealised_MISMIP_mod_Hi_init_config   = -1.0                             ! Suggested value: 100 m
+    refgeo_idealised_ISMIP_HOM_L_config          = 0.0                              ! Suggested value: 5E3 - 160E3 m
+    refgeo_idealised_MISMIPplus_Hi_init_config   = 100.0                            ! Suggested value: 100 m
+    refgeo_idealised_MISMIPplus_tune_A_config    = .FALSE.                          ! If so, the uniform flow factor A is tuned to achieve a steady-state mid-stream grounding-line position at x = 450 km
+
+  ! == Mesh generation
+  ! ==================
+
+    ! How to set up the initial mesh
+    choice_initial_mesh_NAM_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_EAS_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_GRL_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_ANT_config               = 'read_from_file'                 ! Options: 'calc_from_initial_geometry', 'read_from_file'
+
+    ! Paths to files containing initial meshes, if choice_initial_mesh == 'read_from_file'
+    filename_initial_mesh_NAM_config             = ''
+    filename_initial_mesh_EAS_config             = ''
+    filename_initial_mesh_GRL_config             = ''
+    filename_initial_mesh_ANT_config             = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_4km_spinup/main_output_ANT_LAST.nc'
+
+    ! Resolutions for different parts of the ice sheet
+    maximum_resolution_uniform_config            = 10e3                             ! [m]          Maximum resolution for the entire domain
+    maximum_resolution_grounded_ice_config       = 8e3                              ! [m]          Maximum resolution for grounded ice
+    maximum_resolution_floating_ice_config       = 5e3                              ! [m]          Maximum resolution for floating ice
+    maximum_resolution_grounding_line_config     = 4e3                              ! [m]          Maximum resolution for the grounding line
+    maximum_resolution_calving_front_config      = 5e3                              ! [m]          Maximum resolution for the calving front
+    maximum_resolution_ice_front_config          = 20e3                             ! [m]          Maximum resolution for the ice front
+    maximum_resolution_coastline_config          = 1000e3                           ! [m]          Maximum resolution for the coastline
+
+    ! Widths for each resolution band
+    grounding_line_width_config                  = 2.0e3                            ! [m]          Width of the band around the grounding line that should get this resolution
+    calving_front_width_config                   = 2.5e3                            ! [m]          Width of the band around the calving front that should get this resolution
+    maximum_resolution_ice_front_config          = 20e3                             ! [m]          Maximum resolution for the ice front
+    ice_front_width_config                       = 10e3                             ! [m]          Width of the band around the ice front that should get this resolution
+    coastline_width_config                       = 1000e3                           ! [m]          Width of the band around the coastline that should get this resolution
+
+    ! Regions of interest
+    choice_regions_of_interest_config            = ''                               ! Regions of interest where other (higher) resolutions apply. Separated by double vertical bars "||", e.g. "PineIsland||Thwaites"
+    ROI_maximum_resolution_uniform_config        = 100e3                            ! [m]          Maximum resolution for the entire domain
+    ROI_maximum_resolution_grounded_ice_config   = 50e3                             ! [m]          Maximum resolution for grounded ice
+    ROI_maximum_resolution_floating_ice_config   = 20e3                             ! [m]          Maximum resolution for floating ice
+    ROI_maximum_resolution_grounding_line_config = 5e3                              ! [m]          Maximum resolution for the grounding line
+    ROI_maximum_resolution_calving_front_config  = 10e3                             ! [m]          Maximum resolution for the calving front
+    ROI_maximum_resolution_ice_front_config      = 20e3                             ! [m]          Maximum resolution for the ice front
+    ROI_maximum_resolution_coastline_config      = 50e3                             ! [m]          Maximum resolution for the coastline
+
+    ! Widths for each resolution band
+    ROI_grounding_line_width_config              = 2e3                              ! [m]          Width of the band around the grounding line that should get this resolution
+    ROI_calving_front_width_config               = 10e3                             ! [m]          Width of the band around the calving front that should get this resolution
+    ROI_ice_front_width_config                   = 20e3                             ! [m]          Width of the band around the ice front that should get this resolution
+    ROI_coastline_width_config                   = 50e3                             ! [m]          Width of the band around the coastline that should get this resolution
+
+    ! Mesh update settings
+    allow_mesh_updates_config                    = .TRUE.                           ! [-]          Whether or not mesh updates are allowed
+    dt_mesh_update_min_config                    = 10.0                             ! [yr]         Minimum amount of time between mesh updates
+    minimum_mesh_fitness_coefficient_config      = 0.97                             ! [-]          If the mesh fitness drops below this threshold, trigger a mesh update
+    do_out_of_time_calving_front_relax_config    = .TRUE.                           !              Whether or not to step out of time and relax the calving front for a few iterations after a mesh update
+
+    ! Advanced geometry parameters
+    do_singlecore_mesh_creation_config           = .TRUE.                           !              Whether or not to use only a single core for mesh generation (for better reproducibility)
+    alpha_min_config                             = 0.4363                           ! [radians]    Smallest allowed internal triangle angle (recommended value: 25 degrees = 0.4363)
+    nit_Lloyds_algorithm_config                  = 3                                ! [-]          Number of iterations of Lloyds algorithm to be applied after refinement
+    mesh_resolution_tolerance_config             = 1.25                             ! [-]          Factors the target resolution for trangle-size requirement. 1=strict, use >1 to avoid unnecesarily high resolution
+
+    ! Square grid used for smoothing
+    dx_square_grid_smooth_NAM_config             = 2000.0
+    dx_square_grid_smooth_EAS_config             = 2000.0
+    dx_square_grid_smooth_GRL_config             = 2000.0
+    dx_square_grid_smooth_ANT_config             = 2000.0
+
+  ! == The scaled vertical coordinate zeta
+  ! ======================================
+
+    choice_zeta_grid_config                      = 'regular'                        ! The type of vertical grid to use; can be "regular", "irregular_log", "old_15_layer_zeta"
+    nz_config                                    = 12                               ! The number of vertical layers to use
+    zeta_irregular_log_R_config                  = 10.0                             ! Ratio between surface and base layer spacings
+
+  ! == Ice dynamics - velocity
+  ! ==========================
+
+    ! General
+    choice_stress_balance_approximation_config   = 'DIVA'                           ! Choice of stress balance approximation: "none" (= no flow, though geometry can still change due to mass balance), "SIA", "SSA", "SIA/SSA", "DIVA", "BPA"
+    choice_hybrid_SIASSA_scheme_config           = 'add'                            ! Choice of scheme for combining SIA and SSA velocities in the hybrid approach
+    do_include_SSADIVA_crossterms_config         = .TRUE.                           ! Whether or not to include the gradients of the effective viscosity (the "cross-terms") in the solution of the SSA/DIVA
+
+    ! Hybrid DIVA/BPA
+    choice_hybrid_DIVA_BPA_mask_NAM_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for North America
+    choice_hybrid_DIVA_BPA_mask_EAS_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Eurasia
+    choice_hybrid_DIVA_BPA_mask_GRL_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Greenland
+    choice_hybrid_DIVA_BPA_mask_ANT_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Antarctica
+
+    filename_hybrid_DIVA_BPA_mask_NAM_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for North America
+    filename_hybrid_DIVA_BPA_mask_EAS_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Eurasia
+    filename_hybrid_DIVA_BPA_mask_GRL_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Greenland
+    filename_hybrid_DIVA_BPA_mask_ANT_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Antarctica
+
+    ! Initialisation
+    choice_initial_velocity_NAM_config           = 'zero'                           ! Can be 'zero', 'read_from_file'
+    choice_initial_velocity_EAS_config           = 'zero'
+    choice_initial_velocity_GRL_config           = 'zero'
+    choice_initial_velocity_ANT_config           = 'read_from_file'
+    ! Paths to files containing initial velocity fields
+    filename_initial_velocity_NAM_config         = ''
+    filename_initial_velocity_EAS_config         = ''
+    filename_initial_velocity_GRL_config         = ''
+    filename_initial_velocity_ANT_config         = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_4km_spinup/restart_ice_velocity_DIVA_LAST.nc'
+    ! Timeframes to read from the initial velocity files (set to 1E9    if the file has no time dimension)
+    timeframe_initial_velocity_NAM_config        = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_initial_velocity_EAS_config        = 1E9
+    timeframe_initial_velocity_GRL_config        = 1E9
+    timeframe_initial_velocity_ANT_config        = 1e9
+
+    ! Some parameters for numerically solving the stress balance
+    SIA_maximum_diffusivity_config               = 1E5                              ! Limit the diffusivity in the SIA to this value
+    visc_it_norm_dUV_tol_config                  = 5E-5                             ! Stop criterion for the viscosity iteration: the L2-norm of successive velocity solutions should be smaller than this number
+    visc_it_nit_config                           = 50                               ! Maximum number of effective viscosity iterations
+    visc_it_relax_config                         = 0.2                              ! Relaxation parameter for subsequent viscosity iterations (for improved stability)
+    visc_eff_min_config                          = 1E4                              ! Minimum value for effective viscosity
+    vel_max_config                               = 5000.0                           ! Velocities are limited to this value
+    stress_balance_PETSc_rtol_config             = 1E-7                             ! PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
+    stress_balance_PETSc_abstol_config           = 1E-5                             ! PETSc solver - stop criterion, absolute difference
+
+    ! Boundary conditions
+    BC_u_west_config                             = 'zero'                           ! Boundary conditions for the ice velocity field at the domain border
+    BC_u_east_config                             = 'infinite'                       ! Allowed choices: "infinite", "zero", "periodic_ISMIP-HOM"
+    BC_u_south_config                            = 'infinite'
+    BC_u_north_config                            = 'infinite'
+    BC_v_west_config                             = 'zero'
+    BC_v_east_config                             = 'zero'
+    BC_v_south_config                            = 'zero'
+    BC_v_north_config                            = 'zero'
+
+  ! == Ice dynamics - sliding
+  ! =========================
+
+    ! General
+    choice_sliding_law_config                    = 'Schoof2005'                     ! Choice of sliding law: "no_sliding", "idealised", "Coulomb", "Budd", "Weertman", "Tsai2015", "Schoof2005", "Zoet-Iverson"
+    choice_idealised_sliding_law_config          = ''                               ! "ISMIP_HOM_C", "ISMIP_HOM_D", "ISMIP_HOM_E", "ISMIP_HOM_F"
+
+    ! Parameters for different sliding laws
+    slid_Weertman_m_config                       = 3.0                              ! Exponent in Weertman sliding law
+    slid_Budd_q_plastic_config                   = 0.3                              ! Scaling exponent in Budd sliding law
+    slid_Budd_u_threshold_config                 = 100.0                            ! Threshold velocity in Budd sliding law
+    slid_ZI_p_config                             = 5.0                              ! Velocity exponent used in the Zoet-Iverson sliding law
+    slid_ZI_ut_config                            = 200.0                            ! (uniform) transition velocity used in the Zoet-Iverson sliding law [m/yr]
+
+    ! Sub-grid scaling of basal friction
+    do_GL_subgrid_friction_config                = .TRUE.                           ! Whether or not to scale basal friction with the sub-grid grounded fraction (needed to get proper GL migration; only turn this off for showing the effect on the MISMIP_mod results!)
+    choice_subgrid_grounded_fraction_config      = 'bilin_interp_TAF+bedrock_CDF'                    ! Choice of scheme to calculate the sub-grid grounded fractions: 'trilin', 'bedrock_CDF'
+    do_read_bedrock_cdf_from_file_config         = .FALSE.                          ! Whether or not to read the bedrock CDF from the initial mesh file. Requires choice_initial_mesh_XXX_config =  'read_from_file'!
+    subgrid_bedrock_cdf_nbins_config             = 11                               ! Number of bins to be used for sub-grid bedrock cumulative density functions
+    do_subgrid_friction_on_A_grid_config         = .FALSE.                          ! Whether or not to apply a preliminary scaling to basal hydrology and bed roughness on the A grid, before the final scaling of beta on the b grid. The exponent of this scaling is computed based on ice thickness.
+    subgrid_friction_exponent_on_B_grid_config   = 2.0                              ! Exponent to which f_grnd should be raised before being used to scale beta
+
+    ! Stability
+    slid_beta_max_config                         = 1E20                             ! Maximum value for basal friction coefficient
+    slid_delta_v_config                          = 1.0E-3                           ! Normalisation parameter to prevent errors when velocity is zero
+
+  ! == Ice dynamics - ice thickness calculation
+  ! ===========================================
+
+    ! Calculation of dH/dt
+    choice_ice_integration_method_config         = 'semi-implicit'                  ! Choice of ice thickness integration scheme: "none" (i.e. unchanging geometry), "explicit", "semi-implicit"
+    dHi_semiimplicit_fs_config                   = 1.5                              ! Factor for the semi-implicit ice thickness solver (0 = explicit, 0<f<1 = semi-implicit, 1 = implicit, >1 = over-implicit)
+    dHi_PETSc_rtol_config                        = 1E-8                             ! dHi PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
+    dHi_PETSc_abstol_config                      = 1E-6                             ! dHi PETSc solver - stop criterion, absolute difference
+
+    ! Boundary conditions
+    BC_H_west_config                             = 'infinite'                       ! Boundary conditions for ice thickness at the domain boundary
+    BC_H_east_config                             = 'zero'                           ! Allowed choices:  "infinite", "zero", "ISMIP_HOM_F"
+    BC_H_south_config                            = 'infinite'
+    BC_H_north_config                            = 'infinite'
+
+  ! == Ice dynamics - target quantities
+  ! ===================================
+
+    ! Target dHi_dt
+    do_target_dHi_dt_config                      = .FALSE.                          ! Whether or not to use a target dHi_dt field from an external file to alter the modelled one
+    do_limit_target_dHi_dt_to_SMB_config         = .TRUE.                           ! Whether or not to limit a target dHi_dt field to available SMB in that area, so it does not melt all ice there
+    target_dHi_dt_t_end_config                   = 9.9e9                            ! End time of target dHi_dt application
+
+    ! Files containing a target dHi_dt for inversions
+    filename_dHi_dt_target_NAM_config            = ''
+    filename_dHi_dt_target_EAS_config            = ''
+    filename_dHi_dt_target_GRL_config            = ''
+    filename_dHi_dt_target_ANT_config            = ''
+
+    ! Timeframes for reading target dHi_dt from file (set to 1E9_dp if the file has no time dimension)
+    timeframe_dHi_dt_target_NAM_config           = 1E9
+    timeframe_dHi_dt_target_EAS_config           = 1E9
+    timeframe_dHi_dt_target_GRL_config           = 1E9
+    timeframe_dHi_dt_target_ANT_config           = 1E9
+
+  ! == Ice dynamics - time stepping
+  ! ===============================
+
+    ! Time stepping
+    choice_timestepping_config                   = 'pc'                             ! Choice of timestepping method: "direct", "pc" (NOTE: 'direct' does not work with DIVA ice dynamcis!)
+    dt_ice_max_config                            = 10.0                             ! [yr] Maximum time step of the ice dynamics model
+    dt_ice_min_config                            = 0.1                              ! [yr] Minimum time step of the ice dynamics model
+    dt_ice_startup_phase_config                  = 0.0                              ! [yr] Length of time window after start_time and before end_time when dt = dt_min, to ensure smooth restarts
+    do_grounded_only_adv_dt_config               = .FALSE.                          ! If .TRUE., only grounded ice is used in the computation of the advective time step limit (CFL condition)
+
+    ! Predictor-corrector ice-thickness update
+    pc_epsilon_config                            = 0.005                            ! Target truncation error in dHi_dt [m/yr] (epsilon in Robinson et al., 2020, Eq. 33)
+    pc_k_I_config                                = 0.2                              ! Exponent k_I in  Robinson et al., 2020, Eq. 33
+    pc_k_p_config                                = 0.2                              ! Exponent k_p in  Robinson et al., 2020, Eq. 33
+    pc_eta_min_config                            = 1E-8                             ! Normalisation term in estimation of the truncation error (Robinson et al., Eq. 32)
+    pc_max_time_step_increase_config             = 1.1                              ! Each new time step is only allowed to be this much larger than the previous one
+    pc_nit_max_config                            = 50                               ! Maximum number of times a PC timestep can be repeated with reduced dt
+    pc_guilty_max_config                         = 0.0                              ! [%] Maximum percentage of grounded vertices allowed to have a truncation error larger than the tolerance pc_epsilon
+
+    ! Initialisation of the predictor-corrector ice-thickness update
+    pc_choice_initialise_NAM_config              = 'zero'                           ! How to initialise the p/c scheme: 'zero', 'read_from_file'
+    pc_choice_initialise_EAS_config              = 'zero'
+    pc_choice_initialise_GRL_config              = 'zero'
+    pc_choice_initialise_ANT_config              = 'read_from_file'
+    ! Paths to files containing initial fields & values for the p/c scheme
+    filename_pc_initialise_NAM_config            = ''
+    filename_pc_initialise_EAS_config            = ''
+    filename_pc_initialise_GRL_config            = ''
+    filename_pc_initialise_ANT_config            = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_4km_spinup/restart_pc_scheme_LAST.nc'
+    ! Timeframes to read from the p/c scheme initial file (set to 1E9    if the file has no time dimension)
+    timeframe_pc_initialise_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_pc_initialise_EAS_config           = 1E9
+    timeframe_pc_initialise_GRL_config           = 1E9
+    timeframe_pc_initialise_ANT_config           = 1e9
+
+  ! == Ice dynamics - calving
+  ! =========================
+
+    choice_calving_law_config                    = 'none'                           ! Choice of calving law: "none", "threshold_thickness"
+    calving_threshold_thickness_shelf_config     = 100.0                            ! Threshold ice thickness for ice shelf calving front in the "threshold_thickness" calving law
+    calving_threshold_thickness_sheet_config     = 0.0                              ! Threshold ice thickness for ice sheet calving front in the "threshold_thickness" calving law
+    max_calving_rounds_config                    = 20                               ! Maximum number of calving loops during chain reaction
+    do_remove_shelves_config                     = .FALSE.                          ! If set to TRUE, all floating ice is always instantly removed (used in the ABUMIP-ABUK experiment)
+    remove_shelves_larger_than_PD_config         = .FALSE.                          ! If set to TRUE, all floating ice beyond the present-day calving front is removed (used for some Antarctic spin-ups)
+    continental_shelf_calving_config             = .FALSE.                          ! If set to TRUE, all ice beyond the continental shelf edge (set by a maximum depth) is removed
+    continental_shelf_min_height_config          = -2000.0                          ! Maximum depth of the continental shelf
+
+  ! == Ice dynamics - stabilisation
+  ! ===============================
+
+    choice_mask_noice_config                     = 'MISMIP+'                        ! Choice of mask_noice configuration
+    Hi_min_config                                = 0.0                              ! [m] Minimum ice thickness: thinner ice gets temporarily added to the no-ice mask and eventually removed
+    Hi_thin_config                               = 0.0                              ! [m] Thin-ice thickness threshold: thinner ice is considered dynamically unreliable (e.g. over steep slopes)
+    remove_ice_absent_at_PD_config               = .FALSE.                          ! If set to TRUE, all ice not present in PD data is always instantly removed
+
+    ! Geometry relaxation
+    geometry_relaxation_t_years_config           = 0.0                              ! [yr] Amount of years (out-of-time) during which the geometry will relaxed during initialisation: no mass balance, thickness alterations, inversions, or target thinning rates will be applied during this time
+
+    ! Mask conservation
+    do_protect_grounded_mask_config              = .FALSE.                          ! If set to TRUE, grounded ice will not be allowed to cross the floatation threshold and will stay minimally grounded.
+    protect_grounded_mask_t_end_config           = 20000.0                          ! End time of grounded mask protection. After this time, it will be allowed to thin and become afloat
+
+    ! Fix/delay ice thickness evolution
+    do_fixiness_before_start_config              = .TRUE.                           ! Whether or not to apply fixiness values before fixiness_t_start
+    fixiness_t_start_config                      = -9.9E9                           ! Start time of linear transition between fixed/delayed and free evolution
+    fixiness_t_end_config                        = -8.8E8                           ! End   time of linear transition between fixed/delayed and free evolution
+    fixiness_H_gl_gr_config                      = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_gl_fl_config                      = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_grounded_config                   = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_floating_config                   = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_freeland_config                   = .FALSE.                          ! Fix (.TRUE.) ice-free vertices between fixiness_t_start and fixiness_t_end
+    fixiness_H_freeocean_config                  = .FALSE.                          ! Fix (.TRUE.) ice-free vertices between fixiness_t_start and fixiness_t_end
+
+    ! Limit ice thickness evolution
+    do_limitness_before_start_config             = .TRUE.                           ! Whether or not to apply limitness values before limitness_t_start
+    limitness_t_start_config                     = -9.9E9                           ! Start time of linear transition between limited and free evolution
+    limitness_t_end_config                       = -8.8E8                           ! End   time of linear transition between limited and free evolution
+    limitness_H_gl_gr_config                     = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_gl_fl_config                     = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_grounded_config                  = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_floating_config                  = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    modiness_H_style_config                      = 'none'                           ! Dynamic "modiness" limitness-like term: "none", "Ti_hom", "Ti_hom_up", "Ti_hom_down"
+    modiness_T_hom_ref_config                    = 5.0                              ! Reference Ti_hom for the modiness cold exponential style
+
+  ! == Basal hydrology
+  ! ==================
+
+    ! Basal hydrology
+    choice_basal_hydrology_model_config          = 'Martin2011'                     ! Choice of basal hydrology model: "saturated", "Martin2011"
+    Martin2011_hydro_Hb_min_config               = 0.0                              ! Martin et al. (2011) basal hydrology model: low-end  Hb  value of bedrock-dependent pore-water pressure
+    Martin2011_hydro_Hb_max_config               = 1000.0                           ! Martin et al. (2011) basal hydrology model: high-end Hb  value of bedrock-dependent pore-water pressure
+
+  ! == Bed roughness
+  ! ================
+
+    choice_bed_roughness_config                  = 'parameterised'                  ! Choice of source for friction coefficients: "uniform", "parameterised", "read_from_file"
+    choice_bed_roughness_parameterised_config    = 'MISMIPplus'                        ! "Martin2011", "SSA_icestream", "MISMIPplus", "BIVMIP_A", "BIVMIP_B", "BIVMIP_C"
+    ! Paths to files containing bed roughness fields for the chosen sliding law
+    filename_bed_roughness_NAM_config            = ''
+    filename_bed_roughness_EAS_config            = ''
+    filename_bed_roughness_GRL_config            = ''
+    filename_bed_roughness_ANT_config            = ''
+    ! Timeframes to read from the bed roughness file (set to 1E9    if the file has no time dimension)
+    timeframe_bed_roughness_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_bed_roughness_EAS_config           = 1E9
+    timeframe_bed_roughness_GRL_config           = 1E9
+    timeframe_bed_roughness_ANT_config           = 1E9
+    ! Values for uniform bed roughness
+    slid_Weertman_beta_sq_uniform_config         = 1.0E4                            ! Uniform value for beta_sq  in Weertman sliding law
+    slid_Coulomb_phi_fric_uniform_config         = 15.0                             ! Uniform value for phi_fric in Coulomb sliding law
+    slid_Budd_phi_fric_uniform_config            = 15.0                             ! Uniform value for phi_fric in Budd sliding law
+    slid_Tsai2015_alpha_sq_uniform_config        = 0.5                              ! Uniform value for alpha_sq in the Tsai2015 sliding law
+    slid_Tsai2015_beta_sq_uniform_config         = 1.0E4                            ! Uniform value for beta_sq  in the Tsai2015 sliding law
+    slid_Schoof2005_alpha_sq_uniform_config      = 0.5                              ! Uniform value for alpha_sq in the Schoof2005 sliding law
+    slid_Schoof2005_beta_sq_uniform_config       = 1.0E4                            ! Uniform value for beta_sq  in the Schoof2005 sliding law
+    slid_ZI_phi_fric_uniform_config              = 10.0                             ! Uniform value for phi_fric in the Zoet-Iverson sliding law
+    ! Parameters for bed roughness parameterisations
+    Martin2011till_phi_Hb_min_config             = -1000.0                          ! Martin et al. (2011) bed roughness parameterisation: low-end  Hb  value of bedrock-dependent till friction angle
+    Martin2011till_phi_Hb_max_config             = 0.0                              ! Martin et al. (2011) bed roughness parameterisation: high-end Hb  value of bedrock-dependent till friction angle
+    Martin2011till_phi_min_config                = 5.0                              ! Martin et al. (2011) bed roughness parameterisation: low-end  phi value of bedrock-dependent till friction angle
+    Martin2011till_phi_max_config                = 20.0                             ! Martin et al. (2011) bed roughness parameterisation: high-end phi value of bedrock-dependent till friction angle
+
+  ! == Bed roughness inversion by nudging
+  ! =====================================
+
+    ! General
+    do_bed_roughness_nudging_config              = .FALSE.                          !           Whether or not to nudge the basal roughness
+    choice_bed_roughness_nudging_method_config   = ''                               !           Choice of bed roughness nudging method
+    choice_inversion_target_geometry_config      = ''                               !           Which reference geometry to use as the target geometry (can be "init" or "PD")
+    bed_roughness_nudging_dt_config              = 5.0                              ! [yr]      Time step for bed roughness updates
+    bed_roughness_nudging_t_start_config         = -9.9E9                           ! [yr]      Earliest model time when nudging is allowed
+    bed_roughness_nudging_t_end_config           = +9.9E9                           ! [yr]      Latest   model time when nudging is allowed
+    generic_bed_roughness_min_config             = 0.1                              ! [?]       Smallest allowed value for the first  inverted bed roughness field
+    generic_bed_roughness_max_config             = 30.0                             ! [?]       Largest  allowed value for the first  inverted bed roughness field
+
+    ! Basal inversion model based on flowline-averaged values of H and dH/dt
+    bednudge_H_dHdt_flowline_t_scale_config      = 100.0                            ! [yr]      Timescale
+    bednudge_H_dHdt_flowline_dH0_config          = 100.0                            ! [m]       Ice thickness error scale
+    bednudge_H_dHdt_flowline_dHdt0_config        = 0.6                              ! [m yr^-1] Thinning rate scale
+    bednudge_H_dHdt_flowline_Hi_scale_config     = 300.0                            ! [m]       Ice thickness weight scale
+    bednudge_H_dHdt_flowline_u_scale_config      = 3000.0                           ! [m yr^-1] Ice velocity  weight scale
+    bednudge_H_dHdt_flowline_r_smooth_config     = 2500.0                           ! [m]       Radius for Gaussian filter used to smooth dC/dt as regularisation
+    bednudge_H_dHdt_flowline_w_smooth_config     = 0.5                              ! [-]       Relative contribution of smoothed dC/dt in regularisation
+
+  ! == Geothermal heat flux
+  ! =======================
+
+    choice_geothermal_heat_flux_config           = 'uniform'                        ! Choice of geothermal heat flux; can be 'uniform' or 'read_from_file'
+    uniform_geothermal_heat_flux_config          = 1.72E06                          ! Value when choice_geothermal_heat_flux == 'uniform' (1.72E06 J m^-2 yr^-1 according to Sclater et al. (1980))
+    filename_geothermal_heat_flux_config         = 'external/data/GHF/geothermal_heatflux_ShapiroRitzwoller2004_global_1x1_deg.nc'
+
+  ! == Thermodynamics
+  ! =================
+
+    ! Initial temperature profile
+    choice_initial_ice_temperature_NAM_config    = 'Robin'                          ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "read_from_file"
+    choice_initial_ice_temperature_EAS_config    = 'Robin'
+    choice_initial_ice_temperature_GRL_config    = 'Robin'
+    choice_initial_ice_temperature_ANT_config    = 'uniform'
+    ! Uniform initial ice temperature, if choice_initial_ice_temperature == 'uniform'
+    uniform_initial_ice_temperature_NAM_config   = 270.0                            ! Uniform ice temperature (applied when choice_initial_ice_temperature_config = "uniform")
+    uniform_initial_ice_temperature_EAS_config   = 270.0
+    uniform_initial_ice_temperature_GRL_config   = 270.0
+    uniform_initial_ice_temperature_ANT_config   = 270.0
+    ! Paths to files containing initial temperature fields, if
+    filename_initial_ice_temperature_NAM_config  = ''
+    filename_initial_ice_temperature_EAS_config  = ''
+    filename_initial_ice_temperature_GRL_config  = ''
+    filename_initial_ice_temperature_ANT_config  = ''
+    ! Timeframes to read from the bed roughness file (set to 1E9    if the file has no time dimension)
+    timeframe_initial_ice_temperature_NAM_config = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_initial_ice_temperature_EAS_config = 1E9
+    timeframe_initial_ice_temperature_GRL_config = 1E9
+    timeframe_initial_ice_temperature_ANT_config = 1E9
+    ! Thermodynamical model
+    choice_thermo_model_config                   = 'none'                           ! Choice of thermodynamical model: "none", "3D_heat_equation"
+    dt_thermodynamics_config                     = 1.0                              ! [yr] Time step for the thermodynamical model
+    Hi_min_thermo_config                         = 10.0                             ! [m]  Ice thinner than this is assumed to have a temperature equal to the annual mean surface temperature throughout the vertical column
+    choice_GL_temperature_BC_config              = 'grounded'                       ! Choice of basal boundary condition at grounding lines: 'grounded', 'subgrid', 'pmp'
+    choice_ice_heat_capacity_config              = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Pounder1965"
+    uniform_ice_heat_capacity_config             = 2009.0                           ! Uniform ice heat capacity (applied when choice_ice_heat_capacity_config = "uniform")
+    choice_ice_thermal_conductivity_config       = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Ritz1987"
+    uniform_ice_thermal_conductivity_config      = 6.626958E7                       ! Uniform ice thermal conductivity (applied when choice_ice_thermal_conductivity_config = "uniform")
+
+  ! == Rheology and flow law
+  ! =========================
+
+    ! Flow law
+    choice_flow_law_config                       = 'Glen'                           ! Choice of flow law, relating effective viscosity to effective strain rate
+    Glens_flow_law_exponent_config               = 3.0                              ! Exponent in Glen`s flow law
+    Glens_flow_law_epsilon_sq_0_config           = 1E-8                             ! Normalisation term so that zero strain rates produce a high but finite viscosity
+
+    ! Rheology
+    choice_ice_rheology_Glen_config              = 'uniform'                        ! Choice of ice rheology model for Glen`s flow law: "uniform", "Huybrechts1992", "MISMIP_mod"
+    uniform_Glens_flow_factor_config             = 1.4053906563768196E-017          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
+
+    ! Enhancement factors
+    choice_enhancement_factor_transition_config  = 'separate'                       ! Choice of treatment of enhancement factors at transition zones: "separate", "interp"
+    m_enh_sheet_config                           = 1.0                              ! Ice flow enhancement factor for grounded ice
+    m_enh_shelf_config                           = 1.0                              ! Ice flow enhancement factor for floating ice
+
+  ! == Climate
+  ! ==========
+
+    ! Time step
+    do_asynchronous_climate_config               = .TRUE.                           ! Whether or not the climate should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_climate_config                            = 10.0                             ! [yr] Time step for calculating climate
+
+    ! Choice of climate model
+    choice_climate_model_NAM_config              = 'none'
+    choice_climate_model_EAS_config              = 'none'
+    choice_climate_model_GRL_config              = 'none'
+    choice_climate_model_ANT_config              = 'none'
+
+    ! Choice of idealised climate model
+    choice_climate_model_idealised_config        = ''
+
+    ! Choice of realistic climate model
+    choice_climate_model_realistic_config        = ''
+
+    filename_climate_snapshot_NAM_config         = ''
+    filename_climate_snapshot_EAS_config         = ''
+    filename_climate_snapshot_GRL_config         = ''
+    filename_climate_snapshot_ANT_config         = ''
+
+  ! == Ocean
+  ! ========
+
+    ! Time step
+    do_asynchronous_ocean_config                 = .TRUE.                           ! Whether or not the ocean should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_ocean_config                              = 10.0                             ! [yr] Time step for calculating ocean
+
+    ! Vertical grid
+    ocean_vertical_grid_max_depth_config         = 1500.0                           ! Maximum depth of the ocean submodel
+    ocean_vertical_grid_dz_config                = 100.0                            ! Vertical distance between ocean layers
+
+    ! Choice of ocean model
+    choice_ocean_model_NAM_config                = 'none'
+    choice_ocean_model_EAS_config                = 'none'
+    choice_ocean_model_GRL_config                = 'none'
+    choice_ocean_model_ANT_config                = 'none'
+
+    ! Choice of idealised ocean model
+    choice_ocean_model_idealised_config          = ''
+
+    ! Choice of realistic ocean model
+    choice_ocean_model_realistic_config          = ''
+
+    filename_ocean_snapshot_NAM_config           = ''
+    filename_ocean_snapshot_EAS_config           = ''
+    filename_ocean_snapshot_GRL_config           = ''
+    filename_ocean_snapshot_ANT_config           = ''
+
+  ! == Surface mass balance
+  ! =======================
+
+    ! Time step
+    do_asynchronous_SMB_config                   = .TRUE.                           ! Whether or not the SMB should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_SMB_config                                = 10.0                             ! [yr] Time step for calculating SMB
+
+    ! Choice of SMB model
+    choice_SMB_model_NAM_config                  = 'uniform'
+    choice_SMB_model_EAS_config                  = 'uniform'
+    choice_SMB_model_GRL_config                  = 'uniform'
+    choice_SMB_model_ANT_config                  = 'idealised'
+
+    ! Choice of idealised SMB model
+    choice_SMB_model_idealised_config            = 'uniform'
+
+    ! Value to be used for uniform SMB (no regional variants, only used for idealised-geometry experiments)
+    uniform_SMB_config                           = 0.3
+
+    ! Prescribed SMB forcing
+    choice_SMB_prescribed_NAM_config             = ''
+    choice_SMB_prescribed_EAS_config             = ''
+    choice_SMB_prescribed_GRL_config             = ''
+    choice_SMB_prescribed_ANT_config             = ''
+
+    ! Files containing prescribed SMB forcing
+    filename_SMB_prescribed_NAM_config           = ''
+    filename_SMB_prescribed_EAS_config           = ''
+    filename_SMB_prescribed_GRL_config           = ''
+    filename_SMB_prescribed_ANT_config           = ''
+
+    ! Timeframes for reading prescribed SMB forcing from file (set to 1E9 if the file has no time dimension)
+    timeframe_SMB_prescribed_NAM_config          = 1E9
+    timeframe_SMB_prescribed_EAS_config          = 1E9
+    timeframe_SMB_prescribed_GRL_config          = 1E9
+    timeframe_SMB_prescribed_ANT_config          = 1E9
+
+  ! == Basal mass balance
+  ! =====================
+
+    ! Time step
+    do_asynchronous_BMB_config                   = .FALSE.                          ! Whether or not the BMB should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_BMB_config                                = 10.0                             ! [yr] Time step for calculating BMB
+
+    ! Grounding line treatment
+    choice_BMB_subgrid_config                    = 'NMP'                               ! Choice of sub-grid BMB scheme: "FCMP", "PMP" (following Leguy et al., 2021)
+
+    ! Choice of BMB model
+    choice_BMB_model_NAM_config                  = 'uniform'
+    choice_BMB_model_EAS_config                  = 'uniform'
+    choice_BMB_model_GRL_config                  = 'uniform'
+    choice_BMB_model_ANT_config                  = 'idealised'
+
+    ! Choice of idealised BMB model
+    choice_BMB_model_idealised_config            = 'MISMIP+'
+
+    ! Choice of parameterised BMB model
+    choice_BMB_model_parameterised_config        = 'Favier2019'
+
+    ! "uniform"
+    uniform_BMB_config                           = 0.0
+
+    ! "parameterised"
+    BMB_Favier2019_gamma_config                  = 99.32E-5
+
+  ! == Lateral mass balance
+  ! =======================
+
+    ! Time step
+    dt_LMB_config                                = 5.0                              ! [yr] Time step for calculating LMB [not implemented yet]
+
+    ! Choice of LMB model
+    choice_LMB_model_NAM_config                  = 'uniform'
+    choice_LMB_model_EAS_config                  = 'uniform'
+    choice_LMB_model_GRL_config                  = 'uniform'
+    choice_LMB_model_ANT_config                  = 'uniform'
+
+    ! "uniform"
+    uniform_LMB_config                           = 0.0
+
+  ! == Glacial isostatic adjustment
+  ! ===============================
+
+    ! General settings
+    choice_GIA_model_config                      = 'none'
+    dt_GIA_config                                = 100.0                            ! [yr] GIA model time step
+    dx_GIA_config                                = 2000.0                           ! [m]  GIA model square grid resolution
+
+  ! == Sea level
+  ! ============
+
+    choice_sealevel_model_config                 = 'fixed'                          !     Can be "fixed", "prescribed", "eustatic", or "SELEN"
+    fixed_sealevel_config                        = 0.0                              ! [m] Fixed sea level value for the "fixed" choice
+
+  ! == SELEN
+  ! ========
+
+    SELEN_run_at_t_start_config                  = .FALSE.                          ! Whether or not to run SELEN in the first coupling loop (needed for some benchmark experiments)
+    SELEN_n_TDOF_iterations_config               = 1                                ! Number of Time-Dependent Ocean Function iterations
+    SELEN_n_recursion_iterations_config          = 1                                ! Number of recursion iterations
+    SELEN_use_rotational_feedback_config         = .FALSE.                          ! If TRUE, rotational feedback is included
+    SELEN_n_harmonics_config                     = 128                              ! Maximum number of harmonic degrees
+    SELEN_display_progress_config                = .FALSE.                          ! Whether or not to display the progress of the big loops to the screen
+
+    SELEN_dir_config                             = 'external/data/SELEN'                     ! Directory where SELEN initial files and spherical harmonics are stored
+    SELEN_global_topo_filename_config            = 'SELEN_global_topography.nc'     ! Filename for the SELEN global topography file (located in SELEN_dir)
+    SELEN_TABOO_init_filename_config             = 'SELEN_TABOO_initial_file.dat'   ! Filename for the TABOO initial file           (idem                )
+    SELEN_LMJ_VALUES_filename_config             = 'SELEN_lmj_values.bin'           ! Filename for the LJ and MJ values file        (idem                )
+
+    SELEN_irreg_time_n_config                    = 15                               ! Number of entries in the irregular moving time window
+    SELEN_irreg_time_window_config               = 20.0  , 20.0  , 20.0  , 5.0  , 5.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 0.0  ,  0.0  ,  0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  ,  0.0  ,  0.0  ,  0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  ,  0.0  ,  0.0  , 0.0  , 0.0
+
+    SELEN_lith_thickness_config                  = 100.0                            ! Thickness of the elastic lithosphere [km]
+    SELEN_visc_n_config                          = 3                                ! Number      of viscous asthenosphere layers
+    SELEN_visc_prof_config                       = 3.0  , 0.6   , 0.3               ! Viscosities of viscous asthenosphere layers [?]
+
+    ! Settings for the TABOO Earth deformation model
+    SELEN_TABOO_CDE_config                       = 0                                !     code of the model (see taboo for explanation)
+    SELEN_TABOO_TLOVE_config                     = 1                                !     Tidal love numbers yes/no
+    SELEN_TABOO_DEG1_config                      = 1                                !     Tidal love numbers degree
+    SELEN_TABOO_RCMB_config                      = 3480.0                           ! [m] Radius of CMB
+
+  ! == Output
+  ! =========
+
+    ! Basic settings
+    do_create_netcdf_output_config               = .TRUE.                           !     Whether or not NetCDF output files should be created at all
+    dt_output_config                             = 1.0                              !     Time step for writing output
+    dt_output_restart_config                     = 30000.0                          !     Time step for writing restart output
+    dt_output_grid_config                        = 5000.0                           !     Time step for writing gridded output
+    dx_output_grid_NAM_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for North America
+    dx_output_grid_EAS_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for Eurasia
+    dx_output_grid_GRL_config                    = 20E3                             ! [m] Horizontal resolution for the square grid used for output for Greenland
+    dx_output_grid_ANT_config                    = 2e3                              ! [m] Horizontal resolution for the square grid used for output for Antarctica
+    dx_output_grid_ROI_NAM_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for North America
+    dx_output_grid_ROI_EAS_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Eurasia
+    dx_output_grid_ROI_GRL_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Greenland
+    dx_output_grid_ROI_ANT_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Antarctica
+
+    ! Transects
+    transects_NAM_config                         = ''                              ! List of transects to use for North America
+    transects_EAS_config                         = ''                              ! List of transects to use for Eurasia
+    transects_GRL_config                         = ''                              ! List of transects to use for Greenland
+    transects_ANT_config                         = 'westeast,dx=1e3'                              ! List of transects to use for Antarctica
+
+    ! Which data fields we want to write to the main NetCDF output files
+    choice_output_field_01_config                = 'mask'
+    choice_output_field_02_config                = 'Hi'
+    choice_output_field_03_config                = 'Hb'
+    choice_output_field_04_config                = 'Hs'
+    choice_output_field_05_config                = 'u_vav'
+    choice_output_field_06_config                = 'v_vav'
+    choice_output_field_07_config                = 'uabs_vav'
+    choice_output_field_08_config                = 'fraction_gr'
+    choice_output_field_09_config                = 'fraction_gr_b'
+    choice_output_field_10_config                = 'basal_friction_coefficient'
+    choice_output_field_11_config                = 'pc_truncation_error'
+    choice_output_field_12_config                = 'SMB'
+    choice_output_field_13_config                = 'dHi_dt'
+    choice_output_field_14_config                = 'divQ'
+    choice_output_field_15_config                = 'BMB'
+    choice_output_field_16_config                = 'R_shear'
+    choice_output_field_17_config                = 'grounding_line'
+    choice_output_field_18_config                = 'calving_front'
+    choice_output_field_19_config                = 'ice_margin'
+    choice_output_field_20_config                = 'coastline'
+    choice_output_field_21_config                = 'none'
+    choice_output_field_22_config                = 'none'
+    choice_output_field_23_config                = 'none'
+    choice_output_field_24_config                = 'none'
+    choice_output_field_25_config                = 'none'
+    choice_output_field_26_config                = 'none'
+    choice_output_field_27_config                = 'none'
+    choice_output_field_28_config                = 'none'
+    choice_output_field_29_config                = 'none'
+    choice_output_field_30_config                = 'none'
+    choice_output_field_31_config                = 'none'
+    choice_output_field_32_config                = 'none'
+    choice_output_field_33_config                = 'none'
+    choice_output_field_34_config                = 'none'
+    choice_output_field_35_config                = 'none'
+    choice_output_field_36_config                = 'none'
+    choice_output_field_37_config                = 'none'
+    choice_output_field_38_config                = 'none'
+    choice_output_field_39_config                = 'none'
+    choice_output_field_40_config                = 'none'
+    choice_output_field_41_config                = 'none'
+    choice_output_field_42_config                = 'none'
+    choice_output_field_43_config                = 'none'
+    choice_output_field_44_config                = 'none'
+    choice_output_field_45_config                = 'none'
+    choice_output_field_46_config                = 'none'
+    choice_output_field_47_config                = 'none'
+    choice_output_field_48_config                = 'none'
+    choice_output_field_49_config                = 'none'
+    choice_output_field_50_config                = 'none'
+
+/

--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_06_5km_iceocean1r.cfg
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/config_06_5km_iceocean1r.cfg
@@ -1,0 +1,865 @@
+&CONFIG
+
+  ! General model instructions
+  ! ==========================
+
+    ! Output directory
+    create_procedural_output_dir_config          = .FALSE.                          ! Automatically create an output directory with a procedural name (e.g. results_20210720_001/)
+    fixed_output_dir_config                      = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_iceocean1r'   ! If not, create a directory with this name instead (stops the program if this directory already exists)
+
+    ! Debugging
+    do_benchmarks_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
+    do_unit_tests_config                         = .FALSE.                          ! Whether or not to (only) perform the unit tests in the main_validation module
+    do_check_for_NaN_config                      = .FALSE.                          ! Whether or not fields should be checked for NaN values
+    do_time_display_config                       = .TRUE.                           ! Print current model time to screen
+
+  ! == Time of simulation
+  ! =====================
+
+    start_time_of_run_config                     = 0.0                              ! [yr] Start time of the simulation
+    end_time_of_run_config                       = 20.0                             ! [yr] End   time of the simulation
+
+  ! == Which model regions to simulate
+  ! ==================================
+
+    dt_coupling_config                           = 1000.0                           ! [yr] Interval of coupling between the different model regions
+    do_NAM_config                                = .FALSE.
+    do_EAS_config                                = .FALSE.
+    do_GRL_config                                = .FALSE.
+    do_ANT_config                                = .TRUE.
+
+  ! == The four model regions
+  ! =========================
+
+    ! North America
+    lambda_M_NAM_config                          = 265.0                            ! [degrees east]  [default: 265.0]   Longitude of the pole of the stereographic projection for the North America domain
+    phi_M_NAM_config                             =  62.0                            ! [degrees north] [default:  62.0]   Latitude  of the pole of the stereographic projection for the North America domain
+    beta_stereo_NAM_config                       =  71.0                            ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the North America domain
+    xmin_NAM_config                              = -3600000.0                       ! [m]             [default: -3600E3] Western  boundary     of the North America domain
+    xmax_NAM_config                              =  3600000.0                       ! [m]             [default:  3600E3] Eastern  boundary     of the North America domain
+    ymin_NAM_config                              = -2400000.0                       ! [m]             [default: -2400E3] Southern boundary     of the North America domain
+    ymax_NAM_config                              =  2400000.0                       ! [m]             [default:  2400E3] Northern boundary     of the North America domain
+
+    ! Eurasia
+    lambda_M_EAS_config                          = 40.0                             ! [degrees east]  [default:  40.0]   Longitude of the pole of the stereographic projection for the Eurasia domain
+    phi_M_EAS_config                             = 70.0                             ! [degrees north] [default:  70.0]   Latitude  of the pole of the stereographic projection for the Eurasia domain
+    beta_stereo_EAS_config                       = 71.0                             ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the Eurasia domain
+    xmin_EAS_config                              = -3400000.0                       ! [m]             [default: -3400E3] Western  boundary     of the Eurasia domain
+    xmax_EAS_config                              =  3400000.0                       ! [m]             [default:  3400E3] Eastern  boundary     of the Eurasia domain
+    ymin_EAS_config                              = -2080000.0                       ! [m]             [default: -2080E3] Southern boundary     of the Eurasia domain
+    ymax_EAS_config                              =  2080000.0                       ! [m]             [default:  2080E3] Northern boundary     of the Eurasia domain
+
+    ! Greenland
+    lambda_M_GRL_config                          = -45.0                            ! [degrees east]  [default: -45.0]   Longitude of the pole of the stereographic projection for the Greenland domain
+    phi_M_GRL_config                             = 90.0                             ! [degrees north] [default:  90.0]   Latitude  of the pole of the stereographic projection for the Greenland domain
+    beta_stereo_GRL_config                       = 70.0                             ! [degrees]       [default:  70.0]   Standard parallel     of the stereographic projection for the Greenland domain
+    xmin_GRL_config                              =  -720000.0                       ! [m]             [default:  -720E3] Western  boundary     of the Greenland domain [m]
+    xmax_GRL_config                              =   960000.0                       ! [m]             [default:   960E3] Eastern  boundary     of the Greenland domain [m]
+    ymin_GRL_config                              = -3450000.0                       ! [m]             [default: -3450E3] Southern boundary     of the Greenland domain [m]
+    ymax_GRL_config                              =  -570000.0                       ! [m]             [default:  -570E3] Northern boundary     of the Greenland domain [m]
+
+    ! Antarctica
+    lambda_M_ANT_config                          = 0.0                              ! [degrees east]  [default:   0.0]   Longitude of the pole of the stereographic projection for the Antarctica domain
+    phi_M_ANT_config                             = -90.0                            ! [degrees north] [default: -90.0]   Latitude  of the pole of the stereographic projection for the Antarctica domain
+    beta_stereo_ANT_config                       = 71.0                             ! [degrees]       [default:  71.0]   Standard parallel     of the stereographic projection for the Antarctica domain
+    xmin_ANT_config                              = 0.0                              ! [m]             [default: -3040E3] Western  boundary     of the Antarctica domain [m]
+    xmax_ANT_config                              = 800000.0                         ! [m]             [default:  3040E3] Eastern  boundary     of the Antarctica domain [m]
+    ymin_ANT_config                              = -40000.0                         ! [m]             [default: -3040E3] Southern boundary     of the Antarctica domain [m]
+    ymax_ANT_config                              =  40000.0                         ! [m]             [default:  3040E3] Northern boundary     of the Antarctica domain [m]
+
+  ! == Reference geometries (initial, present-day, and GIA equilibrium)
+  ! ===================================================================
+
+    ! Some pre-processing stuff for reference ice geometry
+    refgeo_Hi_min_config                         = 2.0                              ! [m]             [default: 2.0]     Remove ice thinner than this value in the reference ice geometry. Particularly useful for BedMachine Greenland, which somehow covers the entire tundra with half a meter of ice...
+    do_smooth_geometry_config                    = .FALSE                           ! Whether or not to smooth the reference bedrock
+    r_smooth_geometry_config                     = 0.5                              ! [m]             Geometry smoothing radius
+    remove_Lake_Vostok_config                    = .FALSE.                          ! Whether or not to replace subglacial Lake Vostok in Antarctica with ice (recommended to set to TRUE, otherwise it will really slow down your model for the first few hundred years...)
+
+    ! == Initial geometry
+    ! ===================
+
+    choice_refgeo_init_NAM_config                = 'read_from_file'                 ! Choice of initial geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_init_EAS_config                = 'read_from_file'                 ! Choice of initial geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_init_GRL_config                = 'read_from_file'                 ! Choice of initial geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_init_ANT_config                = 'read_from_file'                 ! Choice of initial geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_init == 'idealised'
+    choice_refgeo_init_idealised_config          = 'MISMIPplus'                        ! Choice of idealised initial geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_init_idealised_config              = 1000.0                           ! Resolution of square grid used for idealised initial geometry
+    ! Path to file containing initial geometry when choice_refgeo_init == 'read_from_file'
+    filename_refgeo_init_NAM_config              = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_init_EAS_config              = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_init_GRL_config              = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_init_ANT_config              = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/main_output_ANT_LAST.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_init_NAM_config             = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_init_EAS_config             = 1E9
+    timeframe_refgeo_init_GRL_config             = 1E9
+    timeframe_refgeo_init_ANT_config             = 5000.0
+
+    ! == Present-day geometry
+    ! =======================
+
+    choice_refgeo_PD_NAM_config                  = 'read_from_file'                 ! Choice of present-day geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_EAS_config                  = 'read_from_file'                 ! Choice of present-day geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_GRL_config                  = 'read_from_file'                 ! Choice of present-day geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_PD_ANT_config                  = 'read_from_file'                      ! Choice of present-day geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_PD == 'idealised'
+    choice_refgeo_PD_idealised_config            = 'MISMIPplus'                        ! Choice of idealised present-day geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_PD_idealised_config                = 1000.0                           ! Resolution of square grid used for idealised present-day geometry
+    ! Path to file containing present-day geometry when choice_refgeo_PD == 'read_from_file'
+    filename_refgeo_PD_NAM_config                = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_PD_EAS_config                = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_PD_GRL_config                = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_PD_ANT_config              = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/main_output_ANT_LAST.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_PD_NAM_config               = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_PD_EAS_config               = 1E9
+    timeframe_refgeo_PD_GRL_config               = 1E9
+    timeframe_refgeo_PD_ANT_config               = 5000.0
+
+    ! == GIA equilibrium geometry
+    ! ===========================
+
+    choice_refgeo_GIAeq_NAM_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for North America; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_EAS_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for Eurasia      ; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_GRL_config               = 'read_from_file'                 ! Choice of GIA equilibrium reference geometry for Greenland    ; can be "idealised", or "read_from_file"
+    choice_refgeo_GIAeq_ANT_config               = 'idealised'                      ! Choice of GIA equilibrium reference geometry for Antarctica   ; can be "idealised", or "read_from_file"
+    ! Idealised geometry when choice_refgeo_GIAeq == 'idealised'
+    choice_refgeo_GIAeq_idealised_config         = 'MISMIPplus'                        ! Choice of idealised GIA equilibrium reference geometry; see reference_geometries/calc_idealised_geometry for options
+    dx_refgeo_GIAeq_idealised_config             = 1000.0                           ! Resolution of square grid used for idealised GIA equilibrium reference geometry
+    ! Path to file containing GIA equilibrium reference geometry when choice_refgeo_GIAeq == 'read_from_file'
+    filename_refgeo_GIAeq_NAM_config             = 'external/data/ETOPO1/NorthAmerica_ETOPO1_5km.nc'
+    filename_refgeo_GIAeq_EAS_config             = 'external/data/ETOPO1/Eurasia_ETOPO1_5km.nc'
+    filename_refgeo_GIAeq_GRL_config             = 'external/data/Bedmachine_Greenland/BedMachine_Greenland_v4_5km.nc'
+    filename_refgeo_GIAeq_ANT_config             = 'external/data/Bedmachine_Antarctica/Bedmachine_v1_Antarctica_5km.nc'
+    ! Timeframe to read from the geometry file (set to 1E9    if the file has no time dimension)
+    timeframe_refgeo_GIAeq_NAM_config            = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_refgeo_GIAeq_EAS_config            = 1E9
+    timeframe_refgeo_GIAeq_GRL_config            = 1E9
+    timeframe_refgeo_GIAeq_ANT_config            = 1E9
+
+    ! == Parameters for idealised geometries
+    ! ======================================
+
+    refgeo_idealised_slabonaslope_Hi_config      = 0.0                              ! Suggested value: 2000 m
+    refgeo_idealised_slabonaslope_dhdx_config    = 1.0                              ! Suggested value: -0.001
+    refgeo_idealised_Halfar_H0_config            = 0.0                              ! Suggested value: 3000 m
+    refgeo_idealised_Halfar_R0_config            = 0.0                              ! Suggested value: 500E3 m
+    refgeo_idealised_Bueler_H0_config            = 0.0                              ! Suggested value: 3000 m
+    refgeo_idealised_Bueler_R0_config            = 0.0                              ! Suggested value: 500E3 m
+    refgeo_idealised_Bueler_lambda_config        = 0.0                              ! Suggested value: 5.0
+    refgeo_idealised_SSA_icestream_Hi_config     = -1.0                             ! Suggested value: 2000 m
+    refgeo_idealised_SSA_icestream_dhdx_config   = 1.0                              ! Suggested value: -0.0003
+    refgeo_idealised_SSA_icestream_L_config      = 0.0                              ! Suggested value: 150 km
+    refgeo_idealised_SSA_icestream_m_config      = 0.0                              ! Suggested value: 1.0
+    refgeo_idealised_MISMIP_mod_Hi_init_config   = -1.0                             ! Suggested value: 100 m
+    refgeo_idealised_ISMIP_HOM_L_config          = 0.0                              ! Suggested value: 5E3 - 160E3 m
+    refgeo_idealised_MISMIPplus_Hi_init_config   = 100.0                            ! Suggested value: 100 m
+    refgeo_idealised_MISMIPplus_tune_A_config    = .FALSE.                          ! If so, the uniform flow factor A is tuned to achieve a steady-state mid-stream grounding-line position at x = 450 km
+
+  ! == Mesh generation
+  ! ==================
+
+    ! How to set up the initial mesh
+    choice_initial_mesh_NAM_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_EAS_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_GRL_config               = 'calc_from_initial_geometry'     ! Options: 'calc_from_initial_geometry', 'read_from_file'
+    choice_initial_mesh_ANT_config               = 'read_from_file'                 ! Options: 'calc_from_initial_geometry', 'read_from_file'
+
+    ! Paths to files containing initial meshes, if choice_initial_mesh == 'read_from_file'
+    filename_initial_mesh_NAM_config             = ''
+    filename_initial_mesh_EAS_config             = ''
+    filename_initial_mesh_GRL_config             = ''
+    filename_initial_mesh_ANT_config             = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/main_output_ANT_LAST.nc'
+
+    ! Resolutions for different parts of the ice sheet
+    maximum_resolution_uniform_config            = 10e3                             ! [m]          Maximum resolution for the entire domain
+    maximum_resolution_grounded_ice_config       = 8e3                              ! [m]          Maximum resolution for grounded ice
+    maximum_resolution_floating_ice_config       = 5e3                              ! [m]          Maximum resolution for floating ice
+    maximum_resolution_grounding_line_config     = 5e3                              ! [m]          Maximum resolution for the grounding line
+    maximum_resolution_calving_front_config      = 5e3                              ! [m]          Maximum resolution for the calving front
+    maximum_resolution_ice_front_config          = 20e3                             ! [m]          Maximum resolution for the ice front
+    maximum_resolution_coastline_config          = 1000e3                           ! [m]          Maximum resolution for the coastline
+
+    ! Widths for each resolution band
+    grounding_line_width_config                  = 2.5e3                            ! [m]          Width of the band around the grounding line that should get this resolution
+    calving_front_width_config                   = 2.5e3                            ! [m]          Width of the band around the calving front that should get this resolution
+    maximum_resolution_ice_front_config          = 20e3                             ! [m]          Maximum resolution for the ice front
+    ice_front_width_config                       = 10e3                             ! [m]          Width of the band around the ice front that should get this resolution
+    coastline_width_config                       = 1000e3                           ! [m]          Width of the band around the coastline that should get this resolution
+
+    ! Regions of interest
+    choice_regions_of_interest_config            = ''                               ! Regions of interest where other (higher) resolutions apply. Separated by double vertical bars "||", e.g. "PineIsland||Thwaites"
+    ROI_maximum_resolution_uniform_config        = 100e3                            ! [m]          Maximum resolution for the entire domain
+    ROI_maximum_resolution_grounded_ice_config   = 50e3                             ! [m]          Maximum resolution for grounded ice
+    ROI_maximum_resolution_floating_ice_config   = 20e3                             ! [m]          Maximum resolution for floating ice
+    ROI_maximum_resolution_grounding_line_config = 5e3                              ! [m]          Maximum resolution for the grounding line
+    ROI_maximum_resolution_calving_front_config  = 10e3                             ! [m]          Maximum resolution for the calving front
+    ROI_maximum_resolution_ice_front_config      = 20e3                             ! [m]          Maximum resolution for the ice front
+    ROI_maximum_resolution_coastline_config      = 50e3                             ! [m]          Maximum resolution for the coastline
+
+    ! Widths for each resolution band
+    ROI_grounding_line_width_config              = 2e3                              ! [m]          Width of the band around the grounding line that should get this resolution
+    ROI_calving_front_width_config               = 10e3                             ! [m]          Width of the band around the calving front that should get this resolution
+    ROI_ice_front_width_config                   = 20e3                             ! [m]          Width of the band around the ice front that should get this resolution
+    ROI_coastline_width_config                   = 50e3                             ! [m]          Width of the band around the coastline that should get this resolution
+
+    ! Mesh update settings
+    allow_mesh_updates_config                    = .TRUE.                           ! [-]          Whether or not mesh updates are allowed
+    dt_mesh_update_min_config                    = 10.0                             ! [yr]         Minimum amount of time between mesh updates
+    minimum_mesh_fitness_coefficient_config      = 0.99                             ! [-]          If the mesh fitness drops below this threshold, trigger a mesh update
+    do_out_of_time_calving_front_relax_config    = .TRUE.                           !              Whether or not to step out of time and relax the calving front for a few iterations after a mesh update
+
+    ! Advanced geometry parameters
+    do_singlecore_mesh_creation_config           = .TRUE.                           !              Whether or not to use only a single core for mesh generation (for better reproducibility)
+    alpha_min_config                             = 0.4363                           ! [radians]    Smallest allowed internal triangle angle (recommended value: 25 degrees = 0.4363)
+    nit_Lloyds_algorithm_config                  = 3                                ! [-]          Number of iterations of Lloyds algorithm to be applied after refinement
+    mesh_resolution_tolerance_config             = 1.25                             ! [-]          Factors the target resolution for trangle-size requirement. 1=strict, use >1 to avoid unnecesarily high resolution
+
+    ! Square grid used for smoothing
+    dx_square_grid_smooth_NAM_config             = 2000.0
+    dx_square_grid_smooth_EAS_config             = 2000.0
+    dx_square_grid_smooth_GRL_config             = 2000.0
+    dx_square_grid_smooth_ANT_config             = 2000.0
+
+  ! == The scaled vertical coordinate zeta
+  ! ======================================
+
+    choice_zeta_grid_config                      = 'regular'                        ! The type of vertical grid to use; can be "regular", "irregular_log", "old_15_layer_zeta"
+    nz_config                                    = 12                               ! The number of vertical layers to use
+    zeta_irregular_log_R_config                  = 10.0                             ! Ratio between surface and base layer spacings
+
+  ! == Ice dynamics - velocity
+  ! ==========================
+
+    ! General
+    choice_stress_balance_approximation_config   = 'DIVA'                           ! Choice of stress balance approximation: "none" (= no flow, though geometry can still change due to mass balance), "SIA", "SSA", "SIA/SSA", "DIVA", "BPA"
+    choice_hybrid_SIASSA_scheme_config           = 'add'                            ! Choice of scheme for combining SIA and SSA velocities in the hybrid approach
+    do_include_SSADIVA_crossterms_config         = .TRUE.                           ! Whether or not to include the gradients of the effective viscosity (the "cross-terms") in the solution of the SSA/DIVA
+
+    ! Hybrid DIVA/BPA
+    choice_hybrid_DIVA_BPA_mask_NAM_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for North America
+    choice_hybrid_DIVA_BPA_mask_EAS_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Eurasia
+    choice_hybrid_DIVA_BPA_mask_GRL_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Greenland
+    choice_hybrid_DIVA_BPA_mask_ANT_config       = ''                               ! How to determine where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Antarctica
+
+    filename_hybrid_DIVA_BPA_mask_NAM_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for North America
+    filename_hybrid_DIVA_BPA_mask_EAS_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Eurasia
+    filename_hybrid_DIVA_BPA_mask_GRL_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Greenland
+    filename_hybrid_DIVA_BPA_mask_ANT_config     = ''                               ! Path to a file containing a mask that describes where to solve the DIVA and where the BPA in the hybrid DIVA/BPA for Antarctica
+
+    ! Initialisation
+    choice_initial_velocity_NAM_config           = 'zero'                           ! Can be 'zero', 'read_from_file'
+    choice_initial_velocity_EAS_config           = 'zero'
+    choice_initial_velocity_GRL_config           = 'zero'
+    choice_initial_velocity_ANT_config           = 'read_from_file'
+    ! Paths to files containing initial velocity fields
+    filename_initial_velocity_NAM_config         = ''
+    filename_initial_velocity_EAS_config         = ''
+    filename_initial_velocity_GRL_config         = ''
+    filename_initial_velocity_ANT_config         = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/restart_ice_velocity_DIVA_LAST.nc'
+    ! Timeframes to read from the initial velocity files (set to 1E9    if the file has no time dimension)
+    timeframe_initial_velocity_NAM_config        = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_initial_velocity_EAS_config        = 1E9
+    timeframe_initial_velocity_GRL_config        = 1E9
+    timeframe_initial_velocity_ANT_config        = 1e9
+
+    ! Some parameters for numerically solving the stress balance
+    SIA_maximum_diffusivity_config               = 1E5                              ! Limit the diffusivity in the SIA to this value
+    visc_it_norm_dUV_tol_config                  = 5E-5                             ! Stop criterion for the viscosity iteration: the L2-norm of successive velocity solutions should be smaller than this number
+    visc_it_nit_config                           = 50                               ! Maximum number of effective viscosity iterations
+    visc_it_relax_config                         = 0.2                              ! Relaxation parameter for subsequent viscosity iterations (for improved stability)
+    visc_eff_min_config                          = 1E4                              ! Minimum value for effective viscosity
+    vel_max_config                               = 5000.0                           ! Velocities are limited to this value
+    stress_balance_PETSc_rtol_config             = 1E-7                             ! PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
+    stress_balance_PETSc_abstol_config           = 1E-5                             ! PETSc solver - stop criterion, absolute difference
+
+    ! Boundary conditions
+    BC_u_west_config                             = 'zero'                           ! Boundary conditions for the ice velocity field at the domain border
+    BC_u_east_config                             = 'infinite'                       ! Allowed choices: "infinite", "zero", "periodic_ISMIP-HOM"
+    BC_u_south_config                            = 'infinite'
+    BC_u_north_config                            = 'infinite'
+    BC_v_west_config                             = 'zero'
+    BC_v_east_config                             = 'zero'
+    BC_v_south_config                            = 'zero'
+    BC_v_north_config                            = 'zero'
+
+  ! == Ice dynamics - sliding
+  ! =========================
+
+    ! General
+    choice_sliding_law_config                    = 'Schoof2005'                     ! Choice of sliding law: "no_sliding", "idealised", "Coulomb", "Budd", "Weertman", "Tsai2015", "Schoof2005", "Zoet-Iverson"
+    choice_idealised_sliding_law_config          = ''                               ! "ISMIP_HOM_C", "ISMIP_HOM_D", "ISMIP_HOM_E", "ISMIP_HOM_F"
+
+    ! Parameters for different sliding laws
+    slid_Weertman_m_config                       = 3.0                              ! Exponent in Weertman sliding law
+    slid_Budd_q_plastic_config                   = 0.3                              ! Scaling exponent in Budd sliding law
+    slid_Budd_u_threshold_config                 = 100.0                            ! Threshold velocity in Budd sliding law
+    slid_ZI_p_config                             = 5.0                              ! Velocity exponent used in the Zoet-Iverson sliding law
+    slid_ZI_ut_config                            = 200.0                            ! (uniform) transition velocity used in the Zoet-Iverson sliding law [m/yr]
+
+    ! Sub-grid scaling of basal friction
+    do_GL_subgrid_friction_config                = .TRUE.                           ! Whether or not to scale basal friction with the sub-grid grounded fraction (needed to get proper GL migration; only turn this off for showing the effect on the MISMIP_mod results!)
+    choice_subgrid_grounded_fraction_config      = 'bilin_interp_TAF'                    ! Choice of scheme to calculate the sub-grid grounded fractions: 'trilin', 'bedrock_CDF'
+    do_read_bedrock_cdf_from_file_config         = .FALSE.                          ! Whether or not to read the bedrock CDF from the initial mesh file. Requires choice_initial_mesh_XXX_config =  'read_from_file'!
+    subgrid_bedrock_cdf_nbins_config             = 11                               ! Number of bins to be used for sub-grid bedrock cumulative density functions
+    do_subgrid_friction_on_A_grid_config         = .FALSE.                          ! Whether or not to apply a preliminary scaling to basal hydrology and bed roughness on the A grid, before the final scaling of beta on the b grid. The exponent of this scaling is computed based on ice thickness.
+    subgrid_friction_exponent_on_B_grid_config   = 2.0                              ! Exponent to which f_grnd should be raised before being used to scale beta
+
+    ! Stability
+    slid_beta_max_config                         = 1E20                             ! Maximum value for basal friction coefficient
+    slid_delta_v_config                          = 1.0E-3                           ! Normalisation parameter to prevent errors when velocity is zero
+
+  ! == Ice dynamics - ice thickness calculation
+  ! ===========================================
+
+    ! Calculation of dH/dt
+    choice_ice_integration_method_config         = 'semi-implicit'                  ! Choice of ice thickness integration scheme: "none" (i.e. unchanging geometry), "explicit", "semi-implicit"
+    dHi_semiimplicit_fs_config                   = 1.5                              ! Factor for the semi-implicit ice thickness solver (0 = explicit, 0<f<1 = semi-implicit, 1 = implicit, >1 = over-implicit)
+    dHi_PETSc_rtol_config                        = 1E-8                             ! dHi PETSc solver - stop criterion, relative difference (iteration stops if rtol OR abstol is reached)
+    dHi_PETSc_abstol_config                      = 1E-6                             ! dHi PETSc solver - stop criterion, absolute difference
+
+    ! Boundary conditions
+    BC_H_west_config                             = 'infinite'                       ! Boundary conditions for ice thickness at the domain boundary
+    BC_H_east_config                             = 'zero'                           ! Allowed choices:  "infinite", "zero", "ISMIP_HOM_F"
+    BC_H_south_config                            = 'infinite'
+    BC_H_north_config                            = 'infinite'
+
+  ! == Ice dynamics - target quantities
+  ! ===================================
+
+    ! Target dHi_dt
+    do_target_dHi_dt_config                      = .FALSE.                          ! Whether or not to use a target dHi_dt field from an external file to alter the modelled one
+    do_limit_target_dHi_dt_to_SMB_config         = .TRUE.                           ! Whether or not to limit a target dHi_dt field to available SMB in that area, so it does not melt all ice there
+    target_dHi_dt_t_end_config                   = 9.9e9                            ! End time of target dHi_dt application
+
+    ! Files containing a target dHi_dt for inversions
+    filename_dHi_dt_target_NAM_config            = ''
+    filename_dHi_dt_target_EAS_config            = ''
+    filename_dHi_dt_target_GRL_config            = ''
+    filename_dHi_dt_target_ANT_config            = ''
+
+    ! Timeframes for reading target dHi_dt from file (set to 1E9_dp if the file has no time dimension)
+    timeframe_dHi_dt_target_NAM_config           = 1E9
+    timeframe_dHi_dt_target_EAS_config           = 1E9
+    timeframe_dHi_dt_target_GRL_config           = 1E9
+    timeframe_dHi_dt_target_ANT_config           = 1E9
+
+  ! == Ice dynamics - time stepping
+  ! ===============================
+
+    ! Time stepping
+    choice_timestepping_config                   = 'pc'                             ! Choice of timestepping method: "direct", "pc" (NOTE: 'direct' does not work with DIVA ice dynamcis!)
+    dt_ice_max_config                            = 0.125                             ! [yr] Maximum time step of the ice dynamics model
+    dt_ice_min_config                            = 0.01                              ! [yr] Minimum time step of the ice dynamics model
+    dt_ice_startup_phase_config                  = 0.0                              ! [yr] Length of time window after start_time and before end_time when dt = dt_min, to ensure smooth restarts
+    do_grounded_only_adv_dt_config               = .FALSE.                          ! If .TRUE., only grounded ice is used in the computation of the advective time step limit (CFL condition)
+
+    ! Predictor-corrector ice-thickness update
+    pc_epsilon_config                            = 0.5                            ! Target truncation error in dHi_dt [m/yr] (epsilon in Robinson et al., 2020, Eq. 33)
+    pc_k_I_config                                = 0.2                              ! Exponent k_I in  Robinson et al., 2020, Eq. 33
+    pc_k_p_config                                = 0.2                              ! Exponent k_p in  Robinson et al., 2020, Eq. 33
+    pc_eta_min_config                            = 1E-8                             ! Normalisation term in estimation of the truncation error (Robinson et al., Eq. 32)
+    pc_max_time_step_increase_config             = 1.1                              ! Each new time step is only allowed to be this much larger than the previous one
+    pc_nit_max_config                            = 50                               ! Maximum number of times a PC timestep can be repeated with reduced dt
+    pc_guilty_max_config                         = 0.0                              ! [%] Maximum percentage of grounded vertices allowed to have a truncation error larger than the tolerance pc_epsilon
+
+    ! Initialisation of the predictor-corrector ice-thickness update
+    pc_choice_initialise_NAM_config              = 'zero'                           ! How to initialise the p/c scheme: 'zero', 'read_from_file'
+    pc_choice_initialise_EAS_config              = 'zero'
+    pc_choice_initialise_GRL_config              = 'zero'
+    pc_choice_initialise_ANT_config              = 'read_from_file'
+    ! Paths to files containing initial fields & values for the p/c scheme
+    filename_pc_initialise_NAM_config            = ''
+    filename_pc_initialise_EAS_config            = ''
+    filename_pc_initialise_GRL_config            = ''
+    filename_pc_initialise_ANT_config            = 'automated_testing/integrated_tests/idealised/MISMIPplus/results_5km_spinup/restart_pc_scheme_LAST.nc'
+    ! Timeframes to read from the p/c scheme initial file (set to 1E9    if the file has no time dimension)
+    timeframe_pc_initialise_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_pc_initialise_EAS_config           = 1E9
+    timeframe_pc_initialise_GRL_config           = 1E9
+    timeframe_pc_initialise_ANT_config           = 1e9
+
+  ! == Ice dynamics - calving
+  ! =========================
+
+    choice_calving_law_config                    = 'none'                           ! Choice of calving law: "none", "threshold_thickness"
+    calving_threshold_thickness_shelf_config     = 100.0                            ! Threshold ice thickness for ice shelf calving front in the "threshold_thickness" calving law
+    calving_threshold_thickness_sheet_config     = 0.0                              ! Threshold ice thickness for ice sheet calving front in the "threshold_thickness" calving law
+    max_calving_rounds_config                    = 20                               ! Maximum number of calving loops during chain reaction
+    do_remove_shelves_config                     = .FALSE.                          ! If set to TRUE, all floating ice is always instantly removed (used in the ABUMIP-ABUK experiment)
+    remove_shelves_larger_than_PD_config         = .FALSE.                          ! If set to TRUE, all floating ice beyond the present-day calving front is removed (used for some Antarctic spin-ups)
+    continental_shelf_calving_config             = .FALSE.                          ! If set to TRUE, all ice beyond the continental shelf edge (set by a maximum depth) is removed
+    continental_shelf_min_height_config          = -2000.0                          ! Maximum depth of the continental shelf
+
+  ! == Ice dynamics - stabilisation
+  ! ===============================
+
+    choice_mask_noice_config                     = 'MISMIP+'                        ! Choice of mask_noice configuration
+    Hi_min_config                                = 0.0                              ! [m] Minimum ice thickness: thinner ice gets temporarily added to the no-ice mask and eventually removed
+    Hi_thin_config                               = 0.0                              ! [m] Thin-ice thickness threshold: thinner ice is considered dynamically unreliable (e.g. over steep slopes)
+    remove_ice_absent_at_PD_config               = .FALSE.                          ! If set to TRUE, all ice not present in PD data is always instantly removed
+
+    ! Geometry relaxation
+    geometry_relaxation_t_years_config           = 0.0                              ! [yr] Amount of years (out-of-time) during which the geometry will relaxed during initialisation: no mass balance, thickness alterations, inversions, or target thinning rates will be applied during this time
+
+    ! Mask conservation
+    do_protect_grounded_mask_config              = .FALSE.                          ! If set to TRUE, grounded ice will not be allowed to cross the floatation threshold and will stay minimally grounded.
+    protect_grounded_mask_t_end_config           = 20000.0                          ! End time of grounded mask protection. After this time, it will be allowed to thin and become afloat
+
+    ! Fix/delay ice thickness evolution
+    do_fixiness_before_start_config              = .TRUE.                           ! Whether or not to apply fixiness values before fixiness_t_start
+    fixiness_t_start_config                      = -9.9E9                           ! Start time of linear transition between fixed/delayed and free evolution
+    fixiness_t_end_config                        = -8.8E8                           ! End   time of linear transition between fixed/delayed and free evolution
+    fixiness_H_gl_gr_config                      = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_gl_fl_config                      = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_grounded_config                   = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_floating_config                   = 0.0                              ! Fix (1), release (0), or delay grounded ice geometry evolution
+    fixiness_H_freeland_config                   = .FALSE.                          ! Fix (.TRUE.) ice-free vertices between fixiness_t_start and fixiness_t_end
+    fixiness_H_freeocean_config                  = .FALSE.                          ! Fix (.TRUE.) ice-free vertices between fixiness_t_start and fixiness_t_end
+
+    ! Limit ice thickness evolution
+    do_limitness_before_start_config             = .TRUE.                           ! Whether or not to apply limitness values before limitness_t_start
+    limitness_t_start_config                     = -9.9E9                           ! Start time of linear transition between limited and free evolution
+    limitness_t_end_config                       = -8.8E8                           ! End   time of linear transition between limited and free evolution
+    limitness_H_gl_gr_config                     = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_gl_fl_config                     = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_grounded_config                  = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    limitness_H_floating_config                  = +9.9E9                           ! Maximum departure from PD ice thickness allowed at peak limitness
+    modiness_H_style_config                      = 'none'                           ! Dynamic "modiness" limitness-like term: "none", "Ti_hom", "Ti_hom_up", "Ti_hom_down"
+    modiness_T_hom_ref_config                    = 5.0                              ! Reference Ti_hom for the modiness cold exponential style
+
+  ! == Basal hydrology
+  ! ==================
+
+    ! Basal hydrology
+    choice_basal_hydrology_model_config          = 'Martin2011'                     ! Choice of basal hydrology model: "saturated", "Martin2011"
+    Martin2011_hydro_Hb_min_config               = 0.0                              ! Martin et al. (2011) basal hydrology model: low-end  Hb  value of bedrock-dependent pore-water pressure
+    Martin2011_hydro_Hb_max_config               = 1000.0                           ! Martin et al. (2011) basal hydrology model: high-end Hb  value of bedrock-dependent pore-water pressure
+
+  ! == Bed roughness
+  ! ================
+
+    choice_bed_roughness_config                  = 'parameterised'                  ! Choice of source for friction coefficients: "uniform", "parameterised", "read_from_file"
+    choice_bed_roughness_parameterised_config    = 'MISMIPplus'                        ! "Martin2011", "SSA_icestream", "MISMIPplus", "BIVMIP_A", "BIVMIP_B", "BIVMIP_C"
+    ! Paths to files containing bed roughness fields for the chosen sliding law
+    filename_bed_roughness_NAM_config            = ''
+    filename_bed_roughness_EAS_config            = ''
+    filename_bed_roughness_GRL_config            = ''
+    filename_bed_roughness_ANT_config            = ''
+    ! Timeframes to read from the bed roughness file (set to 1E9    if the file has no time dimension)
+    timeframe_bed_roughness_NAM_config           = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_bed_roughness_EAS_config           = 1E9
+    timeframe_bed_roughness_GRL_config           = 1E9
+    timeframe_bed_roughness_ANT_config           = 1E9
+    ! Values for uniform bed roughness
+    slid_Weertman_beta_sq_uniform_config         = 1.0E4                            ! Uniform value for beta_sq  in Weertman sliding law
+    slid_Coulomb_phi_fric_uniform_config         = 15.0                             ! Uniform value for phi_fric in Coulomb sliding law
+    slid_Budd_phi_fric_uniform_config            = 15.0                             ! Uniform value for phi_fric in Budd sliding law
+    slid_Tsai2015_alpha_sq_uniform_config        = 0.5                              ! Uniform value for alpha_sq in the Tsai2015 sliding law
+    slid_Tsai2015_beta_sq_uniform_config         = 1.0E4                            ! Uniform value for beta_sq  in the Tsai2015 sliding law
+    slid_Schoof2005_alpha_sq_uniform_config      = 0.5                              ! Uniform value for alpha_sq in the Schoof2005 sliding law
+    slid_Schoof2005_beta_sq_uniform_config       = 1.0E4                            ! Uniform value for beta_sq  in the Schoof2005 sliding law
+    slid_ZI_phi_fric_uniform_config              = 10.0                             ! Uniform value for phi_fric in the Zoet-Iverson sliding law
+    ! Parameters for bed roughness parameterisations
+    Martin2011till_phi_Hb_min_config             = -1000.0                          ! Martin et al. (2011) bed roughness parameterisation: low-end  Hb  value of bedrock-dependent till friction angle
+    Martin2011till_phi_Hb_max_config             = 0.0                              ! Martin et al. (2011) bed roughness parameterisation: high-end Hb  value of bedrock-dependent till friction angle
+    Martin2011till_phi_min_config                = 5.0                              ! Martin et al. (2011) bed roughness parameterisation: low-end  phi value of bedrock-dependent till friction angle
+    Martin2011till_phi_max_config                = 20.0                             ! Martin et al. (2011) bed roughness parameterisation: high-end phi value of bedrock-dependent till friction angle
+
+  ! == Bed roughness inversion by nudging
+  ! =====================================
+
+    ! General
+    do_bed_roughness_nudging_config              = .FALSE.                          !           Whether or not to nudge the basal roughness
+    choice_bed_roughness_nudging_method_config   = ''                               !           Choice of bed roughness nudging method
+    choice_inversion_target_geometry_config      = ''                               !           Which reference geometry to use as the target geometry (can be "init" or "PD")
+    bed_roughness_nudging_dt_config              = 5.0                              ! [yr]      Time step for bed roughness updates
+    bed_roughness_nudging_t_start_config         = -9.9E9                           ! [yr]      Earliest model time when nudging is allowed
+    bed_roughness_nudging_t_end_config           = +9.9E9                           ! [yr]      Latest   model time when nudging is allowed
+    generic_bed_roughness_min_config             = 0.1                              ! [?]       Smallest allowed value for the first  inverted bed roughness field
+    generic_bed_roughness_max_config             = 30.0                             ! [?]       Largest  allowed value for the first  inverted bed roughness field
+
+    ! Basal inversion model based on flowline-averaged values of H and dH/dt
+    bednudge_H_dHdt_flowline_t_scale_config      = 100.0                            ! [yr]      Timescale
+    bednudge_H_dHdt_flowline_dH0_config          = 100.0                            ! [m]       Ice thickness error scale
+    bednudge_H_dHdt_flowline_dHdt0_config        = 0.6                              ! [m yr^-1] Thinning rate scale
+    bednudge_H_dHdt_flowline_Hi_scale_config     = 300.0                            ! [m]       Ice thickness weight scale
+    bednudge_H_dHdt_flowline_u_scale_config      = 3000.0                           ! [m yr^-1] Ice velocity  weight scale
+    bednudge_H_dHdt_flowline_r_smooth_config     = 2500.0                           ! [m]       Radius for Gaussian filter used to smooth dC/dt as regularisation
+    bednudge_H_dHdt_flowline_w_smooth_config     = 0.5                              ! [-]       Relative contribution of smoothed dC/dt in regularisation
+
+  ! == Geothermal heat flux
+  ! =======================
+
+    choice_geothermal_heat_flux_config           = 'uniform'                        ! Choice of geothermal heat flux; can be 'uniform' or 'read_from_file'
+    uniform_geothermal_heat_flux_config          = 1.72E06                          ! Value when choice_geothermal_heat_flux == 'uniform' (1.72E06 J m^-2 yr^-1 according to Sclater et al. (1980))
+    filename_geothermal_heat_flux_config         = 'external/data/GHF/geothermal_heatflux_ShapiroRitzwoller2004_global_1x1_deg.nc'
+
+  ! == Thermodynamics
+  ! =================
+
+    ! Initial temperature profile
+    choice_initial_ice_temperature_NAM_config    = 'Robin'                          ! Choice of initial ice temperature profile: "uniform", "linear", "Robin", "read_from_file"
+    choice_initial_ice_temperature_EAS_config    = 'Robin'
+    choice_initial_ice_temperature_GRL_config    = 'Robin'
+    choice_initial_ice_temperature_ANT_config    = 'uniform'
+    ! Uniform initial ice temperature, if choice_initial_ice_temperature == 'uniform'
+    uniform_initial_ice_temperature_NAM_config   = 270.0                            ! Uniform ice temperature (applied when choice_initial_ice_temperature_config = "uniform")
+    uniform_initial_ice_temperature_EAS_config   = 270.0
+    uniform_initial_ice_temperature_GRL_config   = 270.0
+    uniform_initial_ice_temperature_ANT_config   = 270.0
+    ! Paths to files containing initial temperature fields, if
+    filename_initial_ice_temperature_NAM_config  = ''
+    filename_initial_ice_temperature_EAS_config  = ''
+    filename_initial_ice_temperature_GRL_config  = ''
+    filename_initial_ice_temperature_ANT_config  = ''
+    ! Timeframes to read from the bed roughness file (set to 1E9    if the file has no time dimension)
+    timeframe_initial_ice_temperature_NAM_config = 1E9                              ! Can be different from C%start_time_of_run, be careful though!
+    timeframe_initial_ice_temperature_EAS_config = 1E9
+    timeframe_initial_ice_temperature_GRL_config = 1E9
+    timeframe_initial_ice_temperature_ANT_config = 1E9
+    ! Thermodynamical model
+    choice_thermo_model_config                   = 'none'                           ! Choice of thermodynamical model: "none", "3D_heat_equation"
+    dt_thermodynamics_config                     = 1.0                              ! [yr] Time step for the thermodynamical model
+    Hi_min_thermo_config                         = 10.0                             ! [m]  Ice thinner than this is assumed to have a temperature equal to the annual mean surface temperature throughout the vertical column
+    choice_GL_temperature_BC_config              = 'grounded'                       ! Choice of basal boundary condition at grounding lines: 'grounded', 'subgrid', 'pmp'
+    choice_ice_heat_capacity_config              = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Pounder1965"
+    uniform_ice_heat_capacity_config             = 2009.0                           ! Uniform ice heat capacity (applied when choice_ice_heat_capacity_config = "uniform")
+    choice_ice_thermal_conductivity_config       = 'uniform'                        ! Choice of ice heat capacity model: "uniform", "Ritz1987"
+    uniform_ice_thermal_conductivity_config      = 6.626958E7                       ! Uniform ice thermal conductivity (applied when choice_ice_thermal_conductivity_config = "uniform")
+
+  ! == Rheology and flow law
+  ! =========================
+
+    ! Flow law
+    choice_flow_law_config                       = 'Glen'                           ! Choice of flow law, relating effective viscosity to effective strain rate
+    Glens_flow_law_exponent_config               = 3.0                              ! Exponent in Glen`s flow law
+    Glens_flow_law_epsilon_sq_0_config           = 1E-8                             ! Normalisation term so that zero strain rates produce a high but finite viscosity
+
+    ! Rheology
+    choice_ice_rheology_Glen_config              = 'uniform'                        ! Choice of ice rheology model for Glen`s flow law: "uniform", "Huybrechts1992", "MISMIP_mod"
+    uniform_Glens_flow_factor_config             = 1.1187297124212972E-017          ! Uniform ice flow factor (applied when choice_ice_rheology_model_config = "uniform")
+
+    ! Enhancement factors
+    choice_enhancement_factor_transition_config  = 'separate'                       ! Choice of treatment of enhancement factors at transition zones: "separate", "interp"
+    m_enh_sheet_config                           = 1.0                              ! Ice flow enhancement factor for grounded ice
+    m_enh_shelf_config                           = 1.0                              ! Ice flow enhancement factor for floating ice
+
+  ! == Climate
+  ! ==========
+
+    ! Time step
+    do_asynchronous_climate_config               = .TRUE.                           ! Whether or not the climate should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_climate_config                            = 10.0                             ! [yr] Time step for calculating climate
+
+    ! Choice of climate model
+    choice_climate_model_NAM_config              = 'none'
+    choice_climate_model_EAS_config              = 'none'
+    choice_climate_model_GRL_config              = 'none'
+    choice_climate_model_ANT_config              = 'none'
+
+    ! Choice of idealised climate model
+    choice_climate_model_idealised_config        = ''
+
+    ! Choice of realistic climate model
+    choice_climate_model_realistic_config        = ''
+
+    filename_climate_snapshot_NAM_config         = ''
+    filename_climate_snapshot_EAS_config         = ''
+    filename_climate_snapshot_GRL_config         = ''
+    filename_climate_snapshot_ANT_config         = ''
+
+  ! == Ocean
+  ! ========
+
+    ! Time step
+    do_asynchronous_ocean_config                 = .TRUE.                           ! Whether or not the ocean should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_ocean_config                              = 1.0                             ! [yr] Time step for calculating ocean
+
+    ! Vertical grid
+    ocean_vertical_grid_max_depth_config         = 1500.0                           ! Maximum depth of the ocean submodel
+    ocean_vertical_grid_dz_config                = 100.0                            ! Vertical distance between ocean layers
+
+    ! Choice of ocean model
+    choice_ocean_model_NAM_config                = 'none'
+    choice_ocean_model_EAS_config                = 'none'
+    choice_ocean_model_GRL_config                = 'none'
+    choice_ocean_model_ANT_config                = 'idealised'
+
+    ! Choice of idealised ocean model
+    choice_ocean_model_idealised_config          = 'ISOMIP'
+    choice_ocean_isomip_scenario_config          = 'WARM'
+    ocean_tanh_deep_temperature_config           = 1.5                           ! [degC] Deep ocean temperature when using 'TANH' forcing
+    ocean_tanh_thermocline_depth_config          = 450.0                         ! [m]    Depth of thermocline when using 'TANH' forcing
+
+    ! Choice of realistic ocean model
+    choice_ocean_model_realistic_config          = ''
+
+    filename_ocean_snapshot_NAM_config           = ''
+    filename_ocean_snapshot_EAS_config           = ''
+    filename_ocean_snapshot_GRL_config           = ''
+    filename_ocean_snapshot_ANT_config           = ''
+
+  ! == Surface mass balance
+  ! =======================
+
+    ! Time step
+    do_asynchronous_SMB_config                   = .TRUE.                           ! Whether or not the SMB should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_SMB_config                                = 10.0                             ! [yr] Time step for calculating SMB
+
+    ! Choice of SMB model
+    choice_SMB_model_NAM_config                  = 'uniform'
+    choice_SMB_model_EAS_config                  = 'uniform'
+    choice_SMB_model_GRL_config                  = 'uniform'
+    choice_SMB_model_ANT_config                  = 'idealised'
+
+    ! Choice of idealised SMB model
+    choice_SMB_model_idealised_config            = 'uniform'
+
+    ! Value to be used for uniform SMB (no regional variants, only used for idealised-geometry experiments)
+    uniform_SMB_config                           = 0.3
+
+    ! Prescribed SMB forcing
+    choice_SMB_prescribed_NAM_config             = ''
+    choice_SMB_prescribed_EAS_config             = ''
+    choice_SMB_prescribed_GRL_config             = ''
+    choice_SMB_prescribed_ANT_config             = ''
+
+    ! Files containing prescribed SMB forcing
+    filename_SMB_prescribed_NAM_config           = ''
+    filename_SMB_prescribed_EAS_config           = ''
+    filename_SMB_prescribed_GRL_config           = ''
+    filename_SMB_prescribed_ANT_config           = ''
+
+    ! Timeframes for reading prescribed SMB forcing from file (set to 1E9 if the file has no time dimension)
+    timeframe_SMB_prescribed_NAM_config          = 1E9
+    timeframe_SMB_prescribed_EAS_config          = 1E9
+    timeframe_SMB_prescribed_GRL_config          = 1E9
+    timeframe_SMB_prescribed_ANT_config          = 1E9
+
+  ! == Basal mass balance
+  ! =====================
+
+    ! Time step
+    do_asynchronous_BMB_config                   = .TRUE.                          ! Whether or not the BMB should be calculated asynchronously from the rest of the model; if so, use dt_climate; if not, calculate it in every time step
+    dt_BMB_config                                = 0.125                             ! [yr] Time step for calculating BMB
+
+    ! Grounding line treatment
+    choice_BMB_subgrid_config                    = 'PMP'                               ! Choice of sub-grid BMB scheme: "FCMP", "PMP" (following Leguy et al., 2021)
+
+    ! Choice of BMB model
+    choice_BMB_model_NAM_config                  = 'uniform'
+    choice_BMB_model_EAS_config                  = 'uniform'
+    choice_BMB_model_GRL_config                  = 'uniform'
+    choice_BMB_model_ANT_config                  = 'laddie'
+
+    ! Choice of idealised BMB model
+    choice_BMB_model_idealised_config            = 'MISMIP+'
+
+    ! Choice of parameterised BMB model
+    choice_BMB_model_parameterised_config        = 'Favier2019'
+
+    ! "uniform"
+    uniform_BMB_config                           = 0.0
+
+    ! "parameterised"
+    BMB_Favier2019_gamma_config                  = 99.32E-5
+
+  ! == LADDIE model
+  ! ===============
+
+    ! Output
+    do_write_laddie_output_fields_config         = .FALSE.                          ! Whether or not to write output fields on laddie time
+    do_write_laddie_output_scalar_config         = .TRUE.                          ! Whether or not to write output scalars on laddie time
+    time_interval_scalar_output_config           = 1.0
+
+    ! Time step
+    dt_laddie_config                             = 180.0                            ! [s] Time step for integration of laddie model
+    time_duration_laddie_config                  = 4.0                              ! [days] Duration of each run cycle
+    time_duration_laddie_init_config             = 20.0                             ! [days]
+
+    ! Integration
+    choice_laddie_integration_scheme_config      = 'fbrk3'                          ! Options: 'euler', 'fbrk3'
+    laddie_fbrk3_beta1_config                    = 0.500                            ! FBRK3 beta1 value
+    laddie_fbrk3_beta2_config                    = 0.500                            ! FBRK3 beta1 value
+    laddie_fbrk3_beta3_config                    = 0.344                            ! FBRK3 beta1 value
+
+    ! Momentum advection
+    choice_laddie_momentum_advection_config      = 'upstream'                          ! Options: 'none', 'fesom', 'upstream'
+
+    ! Initialisation
+    laddie_initial_thickness_config              = 2.0                             ! [m] Initial value of thickness H
+    laddie_initial_T_offset_config               = 0.0                              ! [degC] Initial offset of T relative to ambien    t
+    laddie_initial_S_offset_config               = -0.1                             ! [PSU] Initial offset of S relative to ambient    . Must be negative for stable buoyancy!
+
+    ! Equation of state
+    choice_laddie_equation_of_state_config       = 'linear'                         ! Choose equation of state. Options: 'linear'
+    uniform_laddie_eos_linear_alpha_config       = 3.733E-5                         ! [K ^-1] 'linear' eos: thermal expansion coeff    icient
+    uniform_laddie_eos_linear_beta_config        = 7.843E-4                         ! [PSU ^-1] 'linear' eos: haline contraction co    efficient
+
+    ! Coriolis
+    choice_laddie_coriolis_config                = 'uniform'                        ! Choose option Coriolis parameter. Options: 'u    niform'
+    uniform_laddie_coriolis_parameter_config     = -1.37E-4                         ! [s ^-1]
+
+    ! Turbulent heat exchange
+    choice_laddie_gamma_config                   = 'Jenkins1991'                        ! Choose option turbulent heat exchange. Op    tions: 'uniform', 'Jenkins1991'
+    uniform_laddie_gamma_T_config                = 1.8E-4                           ! [] 'uniform': gamma_T parameter. gamma_S = ga    mma_T/35
+
+    ! Drag coefficients
+    laddie_drag_coefficient_top_config           = 2.5E-3                           ! [] Drag coefficient Cd_top in friction veloci    ty
+    laddie_drag_coefficient_mom_config           = 2.5E-3                           ! [] Drag coefficient Cd_mom in momentum term
+
+    ! Viscosity and diffusivity
+    laddie_viscosity_config                      = 10.0                              ! [m^2 s^-1] Viscosity parameter Ah
+    laddie_diffusivity_config                    = 100.0                             ! [m^2 s^-1] Diffusivity parameter Kh
+
+    ! Entrainment
+    choice_laddie_entrainment_config             = 'Gaspar1988'                     ! Choose option entrainment parameterisation. O    ptions: 'Holland2006', 'Gaspar1988'
+    laddie_Holland2006_cl_config                 = 1.775E-2                         ! [] Scaling parameter c_l in Holland2006 entra    inment
+    laddie_Gaspar1988_mu_config                  = 2.5                              ! [] Scaling parameter mu in Gaspar1988 entrain    ment
+
+    ! Stability
+    laddie_thickness_minimum_config              = 2.0                              ! [m] Minimum layer thickness allowed
+    laddie_thickness_maximum_config              = 1500.0                           ! [m] Maximum layer thickness allowed
+    laddie_velocity_maximum_config               = 1.0                              ! [m s^-1] Maximum velocity allowed
+    laddie_buoyancy_minimum_config               = 5.0E-3                           ! [kg m^-3] Minimum density difference allowed
+
+    ! Tides
+    choice_laddie_tides_config                   = 'uniform'                        ! Choose option for tidal velocity. Options: 'u    niform'
+    uniform_laddie_tidal_velocity_config         = 0.01                              ! [m s^-1] Uniform tidal velocity
+
+  ! == Lateral mass balance
+  ! =======================
+
+    ! Time step
+    dt_LMB_config                                = 5.0                              ! [yr] Time step for calculating LMB [not implemented yet]
+
+    ! Choice of LMB model
+    choice_LMB_model_NAM_config                  = 'uniform'
+    choice_LMB_model_EAS_config                  = 'uniform'
+    choice_LMB_model_GRL_config                  = 'uniform'
+    choice_LMB_model_ANT_config                  = 'uniform'
+
+    ! "uniform"
+    uniform_LMB_config                           = 0.0
+
+  ! == Glacial isostatic adjustment
+  ! ===============================
+
+    ! General settings
+    choice_GIA_model_config                      = 'none'
+    dt_GIA_config                                = 100.0                            ! [yr] GIA model time step
+    dx_GIA_config                                = 2000.0                           ! [m]  GIA model square grid resolution
+
+  ! == Sea level
+  ! ============
+
+    choice_sealevel_model_config                 = 'fixed'                          !     Can be "fixed", "prescribed", "eustatic", or "SELEN"
+    fixed_sealevel_config                        = 0.0                              ! [m] Fixed sea level value for the "fixed" choice
+
+  ! == SELEN
+  ! ========
+
+    SELEN_run_at_t_start_config                  = .FALSE.                          ! Whether or not to run SELEN in the first coupling loop (needed for some benchmark experiments)
+    SELEN_n_TDOF_iterations_config               = 1                                ! Number of Time-Dependent Ocean Function iterations
+    SELEN_n_recursion_iterations_config          = 1                                ! Number of recursion iterations
+    SELEN_use_rotational_feedback_config         = .FALSE.                          ! If TRUE, rotational feedback is included
+    SELEN_n_harmonics_config                     = 128                              ! Maximum number of harmonic degrees
+    SELEN_display_progress_config                = .FALSE.                          ! Whether or not to display the progress of the big loops to the screen
+
+    SELEN_dir_config                             = 'external/data/SELEN'                     ! Directory where SELEN initial files and spherical harmonics are stored
+    SELEN_global_topo_filename_config            = 'SELEN_global_topography.nc'     ! Filename for the SELEN global topography file (located in SELEN_dir)
+    SELEN_TABOO_init_filename_config             = 'SELEN_TABOO_initial_file.dat'   ! Filename for the TABOO initial file           (idem                )
+    SELEN_LMJ_VALUES_filename_config             = 'SELEN_lmj_values.bin'           ! Filename for the LJ and MJ values file        (idem                )
+
+    SELEN_irreg_time_n_config                    = 15                               ! Number of entries in the irregular moving time window
+    SELEN_irreg_time_window_config               = 20.0  , 20.0  , 20.0  , 5.0  , 5.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 1.0  , 0.0  ,  0.0  ,  0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  ,  0.0  ,  0.0  ,  0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  , 0.0  ,  0.0  ,  0.0  , 0.0  , 0.0
+
+    SELEN_lith_thickness_config                  = 100.0                            ! Thickness of the elastic lithosphere [km]
+    SELEN_visc_n_config                          = 3                                ! Number      of viscous asthenosphere layers
+    SELEN_visc_prof_config                       = 3.0  , 0.6   , 0.3               ! Viscosities of viscous asthenosphere layers [?]
+
+    ! Settings for the TABOO Earth deformation model
+    SELEN_TABOO_CDE_config                       = 0                                !     code of the model (see taboo for explanation)
+    SELEN_TABOO_TLOVE_config                     = 1                                !     Tidal love numbers yes/no
+    SELEN_TABOO_DEG1_config                      = 1                                !     Tidal love numbers degree
+    SELEN_TABOO_RCMB_config                      = 3480.0                           ! [m] Radius of CMB
+
+  ! == Output
+  ! =========
+
+    ! Basic settings
+    do_create_netcdf_output_config               = .TRUE.                           !     Whether or not NetCDF output files should be created at all
+    dt_output_config                             = 1.0                              !     Time step for writing output
+    dt_output_restart_config                     = 30000.0                          !     Time step for writing restart output
+    dt_output_grid_config                        = 1.0                           !     Time step for writing gridded output
+    dx_output_grid_NAM_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for North America
+    dx_output_grid_EAS_config                    = 40E3                             ! [m] Horizontal resolution for the square grid used for output for Eurasia
+    dx_output_grid_GRL_config                    = 20E3                             ! [m] Horizontal resolution for the square grid used for output for Greenland
+    dx_output_grid_ANT_config                    = 2e3                              ! [m] Horizontal resolution for the square grid used for output for Antarctica
+    dx_output_grid_ROI_NAM_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for North America
+    dx_output_grid_ROI_EAS_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Eurasia
+    dx_output_grid_ROI_GRL_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Greenland
+    dx_output_grid_ROI_ANT_config                = 5E3                              ! [m] Horizontal resolution for the square grid used for output for the region of interest for Antarctica
+
+    ! Transects
+    transects_NAM_config                         = ''                              ! List of transects to use for North America
+    transects_EAS_config                         = ''                              ! List of transects to use for Eurasia
+    transects_GRL_config                         = ''                              ! List of transects to use for Greenland
+    transects_ANT_config                         = 'westeast,dx=1e3'                  ! List of transects to use for Antarctica
+
+    ! Which data fields we want to write to the main NetCDF output files
+    choice_output_field_01_config                = 'mask'
+    choice_output_field_02_config                = 'Hi'
+    choice_output_field_03_config                = 'Hb'
+    choice_output_field_04_config                = 'Hs'
+    choice_output_field_05_config                = 'u_vav'
+    choice_output_field_06_config                = 'v_vav'
+    choice_output_field_07_config                = 'uabs_surf'
+    choice_output_field_08_config                = 'fraction_gr'
+    choice_output_field_09_config                = 'fraction_gr_b'
+    choice_output_field_10_config                = 'basal_friction_coefficient'
+    choice_output_field_11_config                = 'pc_truncation_error'
+    choice_output_field_12_config                = 'SMB'
+    choice_output_field_13_config                = 'dHi_dt'
+    choice_output_field_14_config                = 'divQ'
+    choice_output_field_15_config                = 'BMB'
+    choice_output_field_16_config                = 'R_shear'
+    choice_output_field_17_config                = 'grounding_line'
+    choice_output_field_18_config                = 'calving_front'
+    choice_output_field_19_config                = 'ice_margin'
+    choice_output_field_20_config                = 'coastline'
+    choice_output_field_21_config                = 'H_lad'
+    choice_output_field_22_config                = 'U_lad'
+    choice_output_field_23_config                = 'V_lad'
+    choice_output_field_24_config                = 'T_lad'
+    choice_output_field_25_config                = 'S_lad'
+    choice_output_field_26_config                = 'Hib'
+    choice_output_field_27_config                = 'Hs_b'
+    choice_output_field_28_config                = 'dHs_dx'
+    choice_output_field_29_config                = 'dHs_dy'
+    choice_output_field_30_config                = 'dHi'
+    choice_output_field_31_config                = 'none'
+    choice_output_field_32_config                = 'none'
+    choice_output_field_33_config                = 'none'
+    choice_output_field_34_config                = 'none'
+    choice_output_field_35_config                = 'none'
+    choice_output_field_36_config                = 'none'
+    choice_output_field_37_config                = 'none'
+    choice_output_field_38_config                = 'none'
+    choice_output_field_39_config                = 'none'
+    choice_output_field_40_config                = 'none'
+    choice_output_field_41_config                = 'none'
+    choice_output_field_42_config                = 'none'
+    choice_output_field_43_config                = 'none'
+    choice_output_field_44_config                = 'none'
+    choice_output_field_45_config                = 'none'
+    choice_output_field_46_config                = 'none'
+    choice_output_field_47_config                = 'none'
+    choice_output_field_48_config                = 'none'
+    choice_output_field_49_config                = 'none'
+    choice_output_field_50_config                = 'none'
+
+/

--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/make_figures.py
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/make_figures.py
@@ -9,10 +9,8 @@ This script reads model output from NetCDF files and creates a two-panel figure:
 
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.patches import Rectangle
 import netCDF4
 import os
-import glob
 
 
 def read_mismip_ensemble(foldername):
@@ -125,8 +123,7 @@ def read_ufemism_results(foldername):
     ufe = {}
 
     if not os.path.exists(filename):
-        print(f"Warning: File not found: {filename}")
-        return ufe
+        raise FileNotFoundError(f"Required UFEMISM output not found: {filename}")
 
     with netCDF4.Dataset(filename, 'r') as ds:
         # Grounding-line position over time

--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/make_figures.py
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/make_figures.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+Plot UFEMISM model output compared to MISMIP+ ensemble results.
+
+This script reads model output from NetCDF files and creates a two-panel figure:
+- Left panel: Ice geometry (surface and base) at initial and final states
+- Right panel: Grounding-line position over time
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle
+import netCDF4
+import os
+import glob
+
+
+def read_mismip_ensemble(foldername):
+    """
+    Read and process the MISMIP+ model ensemble from Cornford et al. (2020)
+
+    Cornford, S. L., Seroussi, H., Asay-Davis, X. S., Gudmundsson, G. H.,
+    Arthern, R., Borstad, C., Christmann, J., Dias dos Santos, T.,
+    Feldmann, J., Goldberg, D., Hoffman, M. J., Humbert, A., Kleiner, T.,
+    Leguy, G., Lipscomb, W. H., Merino, N., Durand, G., Morlighem, M.,
+    Pollard, D., Rückamp, M., Williams, C. R., and Yu, H.:
+    Results of the third Marine Ice Sheet Model Intercomparison Project
+    (MISMIP+), The Cryosphere 14, 2283--2301, 2020.
+    """
+
+    c2020 = []
+    foldername = os.path.join(foldername, 'submission_data')
+    experiment = 'Ice1r'
+
+    list_of_models = list_models_for_experiment(foldername, experiment)
+
+    for model_name in list_of_models:
+        time, xgl_mid = read_xgl_mid_experiment_model(foldername, experiment, model_name)
+        model = {
+            'name': model_name,
+            'time': time,
+            'xGL': xgl_mid
+        }
+        c2020.append(model)
+
+    return c2020
+
+
+def list_models_for_experiment(foldername, experiment):
+    """List all models for a given experiment in the folder."""
+
+    list_of_models = []
+
+    if not os.path.exists(foldername):
+        return list_of_models
+
+    for filename in os.listdir(foldername):
+        if filename.startswith(experiment + '_') and filename.endswith('.nc'):
+            model_name = filename[len(experiment) + 1:-3]
+            list_of_models.append(model_name)
+
+    return sorted(list_of_models)
+
+
+def read_xgl_mid_experiment_model(foldername, experiment, model_name):
+    """
+    Read grounding-line position at model mid-stream for a specific model.
+    """
+
+    filename = os.path.join(foldername, f'{experiment}_{model_name}.nc')
+
+    if not os.path.exists(filename):
+        return np.array([]), np.array([])
+
+    with netCDF4.Dataset(filename, 'r') as ds:
+        # Read time and process to get relevant timeframes
+        time = ds['time'][:]
+
+        # Find end of relevant time frames (some models have lots of empty frames after)
+        ti_end = 0
+        for i in range(len(time)):
+            if time[i] < 1e5:
+                ti_end = i + 1
+            else:
+                break
+
+        time = time[:ti_end]
+
+        # Read grounding line coordinates
+        # xGL and yGL have dimensions (nPointGL, nTime)
+        xgl = ds['xGL'][:]
+        ygl = ds['yGL'][:]
+
+        # Extract midstream grounding line position
+        y_mid = 4e4
+        xgl_mid = np.zeros(ti_end)
+
+        for ti in range(ti_end):
+            # Get all points on grounding line at this time step
+            xgl_ti = xgl[:, ti]
+            ygl_ti = ygl[:, ti]
+
+            # Remove NaNs and unrealistic values (large fill values)
+            mask = ~np.isnan(xgl_ti) & ~np.isnan(ygl_ti) & (xgl_ti < 1e30)
+            xgl_ti = xgl_ti[mask]
+            ygl_ti = ygl_ti[mask]
+
+            if len(xgl_ti) > 0:
+                # Find point closest to y_mid
+                j_mid = np.argmin(np.abs(ygl_ti - y_mid))
+                xgl_mid[ti] = xgl_ti[j_mid]
+
+        # Some models submitted data in km instead of m
+        if np.max(xgl_mid) < 1e3:
+            xgl_mid = xgl_mid * 1e3
+
+    return time, xgl_mid
+
+
+def read_ufemism_results(foldername):
+    """Read UFEMISM model output from transect NetCDF file."""
+
+    filename = os.path.join(foldername, 'transect_westeast.nc')
+
+    ufe = {}
+
+    if not os.path.exists(filename):
+        print(f"Warning: File not found: {filename}")
+        return ufe
+
+    with netCDF4.Dataset(filename, 'r') as ds:
+        # Grounding-line position over time
+        ufe['time'] = ds['time'][:]
+        ufe['xGL'] = ds['grounding_line_distance_from_start'][:]
+
+        # Coordinate and bedrock
+        V = ds['V'][:]  # V has shape (2, n_spatial) where row 0 is x, row 1 is y
+        ufe['x'] = V[0, :]  # x-coordinates (first row)
+        ufe['Hb'] = ds['Hb'][0, :]  # Bedrock at first time step (or any time, should be same)
+
+        # Initial geometry (first time step, all spatial points)
+        ufe['Hs_init'] = ds['Hs'][0, :]  # Surface elevation at t=0
+        ufe['Hib_init'] = ds['Hib'][0, :]  # Ice base at t=0
+
+        # Final geometry (last time step, all spatial points)
+        ti_end = len(ufe['time']) - 1
+        ufe['Hs_end'] = ds['Hs'][ti_end, :]  # Surface elevation at final time
+        ufe['Hib_end'] = ds['Hib'][ti_end, :]  # Ice base at final time
+
+    return ufe
+
+
+def setup_multipanel_figure(wa, ha, margins_hor, margins_ver):
+    """
+    Set up a multi-panel figure with specified layout.
+
+    Parameters:
+    -----------
+    wa : int or list
+        Width(s) of axes in pixels
+    ha : int or list
+        Height(s) of axes in pixels
+    margins_hor : list
+        Horizontal margins [left, ...inner..., right] in pixels
+    margins_ver : list
+        Vertical margins [top, ...inner..., bottom] in pixels
+
+    Returns:
+    --------
+    fig : matplotlib.figure.Figure
+        The figure object
+    axes : dict
+        Dictionary of axes indexed as (i, j)
+    """
+
+    # Handle scalar inputs for wa and ha
+    if isinstance(wa, int):
+        wa = [wa] * (len(margins_hor) - 1)
+    if isinstance(ha, int):
+        ha = [ha] * (len(margins_ver) - 1)
+
+    nax = len(margins_hor) - 1
+    nay = len(margins_ver) - 1
+
+    # Figure size
+    wf = sum(margins_hor) + sum(wa)
+    hf = sum(margins_ver) + sum(ha)
+
+    # Create figure (convert pixels to inches, assuming 100 dpi)
+    dpi = 100
+    fig = plt.figure(figsize=(wf / dpi, hf / dpi), dpi=dpi)
+    fig.patch.set_facecolor('white')
+
+    # Create axes
+    axes = {}
+    for i in range(nay):
+        for j in range(nax):
+            x = (sum(margins_hor[:j+1]) + sum(wa[:j])) / wf
+            y_top = (sum(margins_ver[:i+1]) + sum(ha[:i])) / hf
+            w = wa[j] / wf
+            h = ha[i] / hf
+            y = 1.0 - y_top - h  # Flip y-coordinate for matplotlib
+
+            ax = fig.add_axes([x, y, w, h])
+            ax.tick_params(labelsize=10)
+            ax.grid(True, alpha=0.3)
+            axes[(i, j)] = ax
+
+    return fig, axes
+
+
+def main():
+    """Main function to create the comparison figure."""
+
+    # Read ensemble results
+    foldername = '../../../external/data/model_ensembles/MISMIPplus/'
+    c2020 = read_mismip_ensemble(foldername)
+
+    # Read UFEMISM results
+    ufe_5km = read_ufemism_results('results_5km_ice1r')
+    ufe_4km = read_ufemism_results('results_4km_ice1r')
+
+    # Set up figure
+    wa = [500, 500]  # Width of two panels in pixels
+    ha = 300  # Height in pixels
+    margins_hor = [100, 25, 100]  # Left, middle, right margins
+    margins_ver = [25, 80]  # Top, bottom margins
+
+    fig, axes = setup_multipanel_figure(wa, ha, margins_hor, margins_ver)
+
+    # ========== Left panel: Ice geometry ==========
+    ax = axes[(0, 0)]
+    ax.set_xlim([0, 800])
+    ax.set_ylim([-1000, 1800])
+    ax.set_xlabel('x (km)', fontsize=11)
+    ax.set_ylabel('z (m)', fontsize=11)
+
+    # Plot lines for legend
+    ax.plot([], [], 'r-', linewidth=2, label='5 km')
+    ax.plot([], [], 'b-', linewidth=2, label='4 km')
+    ax.plot([], [], 'k-', linewidth=2, label='t = 0')
+    ax.plot([], [], 'k--', linewidth=2, label='t = 100 yr')
+
+    # 5 km results - initial geometry
+    ax.plot(ufe_5km['x'] / 1e3, ufe_5km['Hs_init'], 'r-', linewidth=2)
+    ax.plot(ufe_5km['x'] / 1e3, ufe_5km['Hib_init'], 'r-', linewidth=2)
+
+    # 5 km results - final geometry
+    ax.plot(ufe_5km['x'] / 1e3, ufe_5km['Hs_end'], 'r--', linewidth=2)
+    ax.plot(ufe_5km['x'] / 1e3, ufe_5km['Hib_end'], 'r--', linewidth=2)
+
+    # 4 km results - initial geometry
+    ax.plot(ufe_4km['x'] / 1e3, ufe_4km['Hs_init'], 'b-', linewidth=2)
+    ax.plot(ufe_4km['x'] / 1e3, ufe_4km['Hib_init'], 'b-', linewidth=2)
+
+    # 4 km results - final geometry
+    ax.plot(ufe_4km['x'] / 1e3, ufe_4km['Hs_end'], 'b--', linewidth=2)
+    ax.plot(ufe_4km['x'] / 1e3, ufe_4km['Hib_end'], 'b--', linewidth=2)
+
+    # Bedrock (plotted last so it's visible)
+    ax.plot(ufe_4km['x'] / 1e3, ufe_4km['Hb'], 'k-', linewidth=3)
+
+    ax.legend(loc='upper right', fontsize=10)
+
+    # ========== Right panel: Grounding-line position over time ==========
+    ax = axes[(0, 1)]
+    ax.yaxis.set_label_position("right")
+    ax.yaxis.tick_right()
+    ax.set_xlim([0, 100])
+    ax.set_ylim([360, 470])
+    ax.set_xlabel('Time (yr)', fontsize=11)
+    ax.set_ylabel('Grounding-line position (km)', fontsize=11)
+
+    # MISMIP+ ensemble
+    for model in c2020:
+        ax.plot(model['time'], model['xGL'] / 1e3, 'k-', linewidth=1, alpha=0.7)
+
+    # UFEMISM results
+    ax.plot(ufe_5km['time'], ufe_5km['xGL'] / 1e3, 'r-', linewidth=3, label='5 km')
+    ax.plot(ufe_4km['time'], ufe_4km['xGL'] / 1e3, 'b-', linewidth=3, label='4 km')
+
+    # Save figure
+    output_file = 'Fig_integrated_test_MISMIPplus_full.png'
+    fig.savefig(output_file, dpi=100, bbox_inches='tight')
+    print(f"Figure saved to {output_file}")
+
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/test_script.csh
+++ b/automated_testing/UFEMISM/integrated_test_MISMIPplus_full/test_script.csh
@@ -1,0 +1,13 @@
+#! /bin/csh -f
+
+set test_dir = automated_testing/UFEMISM/integrated_test_MISMIPplus_full
+
+rm -rf ${test_dir}/results*
+
+mpiexec  -n 2  UFEMISM_program  ${test_dir}/config_01_5km_spinup_part0.cfg
+mpiexec  -n 2  UFEMISM_program  ${test_dir}/config_02_5km_spinup.cfg
+mpiexec  -n 2  UFEMISM_program  ${test_dir}/config_03_5km_ice1r.cfg
+mpiexec  -n 2  UFEMISM_program  ${test_dir}/config_04_4km_spinup.cfg
+mpiexec  -n 2  UFEMISM_program  ${test_dir}/config_05_4km_ice1r.cfg
+
+#python3 automated_testing/reduce_all_netcdfs_in_folder_to_checksum.py ${test_dir}


### PR DESCRIPTION
Runs the spinup and ice1r experiment with 5 km and 4 km grounding-line resolutions. Includes a Python script for plotting the results. Will eventually become part of the weekly benchmarks test suite.