### PR TITLE
Extract calculation of u_perp to subroutine

### DIFF
--- a/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_explicit.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_explicit.f90
@@ -21,7 +21,7 @@ module conservation_of_mass_explicit
 
 contains
 
-  subroutine calc_dHi_dt_explicit( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+  subroutine calc_dHi_dt_explicit( mesh, Hi, Hb, SL, u_perp, SMB, BMB, LMB, AMB, &
     fraction_margin, mask_noice, dt, dHi_dt, Hi_tplusdt, divQ, dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     !< Calculate ice thickness rates of change (dH/dt)
     !< Use a time-explicit discretisation scheme for the ice fluxes
@@ -48,26 +48,24 @@ contains
     !     [4] (H( t+dt) - H( t)) / dt = -M_divQ H( t) + m
 
     ! In/output variables:
-    type(type_mesh),                        intent(in   )           :: mesh                  ! [-]       The model mesh
-    type(type_ice_model),                   intent(inout)           :: ice                   ! [-]       The ice model
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: Hi                    ! [m]       Ice thickness at time t
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: Hb                    ! [m]       Bedrock elevation at time t
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: SL                    ! [m]       Water surface elevation at time t
-    real(dp), dimension(mesh%ti1:mesh%ti2), intent(in   )           :: u_vav_b               ! [m yr^-1] Vertically averaged ice velocities in the x-direction on the b-grid (triangles)
-    real(dp), dimension(mesh%ti1:mesh%ti2), intent(in   )           :: v_vav_b               ! [m yr^-1] Vertically averaged ice velocities in the y-direction on the b-grid (triangles)
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: SMB                   ! [m yr^-1] Surface mass balance
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: BMB                   ! [m yr^-1] Basal   mass balance
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: LMB                   ! [m yr^-1] Lateral mass balance
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(inout)           :: AMB                   ! [m yr^-1] Artificial mass balance
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: fraction_margin       ! [0-1]     Sub-grid ice-filled fraction
-    logical,  dimension(mesh%vi1:mesh%vi2), intent(in   )           :: mask_noice            ! [-]       Mask of vertices where no ice is allowed
-    real(dp),                               intent(inout)           :: dt                    ! [dt]      Time step
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out)           :: dHi_dt                ! [m yr^-1] Ice thickness rate of change
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out)           :: Hi_tplusdt            ! [m]       Ice thickness at time t + dt
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out)           :: divQ                  ! [m yr^-1] Horizontal ice flux divergence
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: dHi_dt_target         ! [m yr^-1] Target ice thickness rate of change
-    integer,  dimension(mesh%vi1:mesh%vi2), intent(in   ), optional :: BC_prescr_mask        ! [-]       Mask of vertices where thickness is prescribed
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ), optional :: BC_prescr_Hi          ! [m]       Prescribed thicknesses
+    type(type_mesh),                                     intent(in   )           :: mesh                  ! [-]       The model mesh
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: Hi                    ! [m]       Ice thickness at time t
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: Hb                    ! [m]       Bedrock elevation at time t
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: SL                    ! [m]       Water surface elevation at time t
+    real(dp), dimension(mesh%vi1:mesh%vi2, mesh%nC_mem), intent(in   )           :: u_perp                ! [m yr^-1] Vertically-averaged ice velocity components perpendicular to Voronoi cell boundaries
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: SMB                   ! [m yr^-1] Surface mass balance
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: BMB                   ! [m yr^-1] Basal   mass balance
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: LMB                   ! [m yr^-1] Lateral mass balance
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(inout)           :: AMB                   ! [m yr^-1] Artificial mass balance
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: fraction_margin       ! [0-1]     Sub-grid ice-filled fraction
+    logical,  dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: mask_noice            ! [-]       Mask of vertices where no ice is allowed
+    real(dp),                                            intent(inout)           :: dt                    ! [dt]      Time step
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(  out)           :: dHi_dt                ! [m yr^-1] Ice thickness rate of change
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(  out)           :: Hi_tplusdt            ! [m]       Ice thickness at time t + dt
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(  out)           :: divQ                  ! [m yr^-1] Horizontal ice flux divergence
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: dHi_dt_target         ! [m yr^-1] Target ice thickness rate of change
+    integer,  dimension(mesh%vi1:mesh%vi2),              intent(in   ), optional :: BC_prescr_mask        ! [-]       Mask of vertices where thickness is prescribed
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   ), optional :: BC_prescr_Hi          ! [m]       Prescribed thicknesses
 
     ! Local variables:
     character(len=1024), parameter  :: routine_name = 'calc_dHi_dt_explicit'
@@ -79,7 +77,7 @@ contains
     call init_routine( routine_name)
 
     ! Calculate the ice flux divergence matrix M_divQ using an upwind scheme
-    call calc_ice_flux_divergence_matrix_upwind( mesh, ice, u_vav_b, v_vav_b, fraction_margin, M_divQ)
+    call calc_ice_flux_divergence_matrix_upwind( mesh, u_perp, fraction_margin, M_divQ)
 
     ! Calculate the ice flux divergence div(Q)
     call multiply_CSR_matrix_with_vector_1D_wrapper( M_divQ, &

--- a/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_main.f90
@@ -7,8 +7,7 @@ module conservation_of_mass_main
   use model_configuration, only: C
   use mesh_types, only: type_mesh
   use ice_model_types, only: type_ice_model
-  use conservation_of_mass_utilities, only: calc_ice_flux_divergence_matrix_upwind, &
-    apply_mask_noice_direct, calc_flux_limited_timestep
+  use conservation_of_mass_utilities, only: apply_mask_noice_direct
   use conservation_of_mass_explicit, only: calc_dHi_dt_explicit, apply_ice_thickness_BC_explicit
   use conservation_of_mass_semiimplicit, only: calc_dHi_dt_semiimplicit
   use mpi_f08, only: MPI_ALLREDUCE, MPI_IN_PLACE, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD
@@ -23,31 +22,30 @@ module conservation_of_mass_main
 
 contains
 
-  subroutine calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+  subroutine calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_perp, SMB, BMB, LMB, AMB, &
     fraction_margin, mask_noice, dt, dHi_dt, Hi_tplusdt, divQ, dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     !< Calculate ice thickness at time t+dt
 
     ! In/output variables:
-    type(type_mesh),                        intent(in   )           :: mesh                  ! [-]       The model mesh
-    type(type_ice_model),                   intent(inout)           :: ice                   ! [-]       The ice model
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: Hi                    ! [m]       Ice thickness at time t
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: Hb                    ! [m]       Bedrock elevation at time t
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: SL                    ! [m]       Water surface elevation at time t
-    real(dp), dimension(mesh%ti1:mesh%ti2), intent(in   )           :: u_vav_b               ! [m yr^-1] Vertically averaged ice velocities in the x-direction on the b-grid (triangles)
-    real(dp), dimension(mesh%ti1:mesh%ti2), intent(in   )           :: v_vav_b               ! [m yr^-1] Vertically averaged ice velocities in the y-direction on the b-grid (triangles)
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: SMB                   ! [m yr^-1] Surface mass balance
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: BMB                   ! [m yr^-1] Basal   mass balance
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: LMB                   ! [m yr^-1] Lateral mass balance
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(inout)           :: AMB                   ! [m yr^-1] Artificial mass balance
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: fraction_margin       ! [0-1]     Sub-grid ice-filled fraction
-    logical,  dimension(mesh%vi1:mesh%vi2), intent(in   )           :: mask_noice            ! [-]       Mask of vertices where no ice is allowed
-    real(dp),                               intent(inout)           :: dt                    ! [dt]      Time step
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out)           :: dHi_dt                ! [m yr^-1] Ice thickness rate of change
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out)           :: Hi_tplusdt            ! [m]       Ice thickness at time t + dt
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out)           :: divQ                  ! [m yr^-1] Horizontal ice flux divergence
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: dHi_dt_target         ! [m yr^-1] Target ice thickness rate of change
-    integer,  dimension(mesh%vi1:mesh%vi2), intent(in   ), optional :: BC_prescr_mask        ! [-]       Mask of vertices where thickness is prescribed
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ), optional :: BC_prescr_Hi          ! [m]       Prescribed thicknesses
+    type(type_mesh),                                     intent(in   )           :: mesh                  ! [-]       The model mesh
+    type(type_ice_model),                                intent(inout)           :: ice                   ! [-]       The ice model
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: Hi                    ! [m]       Ice thickness at time t
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: Hb                    ! [m]       Bedrock elevation at time t
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: SL                    ! [m]       Water surface elevation at time t
+    real(dp), dimension(mesh%vi1:mesh%vi2, mesh%nC_mem), intent(in   )           :: u_perp                ! [m yr^-1] Vertically-averaged ice velocity components perpendicular to Voronoi cell boundaries
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: SMB                   ! [m yr^-1] Surface mass balance
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: BMB                   ! [m yr^-1] Basal   mass balance
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: LMB                   ! [m yr^-1] Lateral mass balance
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(inout)           :: AMB                   ! [m yr^-1] Artificial mass balance
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: fraction_margin       ! [0-1]     Sub-grid ice-filled fraction
+    logical,  dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: mask_noice            ! [-]       Mask of vertices where no ice is allowed
+    real(dp),                                            intent(inout)           :: dt                    ! [dt]      Time step
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(  out)           :: dHi_dt                ! [m yr^-1] Ice thickness rate of change
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(  out)           :: Hi_tplusdt            ! [m]       Ice thickness at time t + dt
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(  out)           :: divQ                  ! [m yr^-1] Horizontal ice flux divergence
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: dHi_dt_target         ! [m yr^-1] Target ice thickness rate of change
+    integer,  dimension(mesh%vi1:mesh%vi2),              intent(in   ), optional :: BC_prescr_mask        ! [-]       Mask of vertices where thickness is prescribed
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   ), optional :: BC_prescr_Hi          ! [m]       Prescribed thicknesses
 
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'calc_dHi_dt'
@@ -74,10 +72,10 @@ contains
       return
 
     case ('explicit')
-      call calc_dHi_dt_explicit( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+      call calc_dHi_dt_explicit( mesh, Hi, Hb, SL, u_perp, SMB, BMB, LMB, AMB, &
         fraction_margin, mask_noice, dt, dHi_dt, Hi_tplusdt, divQ, dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     case ('semi-implicit')
-      call calc_dHi_dt_semiimplicit( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+      call calc_dHi_dt_semiimplicit( mesh, Hi, Hb, SL, u_perp, SMB, BMB, LMB, AMB, &
         fraction_margin, mask_noice, dt, dHi_dt, Hi_tplusdt, divQ, dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     end select
 

--- a/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_semiimplicit.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_semiimplicit.f90
@@ -20,7 +20,7 @@ module conservation_of_mass_semiimplicit
 
 contains
 
-  subroutine calc_dHi_dt_semiimplicit( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+  subroutine calc_dHi_dt_semiimplicit( mesh, Hi, Hb, SL, u_perp, SMB, BMB, LMB, AMB, &
     fraction_margin, mask_noice, dt, dHi_dt, Hi_tplusdt, divQ, dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     !< Calculate ice thickness rates of change (dH/dt)
     !< Use a semi-implicit time discretisation scheme for the ice fluxes
@@ -68,26 +68,24 @@ contains
     ! to limit melt to the available ice mass.
 
     ! In/output variables:
-    type(type_mesh),                        intent(in   )           :: mesh                  ! [-]       The model mesh
-    type(type_ice_model),                   intent(inout)           :: ice                   ! [-]       The ice model
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: Hi                    ! [m]       Ice thickness at time t
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: Hb                    ! [m]       Bedrock elevation at time t
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: SL                    ! [m]       Water surface elevation at time t
-    real(dp), dimension(mesh%ti1:mesh%ti2), intent(in   )           :: u_vav_b               ! [m yr^-1] Vertically averaged ice velocities in the x-direction on the b-grid (triangles)
-    real(dp), dimension(mesh%ti1:mesh%ti2), intent(in   )           :: v_vav_b               ! [m yr^-1] Vertically averaged ice velocities in the y-direction on the b-grid (triangles)
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: SMB                   ! [m yr^-1] Surface mass balance
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: BMB                   ! [m yr^-1] Basal   mass balance
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: LMB                   ! [m yr^-1] Lateral mass balance
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(inout)           :: AMB                   ! [m yr^-1] Artificial mass balance
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: fraction_margin       ! [0-1]     Sub-grid ice-filled fraction
-    logical,  dimension(mesh%vi1:mesh%vi2), intent(in   )           :: mask_noice            ! [-]       Mask of vertices where no ice is allowed
-    real(dp),                               intent(inout)           :: dt                    ! [dt]      Time step
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out)           :: dHi_dt                ! [m yr^-1] Ice thickness rate of change
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out)           :: Hi_tplusdt            ! [m]       Ice thickness at time t + dt
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out)           :: divQ                  ! [m yr^-1] Horizontal ice flux divergence
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   )           :: dHi_dt_target         ! [m yr^-1] Target ice thickness rate of change
-    integer,  dimension(mesh%vi1:mesh%vi2), intent(in   ), optional :: BC_prescr_mask        ! [-]       Mask of vertices where thickness is prescribed
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ), optional :: BC_prescr_Hi          ! [m]       Prescribed thicknesses
+    type(type_mesh),                                     intent(in   )           :: mesh                  ! [-]       The model mesh
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: Hi                    ! [m]       Ice thickness at time t
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: Hb                    ! [m]       Bedrock elevation at time t
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: SL                    ! [m]       Water surface elevation at time t
+    real(dp), dimension(mesh%vi1:mesh%vi2, mesh%nC_mem), intent(in   )           :: u_perp                ! [m yr^-1] Vertically-averaged ice velocity components perpendicular to Voronoi cell boundaries
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: SMB                   ! [m yr^-1] Surface mass balance
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: BMB                   ! [m yr^-1] Basal   mass balance
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: LMB                   ! [m yr^-1] Lateral mass balance
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(inout)           :: AMB                   ! [m yr^-1] Artificial mass balance
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: fraction_margin       ! [0-1]     Sub-grid ice-filled fraction
+    logical,  dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: mask_noice            ! [-]       Mask of vertices where no ice is allowed
+    real(dp),                                            intent(inout)           :: dt                    ! [dt]      Time step
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(  out)           :: dHi_dt                ! [m yr^-1] Ice thickness rate of change
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(  out)           :: Hi_tplusdt            ! [m]       Ice thickness at time t + dt
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(  out)           :: divQ                  ! [m yr^-1] Horizontal ice flux divergence
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   )           :: dHi_dt_target         ! [m yr^-1] Target ice thickness rate of change
+    integer,  dimension(mesh%vi1:mesh%vi2),              intent(in   ), optional :: BC_prescr_mask        ! [-]       Mask of vertices where thickness is prescribed
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   ), optional :: BC_prescr_Hi          ! [m]       Prescribed thicknesses
 
     ! Local variables:
     character(len=1024), parameter         :: routine_name = 'calc_dHi_dt_semiimplicit'
@@ -106,13 +104,13 @@ contains
     ! First calculate the explicit solution (used to estimate the time step,
     ! and to apply boundary conditions at the domain border)
     dt_ex = dt
-    call calc_dHi_dt_explicit( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB_ex, &
+    call calc_dHi_dt_explicit( mesh, Hi, Hb, SL, u_perp, SMB, BMB, LMB, AMB_ex, &
       fraction_margin, mask_noice, dt_ex, dHi_dt_ex, Hi_tplusdt_ex, divQ_ex, &
       dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
     dt_max = dt_ex
 
     ! Calculate the ice flux divergence matrix M_divQ using an upwind scheme
-    call calc_ice_flux_divergence_matrix_upwind( mesh, ice, u_vav_b, v_vav_b, fraction_margin, M_divQ)
+    call calc_ice_flux_divergence_matrix_upwind( mesh, u_perp, fraction_margin, M_divQ)
 
     ! Calculate the ice flux divergence div(Q)
     call multiply_CSR_matrix_with_vector_1D_wrapper( M_divQ, &

--- a/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_utilities.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_mass/conservation_of_mass_utilities.f90
@@ -4,7 +4,6 @@ module conservation_of_mass_utilities
   use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine
   use model_configuration, only: C
   use mesh_types, only: type_mesh
-  use ice_model_types, only: type_ice_model
   use CSR_matrix_mod, only: type_CSR_matrix_dp
   use map_velocities_to_c_grid, only: map_velocities_from_b_to_c_2D
   use mpi_distributed_memory, only: gather_to_all
@@ -19,7 +18,7 @@ module conservation_of_mass_utilities
 
 contains
 
-  subroutine calc_ice_flux_divergence_matrix_upwind( mesh, ice, u_vav_b, v_vav_b, fraction_margin, M_divQ)
+  subroutine calc_ice_flux_divergence_matrix_upwind( mesh, u_perp, fraction_margin, M_divQ)
     !< Calculate the ice flux divergence matrix M_divQ using an upwind scheme
 
     ! The vertically averaged ice flux divergence represents the net ice volume (which,
@@ -32,30 +31,23 @@ contains
     ! ice thickness at vj.
 
     ! In/output variables:
-    type(type_mesh),                        intent(in   ) :: mesh
-    type(type_ice_model),                   intent(inout) :: ice
-    real(dp), dimension(mesh%ti1:mesh%ti1), intent(in   ) :: u_vav_b
-    real(dp), dimension(mesh%ti1:mesh%ti1), intent(in   ) :: v_vav_b
-    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: fraction_margin
-    type(type_CSR_matrix_dp),        intent(  out) :: M_divQ
+    type(type_mesh),                                     intent(in   ) :: mesh
+    real(dp), dimension(mesh%vi1:mesh%vi2, mesh%nC_mem), intent(in   ) :: u_perp
+    real(dp), dimension(mesh%vi1:mesh%vi2),              intent(in   ) :: fraction_margin
+    type(type_CSR_matrix_dp),                            intent(  out) :: M_divQ
 
     ! Local variables:
-    character(len=1024), parameter         :: routine_name = 'calc_ice_flux_divergence_matrix_upwind'
-    real(dp), dimension(mesh%ei1:mesh%ei2) :: u_vav_c, v_vav_c
-    real(dp), dimension(mesh%nE)           :: u_vav_c_tot, v_vav_c_tot
-    real(dp), dimension(mesh%nV)           :: fraction_margin_tot
-    integer                                :: ncols, ncols_loc, nrows, nrows_loc, nnz_est_proc
-    integer                                :: vi, ci, ei, vj
-    real(dp)                               :: A_i, L_c
-    real(dp), dimension(0:mesh%nC_mem)     :: cM_divQ
+    character(len=1024), parameter     :: routine_name = 'calc_ice_flux_divergence_matrix_upwind'
+    real(dp), dimension(mesh%nV)       :: fraction_margin_tot
+    integer                            :: ncols, ncols_loc, nrows, nrows_loc, nnz_est_proc
+    integer                            :: vi, ci, vj
+    real(dp)                           :: A_i, L_c
+    real(dp), dimension(0:mesh%nC_mem) :: cM_divQ
 
     ! Add routine to path
     call init_routine( routine_name)
 
     ! Calculate vertically averaged ice velocities on the edges
-    call map_velocities_from_b_to_c_2D( mesh, u_vav_b, v_vav_b, u_vav_c, v_vav_c)
-    call gather_to_all( u_vav_c, u_vav_c_tot)
-    call gather_to_all( v_vav_c, v_vav_c_tot)
     call gather_to_all( fraction_margin, fraction_margin_tot)
 
     ! == Initialise the matrix using the native UFEMISM CSR-matrix format
@@ -74,18 +66,12 @@ contains
     ! == Calculate coefficients
     ! =========================
 
-    ice%u_perp = 0._dp
-
     do vi = mesh%vi1, mesh%vi2
 
-      ! Initialise
       cM_divQ = 0._dp
 
-      ! Loop over all connections of vertex vi
       do ci = 1, mesh%nC( vi)
 
-        ! Connection ci from vertex vi leads through edge ei to vertex vj
-        ei = mesh%VE( vi,ci)
         vj = mesh%C(  vi,ci)
 
         ! The Voronoi cell of vertex vi has area A_i
@@ -95,22 +81,19 @@ contains
         ! of vertices vi and vj has length L_c
         L_c = mesh%Cw( vi,ci)
 
-        ! Calculate vertically averaged ice velocity component perpendicular to this shared Voronoi cell boundary section
-        ice%u_perp( vi, ci) = u_vav_c_tot( ei) * mesh%D_x( vi, ci)/mesh%D( vi, ci) + v_vav_c_tot( ei) * mesh%D_y( vi, ci)/mesh%D( vi, ci)
-
         ! Calculate matrix coefficients
         ! =============================
 
         ! u_perp > 0: flow is exiting this vertex into vertex vj
         if (fraction_margin_tot( vi) >= 1._dp) then
-          cM_divQ( 0) = cM_divQ( 0) + L_c * max( 0._dp, ice%u_perp( vi, ci)) / A_i
+          cM_divQ( 0) = cM_divQ( 0) + L_c * max( 0._dp, u_perp( vi, ci)) / A_i
         else
           ! if this vertex is not completely covering its assigned area, then don't let ice out of it yet.
         end if
 
         ! u_perp < 0: flow is entering this vertex from vertex vj
         if (fraction_margin_tot( vj) >= 1._dp) then
-          cM_divQ( ci) = L_c * MIN( 0._dp, ice%u_perp( vi, ci)) / A_i
+          cM_divQ( ci) = L_c * MIN( 0._dp, u_perp( vi, ci)) / A_i
         else
           ! if that vertex is not completely covering its assigned area, then don't let ice out of it yet.
         end if

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
@@ -235,6 +235,8 @@ contains
       ice%uabs_vav(  vi) = sqrt( ice%u_vav(  vi)**2 + ice%v_vav(  vi)**2)
     end do
 
+    call calc_u_perp( mesh, ice%u_vav_b, ice%v_vav_b, ice%u_perp)
+
     ! Slide/shear ratio
     do vi = mesh%vi1, mesh%vi2
       ice%R_shear( vi) = (ice%uabs_base( vi) + 0.1_dp) / (ice%uabs_surf( vi) + 0.1_dp)
@@ -244,6 +246,49 @@ contains
     call finalise_routine( routine_name)
 
   end subroutine calc_secondary_velocities
+
+  subroutine calc_u_perp( mesh, u_vav_b, v_vav_b, u_perp)
+    !< Calculate the vertically averaged ice velocity component
+    !< perpendicular to the shared Voronoi cell boundaries
+
+    ! In/output variables:
+    type(type_mesh),                                     intent(in   ) :: mesh
+    real(dp), dimension(mesh%ti1:mesh%ti1),              intent(in   ) :: u_vav_b
+    real(dp), dimension(mesh%ti1:mesh%ti1),              intent(in   ) :: v_vav_b
+    real(dp), dimension(mesh%vi1:mesh%vi2, mesh%nC_mem), intent(  out) :: u_perp
+
+    ! Local variables:
+    character(len=*), parameter            :: routine_name = 'calc_u_perp'
+    real(dp), dimension(mesh%ei1:mesh%ei2) :: u_vav_c, v_vav_c
+    real(dp), dimension(mesh%nE)           :: u_vav_c_tot, v_vav_c_tot
+    integer                                :: vi, ci, ei, vj
+
+    ! Add routine to path
+    call init_routine( routine_name)
+
+    ! Calculate vertically averaged ice velocities on the edges
+    call map_velocities_from_b_to_c_2D( mesh, u_vav_b, v_vav_b, u_vav_c, v_vav_c)
+    call gather_to_all( u_vav_c, u_vav_c_tot)
+    call gather_to_all( v_vav_c, v_vav_c_tot)
+
+    do vi = mesh%vi1, mesh%vi2
+      do ci = 1, mesh%nC( vi)
+
+        ! Connection ci from vertex vi leads through edge ei to vertex vj
+        ei = mesh%VE( vi,ci)
+
+        ! Calculate vertically averaged ice velocity component perpendicular to this shared Voronoi cell boundary section
+        u_perp( vi, ci) = &
+          u_vav_c_tot( ei) * mesh%D_x( vi, ci)/mesh%D( vi, ci) + &
+          v_vav_c_tot( ei) * mesh%D_y( vi, ci)/mesh%D( vi, ci)
+
+      end do
+    end do
+
+    ! Finalise routine path
+    call finalise_routine( routine_name)
+
+  end subroutine calc_u_perp
 
   subroutine remap_velocity_solver( mesh_old, mesh_new, ice)
     !< Remap the velocity solver for the chosen stress balance approximation

--- a/src/UFEMISM/ice_dynamics/ice_dynamics_main.f90
+++ b/src/UFEMISM/ice_dynamics/ice_dynamics_main.f90
@@ -1275,7 +1275,7 @@ contains
 
       ! Calculate dH/dt around the calving front
       call calc_dHi_dt( mesh, ice, ice%geom%Hi, ice%geom%Hb, ice%geom%SL, &
-        ice%u_vav_b, ice%v_vav_b, SMB_new, BMB_new, LMB_new, AMB_new, ice%geom%fraction_margin, ice%mask_noice, C%dt_ice_min, &
+        ice%u_perp, SMB_new, BMB_new, LMB_new, AMB_new, ice%geom%fraction_margin, ice%mask_noice, C%dt_ice_min, &
         ice%dHi_dt, Hi_tplusdt, divQ, ice%dHi_dt_target, BC_prescr_mask, BC_prescr_Hi)
 
       ! Update ice thickness and advance pseudo-time
@@ -1384,7 +1384,7 @@ contains
         BMB_dummy, region%name, n_visc_its, n_Axb_its)
 
       ! Calculate thinning rates for current geometry and velocity
-      call calc_dHi_dt( region%mesh, region%ice, region%ice%geom%Hi, region%ice%geom%Hb, region%ice%geom%SL, region%ice%u_vav_b, region%ice%v_vav_b, SMB_dummy, BMB_dummy, LMB_dummy, AMB_dummy, region%ice%geom%fraction_margin, &
+      call calc_dHi_dt( region%mesh, region%ice, region%ice%geom%Hi, region%ice%geom%Hb, region%ice%geom%SL, region%ice%u_perp, SMB_dummy, BMB_dummy, LMB_dummy, AMB_dummy, region%ice%geom%fraction_margin, &
                         region%ice%mask_noice, t_step, dHi_dt_new, Hi_new, region%ice%divQ, dHi_dt_target_dummy)
 
       ! Set ice model ice thickness to relaxed field

--- a/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
+++ b/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
@@ -122,7 +122,7 @@ contains
       ! ====================
 
       ! Calculate thinning rates for current geometry and velocity
-      call calc_dHi_dt( region%mesh, region%ice, region%ice%geom%Hi, region%ice%geom%Hb, region%ice%geom%SL, region%ice%u_vav_b, region%ice%v_vav_b, SMB_loc, region%BMB%BMB, region%LMB%LMB, region%AMB%AMB, region%ice%geom%fraction_margin, &
+      call calc_dHi_dt( region%mesh, region%ice, region%ice%geom%Hi, region%ice%geom%Hb, region%ice%geom%SL, region%ice%u_perp, SMB_loc, region%BMB%BMB, region%LMB%LMB, region%AMB%AMB, region%ice%geom%fraction_margin, &
                         region%ice%mask_noice, region%ice%pc%dt_np1, region%ice%pc%dHi_dt_Hi_n_u_n, Hi_dummy, region%ice%divQ, region%ice%dHi_dt_target)
 
       ! Making sure verticies in no ice mask have zero thinning rates
@@ -204,7 +204,7 @@ contains
       call region%ice%geom%calc_effective_thickness()
 
       ! Calculate thinning rates for the current ice thickness and predicted velocity
-      call calc_dHi_dt( region%mesh, region%ice, region%ice%geom%Hi, region%ice%geom%Hb, region%ice%geom%SL, region%ice%u_vav_b, region%ice%v_vav_b, SMB_loc, region%BMB%BMB, region%LMB%LMB, region%AMB%AMB, region%ice%geom%fraction_margin, &
+      call calc_dHi_dt( region%mesh, region%ice, region%ice%geom%Hi, region%ice%geom%Hb, region%ice%geom%SL, region%ice%u_perp, SMB_loc, region%BMB%BMB, region%LMB%LMB, region%AMB%AMB, region%ice%geom%fraction_margin, &
                         region%ice%mask_noice, region%ice%pc%dt_np1, region%ice%pc%dHi_dt_Hi_star_np1_u_np1, Hi_dummy, region%ice%divQ, region%ice%dHi_dt_target)
 
       ! Making sure verticies in no ice mask have zero thinning rates

--- a/src/UFEMISM/validation/component_tests/ct_mass_conservation.f90
+++ b/src/UFEMISM/validation/component_tests/ct_mass_conservation.f90
@@ -17,6 +17,7 @@ module ct_mass_conservation
   use conservation_of_mass_main, only: calc_dHi_dt
   use parameters, only: pi
   use ice_model_memory, only: allocate_ice_model
+  use conservation_of_momentum_main, only: calc_u_perp
 
   implicit none
 
@@ -165,6 +166,7 @@ contains
 
     ! Local variables:
     character(len=1024), parameter         :: routine_name = 'run_mass_cons_test_on_mesh_with_function'
+    real(dp), dimension(mesh%vi1:mesh%vi2, mesh%nC_mem) :: u_perp
     real(dp), dimension(mesh%vi1:mesh%vi2) :: Hb, Hs, SL
     real(dp), dimension(mesh%vi1:mesh%vi2) :: SMB
     real(dp), dimension(mesh%vi1:mesh%vi2) :: BMB, LMB, AMB
@@ -193,30 +195,32 @@ contains
     dHi_dt_target   = 0._dp
     dt              = 0.1_dp
 
+    call calc_u_perp( mesh, u_vav_b, v_vav_b, u_perp)
+
     ! Calculate modelled thinning rates using different solvers
     ! =========================================================
 
     ! Explicit
     C%choice_ice_integration_method = 'explicit'
-    call calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+    call calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_perp, SMB, BMB, LMB, AMB, &
       fraction_margin, mask_noice, dt, dHi_dt_expl, Hi_tplusdt, divQ, dHi_dt_target)
 
     ! Semi-implicit
     C%choice_ice_integration_method = 'semi-implicit'
     C%dHi_semiimplicit_fs = 0.5_dp
-    call calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+    call calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_perp, SMB, BMB, LMB, AMB, &
       fraction_margin, mask_noice, dt, dHi_dt_semiimpl, Hi_tplusdt, divQ, dHi_dt_target)
 
     ! Implicit
     C%choice_ice_integration_method = 'semi-implicit'
     C%dHi_semiimplicit_fs = 1._dp
-    call calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+    call calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_perp, SMB, BMB, LMB, AMB, &
       fraction_margin, mask_noice, dt, dHi_dt_impl, Hi_tplusdt, divQ, dHi_dt_target)
 
     ! Over-implicit
     C%choice_ice_integration_method = 'semi-implicit'
     C%dHi_semiimplicit_fs = 1.5_dp
-    call calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_vav_b, v_vav_b, SMB, BMB, LMB, AMB, &
+    call calc_dHi_dt( mesh, ice, Hi, Hb, SL, u_perp, SMB, BMB, LMB, AMB, &
       fraction_margin, mask_noice, dt, dHi_dt_overimpl, Hi_tplusdt, divQ, dHi_dt_target)
 
     ! Write results to output


### PR DESCRIPTION
First step in removing 'ice' as in input variable for calc_dHi_dt, it should require only an ice geometry model and a velocity solution (which eventually should also become a separate model...).