### PR TITLE
Hybrid memory mesh fields

### DIFF
--- a/src/UPSY/mesh/Voronoi_mesh/mesh_Voronoi.f90
+++ b/src/UPSY/mesh/Voronoi_mesh/mesh_Voronoi.f90
@@ -7,6 +7,8 @@ module mesh_Voronoi
   use precisions, only: dp
   use mesh_types, only: type_mesh
   use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine, crash
+  use mpi_distributed_shared_memory, only: deallocate_dist_shared, allocate_dist_shared
+  use mpi_basic, only: par, sync
 
   implicit none
 
@@ -34,7 +36,7 @@ subroutine construct_Voronoi_mesh( mesh)
   call construct_Voronoi_cells( mesh)
 
   ! Finalise routine path
-  call finalise_routine( routine_name)
+  call finalise_routine( routine_name, n_extra_MPI_windows_expected = 11)
 
 end subroutine construct_Voronoi_mesh
 
@@ -81,21 +83,23 @@ subroutine construct_Voronoi_mesh_translation_tables( mesh)
   ! Add routine to path
   call init_routine( routine_name)
 
-  if (allocated( mesh%vi2vori)) deallocate( mesh%vi2vori)
-  if (allocated( mesh%ti2vori)) deallocate( mesh%ti2vori)
-  if (allocated( mesh%ei2vori)) deallocate( mesh%ei2vori)
+  if (associated( mesh%vi2vori)) call deallocate_dist_shared( mesh%vi2vori, mesh%wvi2vori)
+  if (associated( mesh%ti2vori)) call deallocate_dist_shared( mesh%ti2vori, mesh%wti2vori)
+  if (associated( mesh%ei2vori)) call deallocate_dist_shared( mesh%ei2vori, mesh%wei2vori)
 
-  if (allocated( mesh%vori2vi)) deallocate( mesh%vori2vi)
-  if (allocated( mesh%vori2ti)) deallocate( mesh%vori2ti)
-  if (allocated( mesh%vori2ei)) deallocate( mesh%vori2ei)
+  if (associated( mesh%vori2vi)) call deallocate_dist_shared( mesh%vori2vi, mesh%wvori2vi)
+  if (associated( mesh%vori2ti)) call deallocate_dist_shared( mesh%vori2ti, mesh%wvori2ti)
+  if (associated( mesh%vori2ei)) call deallocate_dist_shared( mesh%vori2ei, mesh%wvori2ei)
 
-  allocate( mesh%vi2vori( mesh%nV  ), source = 0)
-  allocate( mesh%ti2vori( mesh%nTri), source = 0)
-  allocate( mesh%ei2vori( mesh%nE  ), source = 0)
+  call allocate_dist_shared( mesh%vi2vori, mesh%wvi2vori, [1, mesh%nV  ])
+  call allocate_dist_shared( mesh%ti2vori, mesh%wti2vori, [1, mesh%nTri])
+  call allocate_dist_shared( mesh%ei2vori, mesh%wei2vori, [1, mesh%nE  ])
 
-  allocate( mesh%vori2vi( mesh%nVor), source = 0)
-  allocate( mesh%vori2ti( mesh%nVor), source = 0)
-  allocate( mesh%vori2ei( mesh%nVor), source = 0)
+  call allocate_dist_shared( mesh%vori2vi, mesh%wvori2vi, [1, mesh%nVor])
+  call allocate_dist_shared( mesh%vori2ti, mesh%wvori2ti, [1, mesh%nVor])
+  call allocate_dist_shared( mesh%vori2ei, mesh%wvori2ei, [1, mesh%nVor])
+
+  if (par%node_primary) then
 
   vori = 0
 
@@ -124,8 +128,11 @@ subroutine construct_Voronoi_mesh_translation_tables( mesh)
     mesh%vori2vi( vori) = vi
   end do
 
+  end if
+  call sync
+
   ! Finalise routine path
-  call finalise_routine( routine_name)
+  call finalise_routine( routine_name, n_extra_MPI_windows_expected = 6)
 
 end subroutine construct_Voronoi_mesh_translation_tables
 
@@ -141,8 +148,10 @@ subroutine calc_Voronoi_vertex_coordinates( mesh)
   ! Add routine to path
   call init_routine( routine_name)
 
-  if (allocated( mesh%Vor)) deallocate( mesh%Vor)
-  allocate( mesh%Vor( mesh%nVor,2), source = 0._dp)
+  if (associated( mesh%Vor)) call deallocate_dist_shared( mesh%Vor, mesh%wVor)
+  call allocate_dist_shared( mesh%Vor, mesh%wVor, [1, mesh%nVor], [1, 2])
+
+  if (par%node_primary) then
 
   do vori = 1, mesh%nVor
 
@@ -162,8 +171,11 @@ subroutine calc_Voronoi_vertex_coordinates( mesh)
 
   end do
 
+  end if
+  call sync
+
   ! Finalise routine path
-  call finalise_routine( routine_name)
+  call finalise_routine( routine_name, n_extra_MPI_windows_expected = 1)
 
 end subroutine calc_Voronoi_vertex_coordinates
 
@@ -178,18 +190,18 @@ subroutine construct_Voronoi_mesh_connectivity( mesh)
   ! Add routine to path
   call init_routine( routine_name)
 
-  if (allocated( mesh%VornC)) deallocate( mesh%VornC)
-  if (allocated( mesh%VorC )) deallocate( mesh%VorC)
+  if (associated( mesh%VornC)) call deallocate_dist_shared( mesh%VornC, mesh%wVornC)
+  if (associated( mesh%VorC )) call deallocate_dist_shared( mesh%VorC , mesh%wVorC )
 
-  allocate( mesh%VornC( mesh%nVor  ), source = 0)
-  allocate( mesh%VorC ( mesh%nVor,3), source = 0)
+  call allocate_dist_shared( mesh%VornC, mesh%wVornC, [1, mesh%nVor]        )
+  call allocate_dist_shared( mesh%VorC , mesh%wVorC , [1, mesh%nVor], [1, 3])
 
   call construct_Voronoi_mesh_connectivity_triangle_based( mesh)
   call construct_Voronoi_mesh_connectivity_edge_based    ( mesh)
   call construct_Voronoi_mesh_connectivity_vertex_based  ( mesh)
 
   ! Finalise routine path
-  call finalise_routine( routine_name)
+  call finalise_routine( routine_name, n_extra_MPI_windows_expected = 2)
 
 end subroutine construct_Voronoi_mesh_connectivity
 
@@ -204,6 +216,8 @@ subroutine construct_Voronoi_mesh_connectivity_triangle_based( mesh)
 
   ! Add routine to path
   call init_routine( routine_name)
+
+  if (par%node_primary) then
 
   do ti = 1, mesh%nTri
 
@@ -248,6 +262,9 @@ subroutine construct_Voronoi_mesh_connectivity_triangle_based( mesh)
 
   end do
 
+  end if
+  call sync
+
   ! Finalise routine path
   call finalise_routine( routine_name)
 
@@ -264,6 +281,8 @@ subroutine construct_Voronoi_mesh_connectivity_edge_based( mesh)
 
   ! Add routine to path
   call init_routine( routine_name)
+
+  if (par%node_primary) then
 
   do ei = 1, mesh%nE
     if (mesh%EBI( ei) > 0) then
@@ -330,6 +349,9 @@ subroutine construct_Voronoi_mesh_connectivity_edge_based( mesh)
     end if
   end do
 
+  end if
+  call sync
+
   ! Finalise routine path
   call finalise_routine( routine_name)
 
@@ -350,6 +372,8 @@ subroutine construct_Voronoi_mesh_connectivity_vertex_based( mesh)
 
   corners = [mesh%vi_SW, mesh%vi_SE, mesh%vi_NW, mesh%vi_NE]
 
+  if (par%node_primary) then
+
   do cori = 1, 4
     vi = corners( cori)
     vori = mesh%vi2vori( vi)
@@ -369,6 +393,9 @@ subroutine construct_Voronoi_mesh_connectivity_vertex_based( mesh)
 
   end do
 
+  end if
+  call sync
+
   ! Finalise routine path
   call finalise_routine( routine_name)
 
@@ -387,11 +414,13 @@ subroutine construct_Voronoi_cells( mesh)
   ! Add routine to path
   call init_routine( routine_name)
 
-  if (allocated( mesh%nVVor)) deallocate( mesh%nVVor)
-  if (allocated( mesh%VVor )) deallocate( mesh%VVor )
+  if (associated( mesh%nVVor)) call deallocate_dist_shared( mesh%nVVor, mesh%wnVVor)
+  if (associated( mesh%VVor )) call deallocate_dist_shared( mesh%VVor , mesh%wVVor )
 
-  allocate( mesh%nVVor( mesh%nV)             , source = 0)
-  allocate( mesh%VVor ( mesh%nV, mesh%nC_mem), source = 0)
+  call allocate_dist_shared( mesh%nVVor, mesh%wnVVor, [1, mesh%nV]                  )
+  call allocate_dist_shared( mesh%VVor , mesh%wVVor , [1, mesh%nV], [1, mesh%nC_mem])
+
+  if (par%node_primary) then
 
   do vi = 1, mesh%nV
     if (mesh%VBI( vi) == 0) then
@@ -460,8 +489,11 @@ subroutine construct_Voronoi_cells( mesh)
     end if
   end do
 
+  end if
+  call sync
+
   ! Finalise routine path
-  call finalise_routine( routine_name)
+  call finalise_routine( routine_name, n_extra_MPI_windows_expected = 2)
 
 end subroutine construct_Voronoi_cells
 

--- a/src/UPSY/mesh/discretisation/mesh_disc_calc_matrix_operators_2D.f90
+++ b/src/UPSY/mesh/discretisation/mesh_disc_calc_matrix_operators_2D.f90
@@ -52,7 +52,7 @@ subroutine calc_all_matrix_operators_mesh( mesh)
   call calc_zeta_operators_tridiagonal( mesh)
 
   ! Finalise routine path
-  call finalise_routine( routine_name)
+  call finalise_routine( routine_name, n_extra_MPI_windows_expected = 36)
 
 end subroutine calc_all_matrix_operators_mesh
 

--- a/src/UPSY/mesh/discretisation/mesh_translation_tables.f90
+++ b/src/UPSY/mesh/discretisation/mesh_translation_tables.f90
@@ -4,6 +4,8 @@ module mesh_translation_tables
 
   use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine
   use mesh_types, only: type_mesh
+  use allocate_dist_shared_mod, only: allocate_dist_shared
+  use mpi_basic, only: par, sync
 
   implicit none
 
@@ -16,8 +18,8 @@ contains
     type(type_mesh), intent(inout) :: mesh
 
     ! Local variables:
-    character(len=256), parameter :: routine_name = 'calc_field_to_vector_form_translation_tables'
-    integer                       :: nz,vi,ti,ei,k,ks,uv,n
+    character(len=*), parameter :: routine_name = 'calc_field_to_vector_form_translation_tables'
+    integer                     :: nz,vi,ti,ei,k,ks,uv,n
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -46,48 +48,50 @@ contains
     mesh%nncks   = mesh%nE   * (nz-1)
     mesh%nncksuv = mesh%nE   * (nz-1) * 2
 
-    ! allocate shared memory
-    allocate( mesh%n2vi(     mesh%nna       ), source = 0)
-    allocate( mesh%n2viuv(   mesh%nnauv  , 2), source = 0)
-    allocate( mesh%n2vik(    mesh%nnak   , 2), source = 0)
-    allocate( mesh%n2vikuv(  mesh%nnakuv , 3), source = 0)
-    allocate( mesh%n2viks(   mesh%nnaks  , 2), source = 0)
-    allocate( mesh%n2viksuv( mesh%nnaksuv, 3), source = 0)
+    ! Allocate node-shared memory
+    call allocate_dist_shared( mesh%n2vi    , mesh%wn2vi    , [1, mesh%nna    ]        )
+    call allocate_dist_shared( mesh%n2viuv  , mesh%wn2viuv  , [1, mesh%nnauv  ], [1, 2])
+    call allocate_dist_shared( mesh%n2vik   , mesh%wn2vik   , [1, mesh%nnak   ], [1, 2])
+    call allocate_dist_shared( mesh%n2vikuv , mesh%wn2vikuv , [1, mesh%nnakuv ], [1, 3])
+    call allocate_dist_shared( mesh%n2viks  , mesh%wn2viks  , [1, mesh%nnaks  ], [1, 2])
+    call allocate_dist_shared( mesh%n2viksuv, mesh%wn2viksuv, [1, mesh%nnaksuv], [1, 3])
 
-    allocate( mesh%n2ti(     mesh%nnb       ), source = 0)
-    allocate( mesh%n2tiuv(   mesh%nnbuv  , 2), source = 0)
-    allocate( mesh%n2tik(    mesh%nnbk   , 2), source = 0)
-    allocate( mesh%n2tikuv(  mesh%nnbkuv , 3), source = 0)
-    allocate( mesh%n2tiks(   mesh%nnbks  , 2), source = 0)
-    allocate( mesh%n2tiksuv( mesh%nnbksuv, 3), source = 0)
+    call allocate_dist_shared( mesh%n2ti    , mesh%wn2ti    , [1, mesh%nnb    ]        )
+    call allocate_dist_shared( mesh%n2tiuv  , mesh%wn2tiuv  , [1, mesh%nnbuv  ], [1, 2])
+    call allocate_dist_shared( mesh%n2tik   , mesh%wn2tik   , [1, mesh%nnbk   ], [1, 2])
+    call allocate_dist_shared( mesh%n2tikuv , mesh%wn2tikuv , [1, mesh%nnbkuv ], [1, 3])
+    call allocate_dist_shared( mesh%n2tiks  , mesh%wn2tiks  , [1, mesh%nnbks  ], [1, 2])
+    call allocate_dist_shared( mesh%n2tiksuv, mesh%wn2tiksuv, [1, mesh%nnbksuv], [1, 3])
 
-    allocate( mesh%n2ei(     mesh%nnc       ), source = 0)
-    allocate( mesh%n2eiuv(   mesh%nncuv  , 2), source = 0)
-    allocate( mesh%n2eik(    mesh%nnck   , 2), source = 0)
-    allocate( mesh%n2eikuv(  mesh%nnckuv , 3), source = 0)
-    allocate( mesh%n2eiks(   mesh%nncks  , 2), source = 0)
-    allocate( mesh%n2eiksuv( mesh%nncksuv, 3), source = 0)
+    call allocate_dist_shared( mesh%n2ei    , mesh%wn2ei    , [1, mesh%nnc    ]        )
+    call allocate_dist_shared( mesh%n2eiuv  , mesh%wn2eiuv  , [1, mesh%nncuv  ], [1, 2])
+    call allocate_dist_shared( mesh%n2eik   , mesh%wn2eik   , [1, mesh%nnck   ], [1, 2])
+    call allocate_dist_shared( mesh%n2eikuv , mesh%wn2eikuv , [1, mesh%nnckuv ], [1, 3])
+    call allocate_dist_shared( mesh%n2eiks  , mesh%wn2eiks  , [1, mesh%nncks  ], [1, 2])
+    call allocate_dist_shared( mesh%n2eiksuv, mesh%wn2eiksuv, [1, mesh%nncksuv], [1, 3])
 
-    allocate( mesh%vi2n(     mesh%nV           ), source = 0)
-    allocate( mesh%viuv2n(   mesh%nV        , 2), source = 0)
-    allocate( mesh%vik2n(    mesh%nV  , nz     ), source = 0)
-    allocate( mesh%vikuv2n(  mesh%nV  , nz  , 2), source = 0)
-    allocate( mesh%viks2n(   mesh%nV  , nz-1   ), source = 0)
-    allocate( mesh%viksuv2n( mesh%nV  , nz-1, 2), source = 0)
+    call allocate_dist_shared( mesh%vi2n    , mesh%wvi2n    , [1, mesh%nV  ]                 )
+    call allocate_dist_shared( mesh%viuv2n  , mesh%wviuv2n  , [1, mesh%nV  ],          [1, 2])
+    call allocate_dist_shared( mesh%vik2n   , mesh%wvik2n   , [1, mesh%nV  ], [1, nz]        )
+    call allocate_dist_shared( mesh%vikuv2n , mesh%wvikuv2n , [1, mesh%nV  ], [1, nz], [1, 2])
+    call allocate_dist_shared( mesh%viks2n  , mesh%wviks2n  , [1, mesh%nV  ], [1, nz]        )
+    call allocate_dist_shared( mesh%viksuv2n, mesh%wviksuv2n, [1, mesh%nV  ], [1, nz], [1, 2])
 
-    allocate( mesh%ti2n(     mesh%nTri         ), source = 0)
-    allocate( mesh%tiuv2n(   mesh%nTri      , 2), source = 0)
-    allocate( mesh%tik2n(    mesh%nTri, nz     ), source = 0)
-    allocate( mesh%tikuv2n(  mesh%nTri, nz  , 2), source = 0)
-    allocate( mesh%tiks2n(   mesh%nTri, nz-1   ), source = 0)
-    allocate( mesh%tiksuv2n( mesh%nTri, nz-1, 2), source = 0)
+    call allocate_dist_shared( mesh%ti2n    , mesh%wti2n    , [1, mesh%nTri]                 )
+    call allocate_dist_shared( mesh%tiuv2n  , mesh%wtiuv2n  , [1, mesh%nTri],          [1, 2])
+    call allocate_dist_shared( mesh%tik2n   , mesh%wtik2n   , [1, mesh%nTri], [1, nz]        )
+    call allocate_dist_shared( mesh%tikuv2n , mesh%wtikuv2n , [1, mesh%nTri], [1, nz], [1, 2])
+    call allocate_dist_shared( mesh%tiks2n  , mesh%wtiks2n  , [1, mesh%nTri], [1, nz]        )
+    call allocate_dist_shared( mesh%tiksuv2n, mesh%wtiksuv2n, [1, mesh%nTri], [1, nz], [1, 2])
 
-    allocate( mesh%ei2n(     mesh%nE           ), source = 0)
-    allocate( mesh%eiuv2n(   mesh%nE        , 2), source = 0)
-    allocate( mesh%eik2n(    mesh%nE  , nz     ), source = 0)
-    allocate( mesh%eikuv2n(  mesh%nE  , nz  , 2), source = 0)
-    allocate( mesh%eiks2n(   mesh%nE  , nz-1   ), source = 0)
-    allocate( mesh%eiksuv2n( mesh%nE  , nz-1, 2), source = 0)
+    call allocate_dist_shared( mesh%ei2n    , mesh%wei2n    , [1, mesh%nE  ]                 )
+    call allocate_dist_shared( mesh%eiuv2n  , mesh%weiuv2n  , [1, mesh%nE  ],          [1, 2])
+    call allocate_dist_shared( mesh%eik2n   , mesh%weik2n   , [1, mesh%nE  ], [1, nz]        )
+    call allocate_dist_shared( mesh%eikuv2n , mesh%weikuv2n , [1, mesh%nE  ], [1, nz], [1, 2])
+    call allocate_dist_shared( mesh%eiks2n  , mesh%weiks2n  , [1, mesh%nE  ], [1, nz]        )
+    call allocate_dist_shared( mesh%eiksuv2n, mesh%weiksuv2n, [1, mesh%nE  ], [1, nz], [1, 2])
+
+    if (par%node_primary) then
 
     ! == a-grid (vertices)
 
@@ -337,6 +341,9 @@ contains
           end do
         end do
       end do
+
+    end if
+    call sync
 
     ! Finalise routine path
     call finalise_routine( routine_name)

--- a/src/UPSY/mesh/discretisation/mesh_translation_tables.f90
+++ b/src/UPSY/mesh/discretisation/mesh_translation_tables.f90
@@ -346,7 +346,7 @@ contains
     call sync
 
     ! Finalise routine path
-    call finalise_routine( routine_name)
+    call finalise_routine( routine_name, n_extra_MPI_windows_expected = 36)
 
   end subroutine calc_field_to_vector_form_translation_tables
 

--- a/src/UPSY/mesh/edges/mesh_edges.f90
+++ b/src/UPSY/mesh/edges/mesh_edges.f90
@@ -7,6 +7,7 @@ module mesh_edges
   use call_stack_and_comp_time_tracking, only: warning, crash, init_routine, finalise_routine
   use mesh_types, only: type_mesh
   use plane_geometry, only: triangle_area
+  use mpi_distributed_shared_memory, only: allocate_dist_shared, deallocate_dist_shared
 
   implicit none
 
@@ -60,24 +61,25 @@ contains
     ! Add routine to path
     call init_routine( routine_name)
 
-    ! Deallocate memory if necessary
-    if (allocated( mesh%E   )) deallocate( mesh%E   )
-    if (allocated( mesh%VE  )) deallocate( mesh%VE  )
-    if (allocated( mesh%EV  )) deallocate( mesh%EV  )
-    if (allocated( mesh%ETri)) deallocate( mesh%ETri)
-    if (allocated( mesh%TriE)) deallocate( mesh%TriE)
-    if (allocated( mesh%EBI )) deallocate( mesh%EBI )
-    if (allocated( mesh%EA  )) deallocate( mesh%EA  )
+    if (associated( mesh%E   )) call deallocate_dist_shared( mesh%E   , mesh%wE   )
+    if (associated( mesh%VE  )) call deallocate_dist_shared( mesh%VE  , mesh%wVE  )
+    if (associated( mesh%EV  )) call deallocate_dist_shared( mesh%EV  , mesh%wEV  )
+    if (associated( mesh%ETri)) call deallocate_dist_shared( mesh%ETri, mesh%wETri)
+    if (associated( mesh%TriE)) call deallocate_dist_shared( mesh%TriE, mesh%wTriE)
+    if (associated( mesh%EBI )) call deallocate_dist_shared( mesh%EBI , mesh%wEBI )
+    if (associated( mesh%EA  )) call deallocate_dist_shared( mesh%EA  , mesh%wEA  )
 
-    ! Allocate memory
+    ! Allocate node-shared memory
     mesh%nE = sum( mesh%nC) / 2   ! Because every edge is listed by both vertices spanning it
-    allocate( mesh%E    (mesh%nE,   2          ), source = 0._dp)
-    allocate( mesh%VE   (mesh%nV,   mesh%nC_mem), source = 0    )
-    allocate( mesh%EV   (mesh%nE,   4          ), source = 0    )
-    allocate( mesh%ETri (mesh%nE,   2          ), source = 0    )
-    allocate( mesh%TriE (mesh%nTri, 3          ), source = 0    )
-    allocate( mesh%EBI  (mesh%nE               ), source = 0    )
-    allocate( mesh%EA   (mesh%nE               ), source = 0._dp)
+    call allocate_dist_shared( mesh%E   , mesh%wE   , [1, mesh%nE  ], [1, 2          ])
+    call allocate_dist_shared( mesh%VE  , mesh%wVE  , [1, mesh%nV  ], [1, mesh%nC_mem])
+    call allocate_dist_shared( mesh%EV  , mesh%wEV  , [1, mesh%nE  ], [1, 4          ])
+    call allocate_dist_shared( mesh%ETri, mesh%wETri, [1, mesh%nE  ], [1, 2          ])
+    call allocate_dist_shared( mesh%TriE, mesh%wTriE, [1, mesh%nTri], [1, 3          ])
+    call allocate_dist_shared( mesh%EBI , mesh%wEBI , [1, mesh%nE  ]                  )
+    call allocate_dist_shared( mesh%EA  , mesh%wEA  , [1, mesh%nE  ]                  )
+
+    if (par%node_primary) then
 
     ei = 0
     do vi = 1, mesh%nV
@@ -195,10 +197,13 @@ contains
       end do
     end do
 
+    end if
+    call sync
+
     call calc_edge_areas( mesh)
 
     ! Finalise routine path
-    call finalise_routine( routine_name)
+    call finalise_routine( routine_name, n_extra_MPI_windows_expected = 7)
 
   end subroutine construct_mesh_edges
 
@@ -249,6 +254,8 @@ contains
     ! Add routine to path
     call init_routine( routine_name)
 
+    if (par%node_primary) then
+
     do ei = 1, mesh%nE
 
       vi  = mesh%EV( ei,1)
@@ -273,6 +280,9 @@ contains
       end if
 
     end do
+
+    end if
+    call sync
 
     ! Finalise routine path
     call finalise_routine( routine_name)

--- a/src/UPSY/mesh/mesh_parallelisation.f90
+++ b/src/UPSY/mesh/mesh_parallelisation.f90
@@ -167,7 +167,7 @@ contains
     ! call print_parallelisation_info( mesh)
 
     ! Finalise routine path
-    call finalise_routine( routine_name, n_extra_MPI_windows_expected = 12)
+    call finalise_routine( routine_name, n_extra_MPI_windows_expected = 18)
 
   end subroutine setup_mesh_parallelisation
 

--- a/src/UPSY/mesh/mesh_parallelisation.f90
+++ b/src/UPSY/mesh/mesh_parallelisation.f90
@@ -80,19 +80,19 @@ contains
     ! Add routine to path
     call init_routine( routine_name)
 
-    if (allocated( mesh%V_owning_process  )) deallocate( mesh%V_owning_process  )
-    if (allocated( mesh%V_owning_node     )) deallocate( mesh%V_owning_node     )
-    if (allocated( mesh%Tri_owning_process)) deallocate( mesh%Tri_owning_process)
-    if (allocated( mesh%Tri_owning_node   )) deallocate( mesh%Tri_owning_node   )
-    if (allocated( mesh%E_owning_process  )) deallocate( mesh%E_owning_process  )
-    if (allocated( mesh%E_owning_node     )) deallocate( mesh%E_owning_node     )
+    if (associated( mesh%V_owning_process  )) call deallocate_dist_shared( mesh%V_owning_process  , mesh%wV_owning_process  )
+    if (associated( mesh%V_owning_node     )) call deallocate_dist_shared( mesh%V_owning_node     , mesh%wV_owning_node     )
+    if (associated( mesh%Tri_owning_process)) call deallocate_dist_shared( mesh%Tri_owning_process, mesh%wTri_owning_process)
+    if (associated( mesh%Tri_owning_node   )) call deallocate_dist_shared( mesh%Tri_owning_node   , mesh%wTri_owning_node   )
+    if (associated( mesh%E_owning_process  )) call deallocate_dist_shared( mesh%E_owning_process  , mesh%wE_owning_process  )
+    if (associated( mesh%E_owning_node     )) call deallocate_dist_shared( mesh%E_owning_node     , mesh%wE_owning_node     )
 
-    allocate( mesh%V_owning_process  ( mesh%nV))
-    allocate( mesh%V_owning_node     ( mesh%nV))
-    allocate( mesh%Tri_owning_process( mesh%nTri))
-    allocate( mesh%Tri_owning_node   ( mesh%nTri))
-    allocate( mesh%E_owning_process  ( mesh%nE))
-    allocate( mesh%E_owning_node     ( mesh%nE))
+    call allocate_dist_shared( mesh%V_owning_process  , mesh%wV_owning_process  , [1, mesh%nV  ])
+    call allocate_dist_shared( mesh%V_owning_node     , mesh%wV_owning_node     , [1, mesh%nV  ])
+    call allocate_dist_shared( mesh%Tri_owning_process, mesh%wTri_owning_process, [1, mesh%nTri])
+    call allocate_dist_shared( mesh%Tri_owning_node   , mesh%wTri_owning_node   , [1, mesh%nTri])
+    call allocate_dist_shared( mesh%E_owning_process  , mesh%wE_owning_process  , [1, mesh%nE  ])
+    call allocate_dist_shared( mesh%E_owning_node     , mesh%wE_owning_node     , [1, mesh%nE  ])
 
     if (.not. present( mask_active_a_tot)) then
       ! Divide all vertices equally over the processes

--- a/src/UPSY/mesh/mesh_secondary.f90
+++ b/src/UPSY/mesh/mesh_secondary.f90
@@ -20,6 +20,7 @@ MODULE mesh_secondary
   use mesh_Voronoi, only: construct_Voronoi_mesh
   use mesh_parallelisation, only: setup_mesh_parallelisation
   use mpi_f08, only: MPI_ALLREDUCE, MPI_INTEGER, MPI_MIN, MPI_MAX
+  use mpi_distributed_shared_memory, only: deallocate_dist_shared, allocate_dist_shared
 
   IMPLICIT NONE
 
@@ -65,7 +66,7 @@ CONTAINS
     CALL setup_mesh_parallelisation(            mesh, mask_active_a_tot, mask_active_b_tot)
 
     ! Finalise routine path
-    CALL finalise_routine( routine_name, n_extra_MPI_windows_expected = 12)
+    CALL finalise_routine( routine_name, n_extra_MPI_windows_expected = 52)
 
   END SUBROUTINE calc_all_secondary_mesh_data
 
@@ -82,9 +83,10 @@ CONTAINS
     ! Add routine to path
     call init_routine( routine_name)
 
-    ! Allocate clean memory
-    if (allocated( mesh%TriBI)) deallocate( mesh%TriBI)
-    allocate( mesh%TriBI( mesh%nTri), source = 0)
+    if (associated( mesh%TriBI)) call deallocate_dist_shared( mesh%TriBI, mesh%wTriBI)
+    call allocate_dist_shared( mesh%TriBI, mesh%wTriBI, [1, mesh%nTri])
+
+    if (par%node_primary) then
 
     ! Locate the southwest corner
     vi_SW = 0
@@ -129,8 +131,11 @@ CONTAINS
     if (mesh%niTri( vi_NE) == 1) mesh%TriBI( mesh%iTri( vi_NE,1)) = 2
     if (mesh%niTri( vi_NW) == 1) mesh%TriBI( mesh%iTri( vi_NW,1)) = 8
 
+    end if
+    call sync
+
     ! Finalise routine path
-    call finalise_routine( routine_name)
+    call finalise_routine( routine_name, n_extra_MPI_windows_expected = 1)
 
   end subroutine calc_TriBI
 
@@ -154,10 +159,10 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    ! Allocate clean memory
-    IF (ALLOCATED( mesh%A)) DEALLOCATE( mesh%A)
-    ALLOCATE( mesh%A( mesh%nV), source = 0._dp)
+    if (associated( mesh%A)) call deallocate_dist_shared( mesh%A, mesh%wA)
+    call allocate_dist_shared( mesh%A, mesh%wA, [1, mesh%nV])
 
+    if (par%node_primary) then
     DO vi = 1, mesh%nV
 
       CALL calc_Voronoi_cell( mesh, vi, 0._dp, Vor, Vor_vi, Vor_ti, nVor)
@@ -173,6 +178,8 @@ CONTAINS
       END DO
 
     END DO
+    end if
+    call sync
 
     ! Check if everything went alright
     A_tot_Vor = SUM( mesh%A)
@@ -181,7 +188,7 @@ CONTAINS
     IF (Aerr > 0.0001_dp .AND. par%primary) CALL warning('sum of Voronoi cell areas doesnt match square area of mesh! (error of {dp_01} %)', dp_01 = Aerr)
 
     ! Finalise routine path
-    CALL finalise_routine( routine_name)
+    CALL finalise_routine( routine_name, n_extra_MPI_windows_expected = 1)
 
   END SUBROUTINE calc_Voronoi_cell_areas
 
@@ -207,10 +214,10 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    ! Allocate clean memory
-    IF (ALLOCATED( mesh%VorGC)) DEALLOCATE( mesh%VorGC)
-    ALLOCATE( mesh%VorGC( mesh%nV,2), source = 0._dp)
+    if (associated( mesh%VorGC)) call deallocate_dist_shared( mesh%VorGC, mesh%wVorGC)
+    call allocate_dist_shared( mesh%VorGC, mesh%wVorGC, [1, mesh%nV], [1, 2])
 
+    if (par%node_primary) then
     DO vi = 1, mesh%nV
 
       CALL calc_Voronoi_cell( mesh, vi, 0._dp, Vor, Vor_vi, Vor_ti, nVor)
@@ -237,9 +244,11 @@ CONTAINS
       mesh%VorGC( vi,:) = [LI_mxydx / mesh%A( vi), LI_xydy / mesh%A( vi)]
 
     END DO ! DO vi = 1, mesh%nV
+    end if
+    call sync
 
     ! Finalise routine path
-    CALL finalise_routine( routine_name)
+    CALL finalise_routine( routine_name, n_extra_MPI_windows_expected = 1)
 
   END SUBROUTINE calc_Voronoi_cell_geometric_centres
 
@@ -257,11 +266,12 @@ CONTAINS
     ! Add routine to path
     call init_routine( routine_name)
 
-    ! Allocate clean memory
-    if (allocated( mesh%Cw)) deallocate( mesh%Cw)
-    if (allocated( mesh%TriCw)) deallocate( mesh%TriCw)
-    allocate( mesh%Cw( mesh%nV, mesh%nC_mem), source = 0._dp)
-    allocate( mesh%TriCw( mesh%nTri, 3), source = 0._dp)
+    if (associated( mesh%Cw   )) call deallocate_dist_shared( mesh%Cw   , mesh%wCw   )
+    if (associated( mesh%TriCw)) call deallocate_dist_shared( mesh%TriCw, mesh%wTriCw)
+    call allocate_dist_shared( mesh%Cw   , mesh%wCw   , [1, mesh%nV  ], [1, mesh%nC_mem])
+    call allocate_dist_shared( mesh%TriCw, mesh%wTriCw, [1, mesh%nTri], [1, 3          ])
+
+    if (par%node_primary) then
 
     do vi = 1, mesh%nV
       do ci = 1, mesh%nC( vi)
@@ -292,8 +302,11 @@ CONTAINS
       end do ! DO ci = 1, 3
     end do ! DO t1 = 1, mesh%nTri
 
+    end if
+    call sync
+
     ! Finalise routine path
-    call finalise_routine( routine_name)
+    call finalise_routine( routine_name, n_extra_MPI_windows_expected = 2)
 
   end subroutine calc_connection_widths
 
@@ -310,19 +323,21 @@ CONTAINS
     ! Add routine to path
     call init_routine( routine_name)
 
-    ! Allocate clean memory
-    if (allocated( mesh%D_x)) deallocate( mesh%D_x)
-    if (allocated( mesh%D_y)) deallocate( mesh%D_y)
-    if (allocated( mesh%D)) deallocate( mesh%D)
-    if (allocated( mesh%TriD_x)) deallocate( mesh%TriD_x)
-    if (allocated( mesh%TriD_y)) deallocate( mesh%TriD_y)
-    if (allocated( mesh%TriD)) deallocate( mesh%TriD)
-    allocate( mesh%D_x( mesh%nV, mesh%nC_mem), source = 0._dp)
-    allocate( mesh%D_y( mesh%nV, mesh%nC_mem), source = 0._dp)
-    allocate( mesh%D( mesh%nV, mesh%nC_mem), source = 0._dp)
-    allocate( mesh%TriD_x( mesh%nTri, 3), source = 0._dp)
-    allocate( mesh%TriD_y( mesh%nTri, 3), source = 0._dp)
-    allocate( mesh%TriD( mesh%nTri, 3), source = 0._dp)
+    if (associated( mesh%D     )) call deallocate_dist_shared( mesh%D     , mesh%wD     )
+    if (associated( mesh%D_x   )) call deallocate_dist_shared( mesh%D_x   , mesh%wD_x   )
+    if (associated( mesh%D_y   )) call deallocate_dist_shared( mesh%D_x   , mesh%wD_y   )
+    if (associated( mesh%TriD  )) call deallocate_dist_shared( mesh%TriD  , mesh%wTriD  )
+    if (associated( mesh%TriD_x)) call deallocate_dist_shared( mesh%TriD_x, mesh%wTriD_x)
+    if (associated( mesh%TriD_y)) call deallocate_dist_shared( mesh%TriD_x, mesh%wTriD_y)
+
+    call allocate_dist_shared( mesh%D     , mesh%wD     , [1, mesh%nV  ], [1, mesh%nC_mem])
+    call allocate_dist_shared( mesh%D_x   , mesh%wD_x   , [1, mesh%nV  ], [1, mesh%nC_mem])
+    call allocate_dist_shared( mesh%D_y   , mesh%wD_y   , [1, mesh%nV  ], [1, mesh%nC_mem])
+    call allocate_dist_shared( mesh%TriD  , mesh%wTriD  , [1, mesh%nTri], [1, 3])
+    call allocate_dist_shared( mesh%TriD_x, mesh%wTriD_x, [1, mesh%nTri], [1, 3])
+    call allocate_dist_shared( mesh%TriD_y, mesh%wTriD_y, [1, mesh%nTri], [1, 3])
+
+    if (par%node_primary) then
 
     ! Vertex-vertex connections
     do vi = 1, mesh%nV
@@ -360,8 +375,11 @@ CONTAINS
       end do
     end do
 
+    end if
+    call sync
+
     ! Finalise routine path
-    call finalise_routine( routine_name)
+    call finalise_routine( routine_name, n_extra_MPI_windows_expected = 6)
 
   end subroutine calc_connection_lengths
 
@@ -380,9 +398,10 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    ! Allocate clean memory
-    IF (ALLOCATED( mesh%TriA)) DEALLOCATE( mesh%TriA)
-    ALLOCATE( mesh%TriA( mesh%nTri), source = 0._dp)
+    if (associated( mesh%TriA)) call deallocate_dist_shared( mesh%TriA, mesh%wTriA)
+    call allocate_dist_shared( mesh%TriA, mesh%wTriA, [1, mesh%nTri])
+
+    if (par%node_primary) then
 
     DO ti = 1, mesh%nTri
       pa = mesh%V( mesh%Tri( ti,1),:)
@@ -391,8 +410,11 @@ CONTAINS
       mesh%TriA( ti) = triangle_area( pa, pb, pc)
     END DO
 
+    end if
+    call sync
+
     ! Finalise routine path
-    CALL finalise_routine( routine_name)
+    CALL finalise_routine( routine_name, n_extra_MPI_windows_expected = 1)
 
   END SUBROUTINE calc_triangle_areas
 
@@ -410,9 +432,10 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    ! Allocate clean memory
-    IF (ALLOCATED( mesh%R)) DEALLOCATE( mesh%R)
-    ALLOCATE( mesh%R( mesh%nV), source = 0._dp)
+    if (associated( mesh%R)) call deallocate_dist_shared( mesh%R, mesh%wR)
+    call allocate_dist_shared( mesh%R, mesh%wR, [1, mesh%nV])
+
+    if (par%node_primary) then
 
     ! Initialise with large value
     mesh%R = mesh%xmax - mesh%xmin
@@ -424,8 +447,11 @@ CONTAINS
       END DO
     END DO
 
+    end if
+    call sync
+
     ! Finalise routine path
-    CALL finalise_routine( routine_name)
+    CALL finalise_routine( routine_name, n_extra_MPI_windows_expected = 1)
 
   END SUBROUTINE calc_mesh_resolution
 
@@ -444,9 +470,10 @@ CONTAINS
     ! Add routine to path
     CALL init_routine( routine_name)
 
-    ! Allocate clean memory
-    IF (ALLOCATED( mesh%TriGC)) DEALLOCATE( mesh%TriGC)
-    ALLOCATE( mesh%TriGC( mesh%nTri,2), source = 0._dp)
+    if (associated( mesh%TriGC)) call deallocate_dist_shared( mesh%TriGC, mesh%wTriGC)
+    call allocate_dist_shared( mesh%TriGC, mesh%wTriGC, [1, mesh%nTri], [1, 2])
+
+    if (par%node_primary) then
 
     DO ti = 1, mesh%nTri
 
@@ -462,8 +489,11 @@ CONTAINS
 
     END DO
 
+    end if
+    call sync
+
     ! Finalise routine path
-    CALL finalise_routine( routine_name)
+    CALL finalise_routine( routine_name, n_extra_MPI_windows_expected = 1)
 
   END SUBROUTINE calc_triangle_geometric_centres
 
@@ -489,19 +519,22 @@ CONTAINS
     mesh%phi_M       = phi_M
     mesh%beta_stereo = beta_stereo
 
-    ! Allocate clean memory
-    IF (ALLOCATED( mesh%lon)) DEALLOCATE( mesh%lon)
-    ALLOCATE( mesh%lon( mesh%nV), source = 0._dp)
-    IF (ALLOCATED( mesh%lat)) DEALLOCATE( mesh%lat)
-    ALLOCATE( mesh%lat( mesh%nV), source = 0._dp)
+    if (associated( mesh%lon)) call deallocate_dist_shared( mesh%lon, mesh%wlon)
+    if (associated( mesh%lat)) call deallocate_dist_shared( mesh%lat, mesh%wlat)
+    call allocate_dist_shared( mesh%lon, mesh%wlon, [1, mesh%nV])
+    call allocate_dist_shared( mesh%lat, mesh%wlat, [1, mesh%nV])
+
+    if (par%node_primary) then
 
     DO vi = 1, mesh%nV
       CALL inverse_oblique_sg_projection( mesh%V( vi,1), mesh%V( vi,2), lambda_M, phi_M, beta_stereo, mesh%lon( vi), mesh%lat( vi))
     END DO
-    CALL sync
+
+    end if
+    call sync
 
     ! Finalise routine path
-    CALL finalise_routine( routine_name)
+    CALL finalise_routine( routine_name, n_extra_MPI_windows_expected = 2)
 
   END SUBROUTINE calc_lonlat
 

--- a/src/UPSY/mesh/remapping/remapping_mesh_to_mesh.f90
+++ b/src/UPSY/mesh/remapping/remapping_mesh_to_mesh.f90
@@ -662,7 +662,7 @@ contains
     call init_routine( routine_name)
 
     ! Safety
-    if (.not. allocated( mesh_src%vi2n)) then
+    if (.not. associated( mesh_src%vi2n)) then
       call crash('matrix operators for mesh "' // trim( mesh_src%name) // '" have not been calculated!')
     end if
 
@@ -711,7 +711,7 @@ contains
     call init_routine( routine_name)
 
     ! Safety
-    if (.not. allocated( mesh_src%vi2n)) then
+    if (.not. associated( mesh_src%vi2n)) then
       call crash('matrix operators for mesh "' // trim( mesh_src%name) // '" have not been calculated!')
     end if
 

--- a/src/UPSY/types/mesh_types.f90
+++ b/src/UPSY/types/mesh_types.f90
@@ -126,21 +126,24 @@ module mesh_types
     integer,  dimension(:,:  ), allocatable :: VVor                          !           For each regular vertex, the indices of the Voronoi vertices spanning its Voronoi cell
 
     ! Parallelisation ranges
-    integer                                 :: vi1, vi2, nV_loc              ! Each process "owns" nV_loc    vertices  vi1      - vi2     , so that nV_loc    = vi2      + 1 - vi1
-    integer                                 :: ti1, ti2, nTri_loc            ! Each process "owns" nTri_loc  triangles ti1      - ti2     , so that nTri_loc  = ti2      + 1 - ti1
-    integer                                 :: ei1, ei2, nE_loc              ! Each process "owns" nE_loc    edges     ei1      - ei2     , so that nE_loc    = ei2      + 1 - ei1
+    integer                                         :: vi1, vi2, nV_loc              ! Each process "owns" nV_loc    vertices  vi1      - vi2     , so that nV_loc    = vi2      + 1 - vi1
+    integer                                         :: ti1, ti2, nTri_loc            ! Each process "owns" nTri_loc  triangles ti1      - ti2     , so that nTri_loc  = ti2      + 1 - ti1
+    integer                                         :: ei1, ei2, nE_loc              ! Each process "owns" nE_loc    edges     ei1      - ei2     , so that nE_loc    = ei2      + 1 - ei1
 
-    integer,  dimension(:    ), allocatable :: V_owning_process              !           Which process owns each vertex
-    integer,  dimension(:    ), allocatable :: Tri_owning_process            !           Which process owns each triangle
-    integer,  dimension(:    ), allocatable :: E_owning_process              !           Which process owns each edge
-    integer,  dimension(:    ), allocatable :: V_owning_node                 !           Which node owns each vertex
-    integer,  dimension(:    ), allocatable :: Tri_owning_node               !           Which node owns each triangle
-    integer,  dimension(:    ), allocatable :: E_owning_node                 !           Which node owns each edge
+    integer,  dimension(:    ), contiguous, pointer :: V_owning_process   => null()  ! Which process owns each vertex
+    integer,  dimension(:    ), contiguous, pointer :: Tri_owning_process => null()  ! Which process owns each triangle
+    integer,  dimension(:    ), contiguous, pointer :: E_owning_process   => null()  ! Which process owns each edge
+    integer,  dimension(:    ), contiguous, pointer :: V_owning_node      => null()  ! Which node owns each vertex
+    integer,  dimension(:    ), contiguous, pointer :: Tri_owning_node    => null()  ! Which node owns each triangle
+    integer,  dimension(:    ), contiguous, pointer :: E_owning_node      => null()  ! Which node owns each edge
+    type(MPI_WIN) :: wV_owning_process, wTri_owning_process, wE_owning_process
+    type(MPI_WIN) :: wV_owning_node, wTri_owning_node, wE_owning_node
 
-    type(type_par_arr_info)                 :: pai_V                         ! Parallelisation info for vertex-based fields
-    type(type_par_arr_info)                 :: pai_Tri                       ! Parallelisation info for triangle-based fields
-    type(type_par_arr_info)                 :: pai_E                         ! Parallelisation info for edge-based fields
+    type(type_par_arr_info)                         :: pai_V                          ! Parallelisation info for vertex-based fields
+    type(type_par_arr_info)                         :: pai_Tri                        ! Parallelisation info for triangle-based fields
+    type(type_par_arr_info)                         :: pai_E                          ! Parallelisation info for edge-based fields
 
+    ! Buffer shared memory
     real(dp), dimension(:    ), contiguous, pointer :: buffer1_d_a_nih  => null()     ! Pre-allocated buffer memory on the a-grid (vertices)
     real(dp), dimension(:    ), contiguous, pointer :: buffer2_d_a_nih  => null()
     real(dp), dimension(:,:  ), contiguous, pointer :: buffer1_d_ak_nih => null()
@@ -297,7 +300,29 @@ contains
 
     type(type_mesh) :: mesh
 
-    ! Deallocate grid-cell-to-matrix-row translation tables
+    ! Parallelisation ranges
+    if (associated( mesh%V_owning_process  )) call deallocate_dist_shared( mesh%V_owning_process  , mesh%wV_owning_process  )
+    if (associated( mesh%Tri_owning_process)) call deallocate_dist_shared( mesh%Tri_owning_process, mesh%wTri_owning_process)
+    if (associated( mesh%E_owning_process  )) call deallocate_dist_shared( mesh%E_owning_process  , mesh%wE_owning_process  )
+    if (associated( mesh%V_owning_node     )) call deallocate_dist_shared( mesh%V_owning_node     , mesh%wV_owning_node     )
+    if (associated( mesh%Tri_owning_node   )) call deallocate_dist_shared( mesh%Tri_owning_node   , mesh%wTri_owning_node   )
+    if (associated( mesh%E_owning_node     )) call deallocate_dist_shared( mesh%E_owning_node     , mesh%wE_owning_node     )
+
+    ! Buffer shared memory
+    if (associated( mesh%buffer1_d_a_nih )) call deallocate_dist_shared( mesh%buffer1_d_a_nih , mesh%wbuffer1_d_a_nih )
+    if (associated( mesh%buffer2_d_a_nih )) call deallocate_dist_shared( mesh%buffer2_d_a_nih , mesh%wbuffer2_d_a_nih )
+    if (associated( mesh%buffer1_d_ak_nih)) call deallocate_dist_shared( mesh%buffer1_d_ak_nih, mesh%wbuffer1_d_ak_nih)
+    if (associated( mesh%buffer2_d_ak_nih)) call deallocate_dist_shared( mesh%buffer2_d_ak_nih, mesh%wbuffer2_d_ak_nih)
+    if (associated( mesh%buffer1_d_b_nih )) call deallocate_dist_shared( mesh%buffer1_d_b_nih , mesh%wbuffer1_d_b_nih )
+    if (associated( mesh%buffer2_d_b_nih )) call deallocate_dist_shared( mesh%buffer2_d_b_nih , mesh%wbuffer2_d_b_nih )
+    if (associated( mesh%buffer1_d_bk_nih)) call deallocate_dist_shared( mesh%buffer1_d_bk_nih, mesh%wbuffer1_d_bk_nih)
+    if (associated( mesh%buffer2_d_bk_nih)) call deallocate_dist_shared( mesh%buffer2_d_bk_nih, mesh%wbuffer2_d_bk_nih)
+    if (associated( mesh%buffer1_d_c_nih )) call deallocate_dist_shared( mesh%buffer1_d_c_nih , mesh%wbuffer1_d_c_nih )
+    if (associated( mesh%buffer2_d_c_nih )) call deallocate_dist_shared( mesh%buffer2_d_c_nih , mesh%wbuffer2_d_c_nih )
+    if (associated( mesh%buffer1_d_ck_nih)) call deallocate_dist_shared( mesh%buffer1_d_ck_nih, mesh%wbuffer1_d_ck_nih)
+    if (associated( mesh%buffer2_d_ck_nih)) call deallocate_dist_shared( mesh%buffer2_d_ck_nih, mesh%wbuffer2_d_ck_nih)
+
+    ! Grid-cell-to-matrix-row translation tables
 
     ! a-grid (vertices)
     if (associated( mesh%n2vi    )) call deallocate_dist_shared( mesh%n2vi    , mesh%wn2vi    )
@@ -340,20 +365,6 @@ contains
     if (associated( mesh%eikuv2n )) call deallocate_dist_shared( mesh%eikuv2n , mesh%weikuv2n )
     if (associated( mesh%eiks2n  )) call deallocate_dist_shared( mesh%eiks2n  , mesh%weiks2n  )
     if (associated( mesh%eiksuv2n)) call deallocate_dist_shared( mesh%eiksuv2n, mesh%weiksuv2n)
-
-    ! Deallocate buffer shared memory
-    if (associated( mesh%buffer1_d_a_nih )) call deallocate_dist_shared( mesh%buffer1_d_a_nih , mesh%wbuffer1_d_a_nih )
-    if (associated( mesh%buffer2_d_a_nih )) call deallocate_dist_shared( mesh%buffer2_d_a_nih , mesh%wbuffer2_d_a_nih )
-    if (associated( mesh%buffer1_d_ak_nih)) call deallocate_dist_shared( mesh%buffer1_d_ak_nih, mesh%wbuffer1_d_ak_nih)
-    if (associated( mesh%buffer2_d_ak_nih)) call deallocate_dist_shared( mesh%buffer2_d_ak_nih, mesh%wbuffer2_d_ak_nih)
-    if (associated( mesh%buffer1_d_b_nih )) call deallocate_dist_shared( mesh%buffer1_d_b_nih , mesh%wbuffer1_d_b_nih )
-    if (associated( mesh%buffer2_d_b_nih )) call deallocate_dist_shared( mesh%buffer2_d_b_nih , mesh%wbuffer2_d_b_nih )
-    if (associated( mesh%buffer1_d_bk_nih)) call deallocate_dist_shared( mesh%buffer1_d_bk_nih, mesh%wbuffer1_d_bk_nih)
-    if (associated( mesh%buffer2_d_bk_nih)) call deallocate_dist_shared( mesh%buffer2_d_bk_nih, mesh%wbuffer2_d_bk_nih)
-    if (associated( mesh%buffer1_d_c_nih )) call deallocate_dist_shared( mesh%buffer1_d_c_nih , mesh%wbuffer1_d_c_nih )
-    if (associated( mesh%buffer2_d_c_nih )) call deallocate_dist_shared( mesh%buffer2_d_c_nih , mesh%wbuffer2_d_c_nih )
-    if (associated( mesh%buffer1_d_ck_nih)) call deallocate_dist_shared( mesh%buffer1_d_ck_nih, mesh%wbuffer1_d_ck_nih)
-    if (associated( mesh%buffer2_d_ck_nih)) call deallocate_dist_shared( mesh%buffer2_d_ck_nih, mesh%wbuffer2_d_ck_nih)
 
   end subroutine finalise
 

--- a/src/UPSY/types/mesh_types.f90
+++ b/src/UPSY/types/mesh_types.f90
@@ -82,48 +82,54 @@ module mesh_types
   ! =======================================================================================
 
     ! Derived geometry data
-    real(dp), dimension(:    ), allocatable :: A                             ! [m^2]     The area             of each vertex's Voronoi cell
-    real(dp), dimension(:,:  ), allocatable :: VorGC                         ! [m]       The geometric centre of each vertex's Voronoi cell
-    real(dp), dimension(:    ), allocatable :: R                             ! [m]       The resolution of each vertex (defined as distance to nearest neighbour)
-    real(dp), dimension(:,:  ), allocatable :: Cw                            ! [m]       The width of all vertex connections (= length of the shared Voronoi cell edge)
-    real(dp), dimension(:,:  ), allocatable :: D_x                           ! [m]       x-component of vertex-vertex connections
-    real(dp), dimension(:,:  ), allocatable :: D_y                           ! [m]       y-component of vertex-vertex connections
-    real(dp), dimension(:,:  ), allocatable :: D                             ! [m]       absolute distance of vertex-vertex connections
-    real(dp), dimension(:,:  ), allocatable :: TriCw                         ! [m]       The width of all triangle connections (= shared triangle edge)
-    integer,  dimension(:    ), allocatable :: TriBI                         ! [0-8]     Each triangle's border index; 0 = free, 1 = north, 2 = northeast, ..., 8 = northwest
-    real(dp), dimension(:,:  ), allocatable :: TriGC                         ! [m]       The X,Y-coordinates of each triangle's geometric centre
-    real(dp), dimension(:    ), allocatable :: TriA                          ! [m^2]     The area of each triangle
-    real(dp), dimension(:,:  ), allocatable :: TriD_x                        ! [m]       x-component of triangle-triangle connections
-    real(dp), dimension(:,:  ), allocatable :: TriD_y                        ! [m]       y-component of triangle-triangle connections
-    real(dp), dimension(:,:  ), allocatable :: TriD                          ! [m]       absolute distance of triangle-triangle connections
+    real(dp), dimension(:    ), contiguous, pointer :: A       => null()             ! [m^2]     The area             of each vertex's Voronoi cell
+    real(dp), dimension(:,:  ), contiguous, pointer :: VorGC   => null()             ! [m]       The geometric centre of each vertex's Voronoi cell
+    real(dp), dimension(:    ), contiguous, pointer :: R       => null()             ! [m]       The resolution of each vertex (defined as distance to nearest neighbour)
+    real(dp), dimension(:,:  ), contiguous, pointer :: Cw      => null()             ! [m]       The width of all vertex connections (= length of the shared Voronoi cell edge)
+    real(dp), dimension(:,:  ), contiguous, pointer :: D_x     => null()             ! [m]       x-component of vertex-vertex connections
+    real(dp), dimension(:,:  ), contiguous, pointer :: D_y     => null()             ! [m]       y-component of vertex-vertex connections
+    real(dp), dimension(:,:  ), contiguous, pointer :: D       => null()             ! [m]       absolute distance of vertex-vertex connections
+    real(dp), dimension(:,:  ), contiguous, pointer :: TriCw   => null()             ! [m]       The width of all triangle connections (= shared triangle edge)
+    integer,  dimension(:    ), contiguous, pointer :: TriBI   => null()             ! [0-8]     Each triangle's border index; 0 = free, 1 = north, 2 = northeast, ..., 8 = northwest
+    real(dp), dimension(:,:  ), contiguous, pointer :: TriGC   => null()             ! [m]       The X,Y-coordinates of each triangle's geometric centre
+    real(dp), dimension(:    ), contiguous, pointer :: TriA    => null()             ! [m^2]     The area of each triangle
+    real(dp), dimension(:,:  ), contiguous, pointer :: TriD_x  => null()             ! [m]       x-component of triangle-triangle connections
+    real(dp), dimension(:,:  ), contiguous, pointer :: TriD_y  => null()             ! [m]       y-component of triangle-triangle connections
+    real(dp), dimension(:,:  ), contiguous, pointer :: TriD    => null()             ! [m]       absolute distance of triangle-triangle connections
+    type(MPI_WIN) :: wA, wVorGC, wR, wCw, wD_x, wD_y, wD, wTriCw
+    type(MPI_WIN) :: wTriBI, wTriGC, wTriA, wTriD_x, wTriD_y, wTriD
 
     ! lon/lat coordinates
-    real(dp), dimension(:    ), allocatable :: lat                           ! [degrees north] Latitude  of each vertex
-    real(dp), dimension(:    ), allocatable :: lon                           ! [degrees east]  Longitude of each vertex
+    real(dp), dimension(:    ), contiguous, pointer :: lat     => null()             ! [degrees north] Latitude  of each vertex
+    real(dp), dimension(:    ), contiguous, pointer :: lon     => null()             ! [degrees east]  Longitude of each vertex
+    type(MPI_WIN) :: wlon, wlat
 
     ! Edges (c-grid)
-    integer                                 :: nE                            !           Number of edges
-    real(dp), dimension(:,:  ), allocatable :: E                             ! [m]       The x,y-coordinates of all the edges
-    integer,  dimension(:,:  ), allocatable :: VE                            !           Vertex-to-edge connectivity list
-    integer,  dimension(:,:  ), allocatable :: EV                            !           Edge-to-vertex connectivity list
-    integer,  dimension(:,:  ), allocatable :: ETri                          !           Edge-to-triangle connectivity list
-    integer,  dimension(:,:  ), allocatable :: TriE                          !           Triangle-to-edge connectivity list (order of TriC, across from 1st, 2nd, 3rd vertex)
-    integer,  dimension(:    ), allocatable :: EBI                           ! [0-8]     Each edge's border index; 0 = free, 1 = north, 2 = northeast, ..., 8 = northwest
-    real(dp), dimension(:    ), allocatable :: EA                            ! [m^2]     Area of each edge's "cell"
+    integer                                         :: nE                            !           Number of edges
+    real(dp), dimension(:,:  ), contiguous, pointer :: E       => null()             ! [m]       The x,y-coordinates of all the edges
+    integer,  dimension(:,:  ), contiguous, pointer :: VE      => null()             !           Vertex-to-edge connectivity list
+    integer,  dimension(:,:  ), contiguous, pointer :: EV      => null()             !           Edge-to-vertex connectivity list
+    integer,  dimension(:,:  ), contiguous, pointer :: ETri    => null()             !           Edge-to-triangle connectivity list
+    integer,  dimension(:,:  ), contiguous, pointer :: TriE    => null()             !           Triangle-to-edge connectivity list (order of TriC, across from 1st, 2nd, 3rd vertex)
+    integer,  dimension(:    ), contiguous, pointer :: EBI     => null()             ! [0-8]     Each edge's border index; 0 = free, 1 = north, 2 = northeast, ..., 8 = northwest
+    real(dp), dimension(:    ), contiguous, pointer :: EA      => null()             ! [m^2]     Area of each edge's "cell"
+    type(MPI_WIN) :: wE, wVE, wEV, wETri, wTriE, wEBI, wEA
 
     ! Voronoi mesh
-    integer                                 :: nVor                          !           Total number of Voronoi vertices
-    integer,  dimension(:    ), allocatable :: vi2vori                       !           To which Voronoi vertex (if any) each vertex   corresponds (>0 only for the four corner vertices)
-    integer,  dimension(:    ), allocatable :: ti2vori                       !           To which Voronoi vertex (if any) each triangle corresponds (>0 always)
-    integer,  dimension(:    ), allocatable :: ei2vori                       !           To which Voronoi vertex (if any) each edge     corresponds (>0 only for border edges)
-    integer,  dimension(:    ), allocatable :: vori2vi                       !           To which regular vertex (if any) each Voronoi vertex corresponds (vori2vi( vi2vori( vi)) = vi)
-    integer,  dimension(:    ), allocatable :: vori2ti                       !           To which triangle       (if any) each Voronoi vertex corresponds (vori2ti( ti2vori( ti)) = ti)
-    integer,  dimension(:    ), allocatable :: vori2ei                       !           To which edge           (if any) each Voronoi vertex corresponds (vori2ei( ei2vori( ei)) = ei)
-    real(dp), dimension(:,:  ), allocatable :: Vor                           ! [m]       Coordinates of all the Voronoi vertices
-    integer,  dimension(:    ), allocatable :: VornC                         !           Number  of other Voronoi vertices that each Voronoi vertex is connected to (2 for corners, 3 otherwise)
-    integer,  dimension(:,:  ), allocatable :: VorC                          !           Indices of other Voronoi vertices that each Voronoi vertex is connected to
-    integer,  dimension(:    ), allocatable :: nVVor                         !           For each regular vertex, the number of Voronoi vertices spanning its Voronoi cell
-    integer,  dimension(:,:  ), allocatable :: VVor                          !           For each regular vertex, the indices of the Voronoi vertices spanning its Voronoi cell
+    integer                                         :: nVor                          !           Total number of Voronoi vertices
+    integer,  dimension(:    ), contiguous, pointer :: vi2vori => null()             !           To which Voronoi vertex (if any) each vertex   corresponds (>0 only for the four corner vertices)
+    integer,  dimension(:    ), contiguous, pointer :: ti2vori => null()             !           To which Voronoi vertex (if any) each triangle corresponds (>0 always)
+    integer,  dimension(:    ), contiguous, pointer :: ei2vori => null()             !           To which Voronoi vertex (if any) each edge     corresponds (>0 only for border edges)
+    integer,  dimension(:    ), contiguous, pointer :: vori2vi => null()             !           To which regular vertex (if any) each Voronoi vertex corresponds (vori2vi( vi2vori( vi)) = vi)
+    integer,  dimension(:    ), contiguous, pointer :: vori2ti => null()             !           To which triangle       (if any) each Voronoi vertex corresponds (vori2ti( ti2vori( ti)) = ti)
+    integer,  dimension(:    ), contiguous, pointer :: vori2ei => null()             !           To which edge           (if any) each Voronoi vertex corresponds (vori2ei( ei2vori( ei)) = ei)
+    real(dp), dimension(:,:  ), contiguous, pointer :: Vor     => null()             ! [m]       Coordinates of all the Voronoi vertices
+    integer,  dimension(:    ), contiguous, pointer :: VornC   => null()             !           Number  of other Voronoi vertices that each Voronoi vertex is connected to (2 for corners, 3 otherwise)
+    integer,  dimension(:,:  ), contiguous, pointer :: VorC    => null()             !           Indices of other Voronoi vertices that each Voronoi vertex is connected to
+    integer,  dimension(:    ), contiguous, pointer :: nVVor   => null()             !           For each regular vertex, the number of Voronoi vertices spanning its Voronoi cell
+    integer,  dimension(:,:  ), contiguous, pointer :: VVor    => null()             !           For each regular vertex, the indices of the Voronoi vertices spanning its Voronoi cell
+    type(MPI_WIN) :: wvi2vori, wti2vori, wei2vori, wvori2vi, wvori2ti, wvori2ei
+    type(MPI_WIN) :: wVor, wVornC, wVorC, wnVVor, wVVor
 
     ! Parallelisation ranges
     integer                                         :: vi1, vi2, nV_loc              ! Each process "owns" nV_loc    vertices  vi1      - vi2     , so that nV_loc    = vi2      + 1 - vi1
@@ -299,6 +305,48 @@ contains
     !< not captured by automatic finalisation)
 
     type(type_mesh) :: mesh
+
+    ! Derived geometry data
+    if (associated( mesh%A     )) call deallocate_dist_shared( mesh%A     , mesh%wA     )
+    if (associated( mesh%VorGC )) call deallocate_dist_shared( mesh%VorGC , mesh%wVorGC )
+    if (associated( mesh%R     )) call deallocate_dist_shared( mesh%R     , mesh%wR     )
+    if (associated( mesh%Cw    )) call deallocate_dist_shared( mesh%Cw    , mesh%wCw    )
+    if (associated( mesh%D_x   )) call deallocate_dist_shared( mesh%D_x   , mesh%wD_x   )
+    if (associated( mesh%D_y   )) call deallocate_dist_shared( mesh%D_y   , mesh%wD_y   )
+    if (associated( mesh%D     )) call deallocate_dist_shared( mesh%D     , mesh%wD     )
+    if (associated( mesh%TriCw )) call deallocate_dist_shared( mesh%TriCw , mesh%wTriCw )
+    if (associated( mesh%TriBI )) call deallocate_dist_shared( mesh%TriBI , mesh%wTriBI )
+    if (associated( mesh%TriGC )) call deallocate_dist_shared( mesh%TriGC , mesh%wTriGC )
+    if (associated( mesh%TriA  )) call deallocate_dist_shared( mesh%TriA  , mesh%wTriA  )
+    if (associated( mesh%TriD_x)) call deallocate_dist_shared( mesh%TriD_x, mesh%wTriD_x)
+    if (associated( mesh%TriD_y)) call deallocate_dist_shared( mesh%TriD_y, mesh%wTriD_y)
+    if (associated( mesh%TriD  )) call deallocate_dist_shared( mesh%TriD  , mesh%wTriD  )
+
+    ! lon/lat coordinates
+    if (associated( mesh%lat)) call deallocate_dist_shared( mesh%lat, mesh%wlat)
+    if (associated( mesh%lon)) call deallocate_dist_shared( mesh%lon, mesh%wlon)
+
+    ! Edges (c-grid)
+    if (associated( mesh%E   )) call deallocate_dist_shared( mesh%E   , mesh%wE   )
+    if (associated( mesh%VE  )) call deallocate_dist_shared( mesh%VE  , mesh%wVE  )
+    if (associated( mesh%EV  )) call deallocate_dist_shared( mesh%EV  , mesh%wEV  )
+    if (associated( mesh%ETri)) call deallocate_dist_shared( mesh%ETri, mesh%wETri)
+    if (associated( mesh%TriE)) call deallocate_dist_shared( mesh%TriE, mesh%wTriE)
+    if (associated( mesh%EBI )) call deallocate_dist_shared( mesh%EBI , mesh%wEBI )
+    if (associated( mesh%EA  )) call deallocate_dist_shared( mesh%EA  , mesh%wEA  )
+
+    ! Voronoi mesh
+    if (associated( mesh%vi2vori)) call deallocate_dist_shared( mesh%vi2vori, mesh%wvi2vori)
+    if (associated( mesh%ti2vori)) call deallocate_dist_shared( mesh%ti2vori, mesh%wti2vori)
+    if (associated( mesh%ei2vori)) call deallocate_dist_shared( mesh%ei2vori, mesh%wei2vori)
+    if (associated( mesh%vori2vi)) call deallocate_dist_shared( mesh%vori2vi, mesh%wvori2vi)
+    if (associated( mesh%vori2ti)) call deallocate_dist_shared( mesh%vori2ti, mesh%wvori2ti)
+    if (associated( mesh%vori2ei)) call deallocate_dist_shared( mesh%vori2ei, mesh%wvori2ei)
+    if (associated( mesh%Vor    )) call deallocate_dist_shared( mesh%Vor    , mesh%wVor    )
+    if (associated( mesh%VornC  )) call deallocate_dist_shared( mesh%VornC  , mesh%wVornC  )
+    if (associated( mesh%VorC   )) call deallocate_dist_shared( mesh%VorC   , mesh%wVorC   )
+    if (associated( mesh%nVVor  )) call deallocate_dist_shared( mesh%nVVor  , mesh%wnVVor  )
+    if (associated( mesh%VVor   )) call deallocate_dist_shared( mesh%VVor   , mesh%wVVor   )
 
     ! Parallelisation ranges
     if (associated( mesh%V_owning_process  )) call deallocate_dist_shared( mesh%V_owning_process  , mesh%wV_owning_process  )

--- a/src/UPSY/types/mesh_types.f90
+++ b/src/UPSY/types/mesh_types.f90
@@ -163,49 +163,55 @@ module mesh_types
     ! Grid-cell-to-matrix-row translation tables
 
     ! a-grid (vertices)
-    integer                                 :: nna, nnauv, nnak, nnaks, nnakuv, nnaksuv
-    integer,  dimension(:    ), allocatable :: n2vi
-    integer,  dimension(:,:  ), allocatable :: n2viuv
-    integer,  dimension(:,:  ), allocatable :: n2vik
-    integer,  dimension(:,:  ), allocatable :: n2vikuv
-    integer,  dimension(:,:  ), allocatable :: n2viks
-    integer,  dimension(:,:  ), allocatable :: n2viksuv
-    integer,  dimension(:    ), allocatable :: vi2n
-    integer,  dimension(:,:  ), allocatable :: viuv2n
-    integer,  dimension(:,:  ), allocatable :: vik2n
-    integer,  dimension(:,:,:), allocatable :: vikuv2n
-    integer,  dimension(:,:  ), allocatable :: viks2n
-    integer,  dimension(:,:,:), allocatable :: viksuv2n
+    integer                                         :: nna, nnauv, nnak, nnaks, nnakuv, nnaksuv
+    integer,  dimension(:    ), contiguous, pointer :: n2vi     => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2viuv   => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2vik    => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2vikuv  => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2viks   => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2viksuv => null()
+    integer,  dimension(:    ), contiguous, pointer :: vi2n     => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: viuv2n   => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: vik2n    => null()
+    integer,  dimension(:,:,:), contiguous, pointer :: vikuv2n  => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: viks2n   => null()
+    integer,  dimension(:,:,:), contiguous, pointer :: viksuv2n => null()
+    type(MPI_WIN) :: wn2vi, wn2viuv, wn2vik, wn2vikuv, wn2viks, wn2viksuv
+    type(MPI_WIN) :: wvi2n, wviuv2n, wvik2n, wvikuv2n, wviks2n, wviksuv2n
 
     ! b-grid (triangles)
-    integer                                 :: nnb, nnbuv, nnbk, nnbks, nnbkuv, nnbksuv
-    integer,  dimension(:    ), allocatable :: n2ti
-    integer,  dimension(:,:  ), allocatable :: n2tiuv
-    integer,  dimension(:,:  ), allocatable :: n2tik
-    integer,  dimension(:,:  ), allocatable :: n2tikuv
-    integer,  dimension(:,:  ), allocatable :: n2tiks
-    integer,  dimension(:,:  ), allocatable :: n2tiksuv
-    integer,  dimension(:    ), allocatable :: ti2n
-    integer,  dimension(:,:  ), allocatable :: tiuv2n
-    integer,  dimension(:,:  ), allocatable :: tik2n
-    integer,  dimension(:,:,:), allocatable :: tikuv2n
-    integer,  dimension(:,:  ), allocatable :: tiks2n
-    integer,  dimension(:,:,:), allocatable :: tiksuv2n
+    integer                                         :: nnb, nnbuv, nnbk, nnbks, nnbkuv, nnbksuv
+    integer,  dimension(:    ), contiguous, pointer :: n2ti     => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2tiuv   => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2tik    => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2tikuv  => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2tiks   => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2tiksuv => null()
+    integer,  dimension(:    ), contiguous, pointer :: ti2n     => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: tiuv2n   => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: tik2n    => null()
+    integer,  dimension(:,:,:), contiguous, pointer :: tikuv2n  => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: tiks2n   => null()
+    integer,  dimension(:,:,:), contiguous, pointer :: tiksuv2n => null()
+    type(MPI_WIN) :: wn2ti, wn2tiuv, wn2tik, wn2tikuv, wn2tiks, wn2tiksuv
+    type(MPI_WIN) :: wti2n, wtiuv2n, wtik2n, wtikuv2n, wtiks2n, wtiksuv2n
 
     ! c-grid (edges)
-    integer                                 :: nnc, nncuv, nnck, nncks, nnckuv, nncksuv
-    integer,  dimension(:    ), allocatable :: n2ei
-    integer,  dimension(:,:  ), allocatable :: n2eiuv
-    integer,  dimension(:,:  ), allocatable :: n2eik
-    integer,  dimension(:,:  ), allocatable :: n2eikuv
-    integer,  dimension(:,:  ), allocatable :: n2eiks
-    integer,  dimension(:,:  ), allocatable :: n2eiksuv
-    integer,  dimension(:    ), allocatable :: ei2n
-    integer,  dimension(:,:  ), allocatable :: eiuv2n
-    integer,  dimension(:,:  ), allocatable :: eik2n
-    integer,  dimension(:,:,:), allocatable :: eikuv2n
-    integer,  dimension(:,:  ), allocatable :: eiks2n
-    integer,  dimension(:,:,:), allocatable :: eiksuv2n
+    integer                                         :: nnc, nncuv, nnck, nncks, nnckuv, nncksuv
+    integer,  dimension(:    ), contiguous, pointer :: n2ei     => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2eiuv   => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2eik    => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2eikuv  => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2eiks   => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: n2eiksuv => null()
+    integer,  dimension(:    ), contiguous, pointer :: ei2n     => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: eiuv2n   => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: eik2n    => null()
+    integer,  dimension(:,:,:), contiguous, pointer :: eikuv2n  => null()
+    integer,  dimension(:,:  ), contiguous, pointer :: eiks2n   => null()
+    integer,  dimension(:,:,:), contiguous, pointer :: eiksuv2n => null()
+    type(MPI_WIN) :: wn2ei, wn2eiuv, wn2eik, wn2eikuv, wn2eiks, wn2eiksuv
+    type(MPI_WIN) :: wei2n, weiuv2n, weik2n, weikuv2n, weiks2n, weiksuv2n
 
     ! Basic 2-D mapping and gradient operators
 
@@ -291,6 +297,51 @@ contains
 
     type(type_mesh) :: mesh
 
+    ! Deallocate grid-cell-to-matrix-row translation tables
+
+    ! a-grid (vertices)
+    if (associated( mesh%n2vi    )) call deallocate_dist_shared( mesh%n2vi    , mesh%wn2vi    )
+    if (associated( mesh%n2viuv  )) call deallocate_dist_shared( mesh%n2viuv  , mesh%wn2viuv  )
+    if (associated( mesh%n2vik   )) call deallocate_dist_shared( mesh%n2vik   , mesh%wn2vik   )
+    if (associated( mesh%n2vikuv )) call deallocate_dist_shared( mesh%n2vikuv , mesh%wn2vikuv )
+    if (associated( mesh%n2viks  )) call deallocate_dist_shared( mesh%n2viks  , mesh%wn2viks  )
+    if (associated( mesh%n2viksuv)) call deallocate_dist_shared( mesh%n2viksuv, mesh%wn2viksuv)
+    if (associated( mesh%vi2n    )) call deallocate_dist_shared( mesh%vi2n    , mesh%wvi2n    )
+    if (associated( mesh%viuv2n  )) call deallocate_dist_shared( mesh%viuv2n  , mesh%wviuv2n  )
+    if (associated( mesh%vik2n   )) call deallocate_dist_shared( mesh%vik2n   , mesh%wvik2n   )
+    if (associated( mesh%vikuv2n )) call deallocate_dist_shared( mesh%vikuv2n , mesh%wvikuv2n )
+    if (associated( mesh%viks2n  )) call deallocate_dist_shared( mesh%viks2n  , mesh%wviks2n  )
+    if (associated( mesh%viksuv2n)) call deallocate_dist_shared( mesh%viksuv2n, mesh%wviksuv2n)
+
+    ! b-grid (triangles)
+    if (associated( mesh%n2ti    )) call deallocate_dist_shared( mesh%n2ti    , mesh%wn2ti    )
+    if (associated( mesh%n2tiuv  )) call deallocate_dist_shared( mesh%n2tiuv  , mesh%wn2tiuv  )
+    if (associated( mesh%n2tik   )) call deallocate_dist_shared( mesh%n2tik   , mesh%wn2tik   )
+    if (associated( mesh%n2tikuv )) call deallocate_dist_shared( mesh%n2tikuv , mesh%wn2tikuv )
+    if (associated( mesh%n2tiks  )) call deallocate_dist_shared( mesh%n2tiks  , mesh%wn2tiks  )
+    if (associated( mesh%n2tiksuv)) call deallocate_dist_shared( mesh%n2tiksuv, mesh%wn2tiksuv)
+    if (associated( mesh%ti2n    )) call deallocate_dist_shared( mesh%ti2n    , mesh%wti2n    )
+    if (associated( mesh%tiuv2n  )) call deallocate_dist_shared( mesh%tiuv2n  , mesh%wtiuv2n  )
+    if (associated( mesh%tik2n   )) call deallocate_dist_shared( mesh%tik2n   , mesh%wtik2n   )
+    if (associated( mesh%tikuv2n )) call deallocate_dist_shared( mesh%tikuv2n , mesh%wtikuv2n )
+    if (associated( mesh%tiks2n  )) call deallocate_dist_shared( mesh%tiks2n  , mesh%wtiks2n  )
+    if (associated( mesh%tiksuv2n)) call deallocate_dist_shared( mesh%tiksuv2n, mesh%wtiksuv2n)
+
+    ! c-grid (edges)
+    if (associated( mesh%n2ei    )) call deallocate_dist_shared( mesh%n2ei    , mesh%wn2ei    )
+    if (associated( mesh%n2eiuv  )) call deallocate_dist_shared( mesh%n2eiuv  , mesh%wn2eiuv  )
+    if (associated( mesh%n2eik   )) call deallocate_dist_shared( mesh%n2eik   , mesh%wn2eik   )
+    if (associated( mesh%n2eikuv )) call deallocate_dist_shared( mesh%n2eikuv , mesh%wn2eikuv )
+    if (associated( mesh%n2eiks  )) call deallocate_dist_shared( mesh%n2eiks  , mesh%wn2eiks  )
+    if (associated( mesh%n2eiksuv)) call deallocate_dist_shared( mesh%n2eiksuv, mesh%wn2eiksuv)
+    if (associated( mesh%ei2n    )) call deallocate_dist_shared( mesh%ei2n    , mesh%wei2n    )
+    if (associated( mesh%eiuv2n  )) call deallocate_dist_shared( mesh%eiuv2n  , mesh%weiuv2n  )
+    if (associated( mesh%eik2n   )) call deallocate_dist_shared( mesh%eik2n   , mesh%weik2n   )
+    if (associated( mesh%eikuv2n )) call deallocate_dist_shared( mesh%eikuv2n , mesh%weikuv2n )
+    if (associated( mesh%eiks2n  )) call deallocate_dist_shared( mesh%eiks2n  , mesh%weiks2n  )
+    if (associated( mesh%eiksuv2n)) call deallocate_dist_shared( mesh%eiksuv2n, mesh%weiksuv2n)
+
+    ! Deallocate buffer shared memory
     if (associated( mesh%buffer1_d_a_nih )) call deallocate_dist_shared( mesh%buffer1_d_a_nih , mesh%wbuffer1_d_a_nih )
     if (associated( mesh%buffer2_d_a_nih )) call deallocate_dist_shared( mesh%buffer2_d_a_nih , mesh%wbuffer2_d_a_nih )
     if (associated( mesh%buffer1_d_ak_nih)) call deallocate_dist_shared( mesh%buffer1_d_ak_nih, mesh%wbuffer1_d_ak_nih)

--- a/src/UPSY/validation/basic_tests/tests_mesh.f90
+++ b/src/UPSY/validation/basic_tests/tests_mesh.f90
@@ -656,7 +656,7 @@ contains
 
     res = .true.
 
-    if (.not. allocated( mesh%VornC)) return
+    if (.not. associated( mesh%VornC)) return
 
     do vori = 1, mesh%nVor
 


### PR DESCRIPTION
Convert all secondary mesh data fields to node-shared memory. Instead of each process now owning a complete copy of every field, now each node owns a complete copy, stored in shared memory. That means that each process can still access the entire field, but the number of copies (and therefore the amount of memory) is reduced by [number of processes on the node].