### PR TITLE
Input ice geometry model to velocity solver

### DIFF
--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/BPA/BPA_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/BPA/BPA_main.f90
@@ -12,6 +12,7 @@ module BPA_main
   use petsc_basic, only: solve_matrix_equation_CSR_PETSc
   use mesh_types, only: type_mesh
   use ice_model_types, only: type_ice_model, type_ice_velocity_solver_BPA
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
   use parameters
   use mesh_disc_apply_operators, only: map_a_b_2D, map_a_b_3D, ddx_a_b_2D, ddy_a_b_2D, &
     ddx_b_a_3D, ddy_b_a_3D, calc_3D_gradient_bk_ak, calc_3D_gradient_bk_bks, &
@@ -87,13 +88,14 @@ contains
 
   end subroutine initialise_BPA_solver
 
-  subroutine solve_BPA( mesh, ice, bed_roughness, BPA, n_visc_its, n_Axb_its, &
+  subroutine solve_BPA( mesh, ice, geom, bed_roughness, BPA, n_visc_its, n_Axb_its, &
     BC_prescr_mask_bk, BC_prescr_u_bk, BC_prescr_v_bk)
     !< Calculate ice velocities by solving the Blatter-Pattyn Approximation
 
     ! In/output variables:
     type(type_mesh),                    intent(inout) :: mesh
     type(type_ice_model),               intent(inout) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
     type(type_bed_roughness_model),     intent(in   ) :: bed_roughness
     type(type_ice_velocity_solver_BPA), intent(inout) :: BPA
     integer,                            intent(  out) :: n_visc_its            ! Number of non-linear viscosity iterations
@@ -122,7 +124,7 @@ contains
     call init_routine( routine_name)
 
     ! if there is no grounded ice, or no sliding, no need to solve the BPA
-    grounded_ice_exists = any( ice%geom%mask_grounded_ice)
+    grounded_ice_exists = any( geom%mask_grounded_ice)
     call MPI_ALLREDUCE( MPI_IN_PLACE, grounded_ice_exists, 1, MPI_logical, MPI_LOR, MPI_COMM_WORLD, ierr)
     if (.not. grounded_ice_exists) then
       BPA%u_bk = 0._dp
@@ -150,7 +152,7 @@ contains
     end if
 
     ! Calculate zeta gradients
-    call calc_zeta_gradients( mesh, ice)
+    call calc_zeta_gradients( mesh, ice, geom)
 
     ! Calculate 3-D matrix operators for the current ice geometry
     call calc_3D_matrix_operators_mesh( mesh, &
@@ -159,7 +161,7 @@ contains
       ice%d2zeta_dx2_bk, ice%d2zeta_dxdy_bk, ice%d2zeta_dy2_bk)
 
     ! Calculate the driving stress
-    call calc_driving_stress( mesh, ice, BPA)
+    call calc_driving_stress( mesh, geom, BPA)
 
     ! Adaptive relaxation parameter for the viscosity iteration
     resid_UV                            = 1E9_dp
@@ -184,7 +186,7 @@ contains
       call calc_effective_viscosity( mesh, ice, BPA, Glens_flow_law_epsilon_sq_0_applied)
 
       ! Calculate the basal friction coefficient betab for the current velocity solution
-      call calc_applied_basal_friction_coefficient( mesh, ice, bed_roughness, BPA)
+      call calc_applied_basal_friction_coefficient( mesh, ice, geom, bed_roughness, BPA)
 
       ! Solve the linearised BPA to calculate a new velocity solution
       call solve_BPA_linearised( mesh, ice, BPA, n_Axb_its_visc_it, &
@@ -1725,11 +1727,11 @@ contains
 
 ! == Calculate several intermediate terms in the BPA
 
-  subroutine calc_driving_stress( mesh, ice, BPA)
+  subroutine calc_driving_stress( mesh, geom, BPA)
 
     ! In/output variables:
     type(type_mesh),                    intent(in   ) :: mesh
-    type(type_ice_model),               intent(in   ) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
     type(type_ice_velocity_solver_BPA), intent(inout) :: BPA
 
     ! Local variables:
@@ -1740,10 +1742,10 @@ contains
     call init_routine( routine_name)
 
     ! Calculate dh/dx, dh/dy, db/dx, db/dy on the b-grid
-    call ddx_a_b_2D( mesh, ice%geom%Hs , BPA%dh_dx_b)
-    call ddy_a_b_2D( mesh, ice%geom%Hs , BPA%dh_dy_b)
-    call ddx_a_b_2D( mesh, ice%geom%Hib, BPA%db_dx_b)
-    call ddy_a_b_2D( mesh, ice%geom%Hib, BPA%db_dy_b)
+    call ddx_a_b_2D( mesh, geom%Hs , BPA%dh_dx_b)
+    call ddy_a_b_2D( mesh, geom%Hs , BPA%dh_dy_b)
+    call ddx_a_b_2D( mesh, geom%Hib, BPA%db_dx_b)
+    call ddy_a_b_2D( mesh, geom%Hib, BPA%db_dy_b)
 
     ! Calculate the driving stress
     do ti = mesh%ti1, mesh%ti2
@@ -1931,7 +1933,7 @@ contains
 
   end subroutine calc_effective_viscosity
 
-  subroutine calc_applied_basal_friction_coefficient( mesh, ice, bed_roughness, BPA)
+  subroutine calc_applied_basal_friction_coefficient( mesh, ice, geom, bed_roughness, BPA)
     !< Calculate the applied basal friction coefficient beta_b, i.e. on the b-grid
     !< and scaled with the sub-grid grounded fraction
 
@@ -1940,6 +1942,7 @@ contains
     ! In/output variables:
     type(type_mesh),                    intent(in   ) :: mesh
     type(type_ice_model),               intent(inout) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
     type(type_bed_roughness_model),     intent(in   ) :: bed_roughness
     type(type_ice_velocity_solver_BPA), intent(inout) :: BPA
 
@@ -1962,7 +1965,7 @@ contains
     ! Map velocities to the a-grid
     call map_b_a_2D( mesh, u_base_b, u_base_a)
     call map_b_a_2D( mesh, v_base_b, v_base_a)
-    call calc_basal_friction_coefficient( mesh, ice%geom, bed_roughness, u_base_a, v_base_a, &
+    call calc_basal_friction_coefficient( mesh, geom, bed_roughness, u_base_a, v_base_a, &
       ice%effective_pressure, ice%till_yield_stress, ice%basal_friction_coefficient)
 
     ! Map basal friction coefficient beta_b to the b-grid
@@ -1971,7 +1974,7 @@ contains
     ! Apply the sub-grid grounded fraction, and limit the friction coefficient to improve stability
     if (C%do_GL_subgrid_friction) then
       do ti = mesh%ti1, mesh%ti2
-        BPA%basal_friction_coefficient_b( ti) = BPA%basal_friction_coefficient_b( ti) * ice%geom%fraction_gr_b( ti)**C%subgrid_friction_exponent_on_B_grid
+        BPA%basal_friction_coefficient_b( ti) = BPA%basal_friction_coefficient_b( ti) * geom%fraction_gr_b( ti)**C%subgrid_friction_exponent_on_B_grid
       end do
     end if
 

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/BPA/BPA_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/BPA/BPA_main.f90
@@ -1962,7 +1962,8 @@ contains
     ! Map velocities to the a-grid
     call map_b_a_2D( mesh, u_base_b, u_base_a)
     call map_b_a_2D( mesh, v_base_b, v_base_a)
-    call calc_basal_friction_coefficient( mesh, ice, bed_roughness, u_base_a, v_base_a)
+    call calc_basal_friction_coefficient( mesh, ice%geom, bed_roughness, u_base_a, v_base_a, &
+      ice%effective_pressure, ice%till_yield_stress, ice%basal_friction_coefficient)
 
     ! Map basal friction coefficient beta_b to the b-grid
     call map_a_b_2D( mesh, ice%basal_friction_coefficient, BPA%basal_friction_coefficient_b)

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/SIA/SIA_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/SIA/SIA_main.f90
@@ -7,6 +7,7 @@ module SIA_main
   use model_configuration, only: C
   use mesh_types, only: type_mesh
   use ice_model_types, only: type_ice_model, type_ice_velocity_solver_SIA
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
   use parameters, only: grav, ice_density
   use reallocate_mod, only: reallocate_bounds
   use constitutive_equation, only: calc_ice_rheology_Glen
@@ -62,12 +63,13 @@ contains
 
   end subroutine allocate_SIA_solver
 
-  subroutine solve_SIA( mesh, ice, SIA)
+  subroutine solve_SIA( mesh, ice, geom, SIA)
     !< Calculate ice velocities by solving the Shallow Ice Approximation with Glen's flow law
 
     ! In/output variables:
     type(type_mesh),                     intent(in   ) :: mesh
     type(type_ice_model),                intent(inout) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
     type(type_ice_velocity_solver_SIA),  intent(inout) :: SIA
 
     ! Local variables:
@@ -99,12 +101,12 @@ contains
     call calc_ice_rheology_Glen( mesh, ice)
 
     ! Calculate ice thickness, surface elevation, surface slopes, and ice flow factor on the b-grid
-    call map_a_b_2D( mesh, ice%geom%Hi    , Hi_b    )
-    call map_a_b_2D( mesh, ice%geom%Hs    , Hs_b    )
-    call ddx_a_a_2D( mesh, ice%geom%Hs    , dHs_dx  )
-    call ddy_a_a_2D( mesh, ice%geom%Hs    , dHs_dy  )
-    call ddx_a_b_2D( mesh, ice%geom%Hs    , dHs_dx_b)
-    call ddy_a_b_2D( mesh, ice%geom%Hs    , dHs_dy_b)
+    call map_a_b_2D( mesh, geom%Hi    , Hi_b    )
+    call map_a_b_2D( mesh, geom%Hs    , Hs_b    )
+    call ddx_a_a_2D( mesh, geom%Hs    , dHs_dx  )
+    call ddy_a_a_2D( mesh, geom%Hs    , dHs_dy  )
+    call ddx_a_b_2D( mesh, geom%Hs    , dHs_dx_b)
+    call ddy_a_b_2D( mesh, geom%Hs    , dHs_dy_b)
     call map_a_b_3D( mesh, ice%A_flow, A_flow_b)
 
     ! Calculate velocities and strain rates according to the analytical solution of the SIA:
@@ -141,13 +143,13 @@ contains
     do vi = mesh%vi1, mesh%vi2
 
       abs_grad_Hs = SQRT( dHs_dx( vi)**2 + dHs_dy( vi)**2)
-      z = ice%geom%Hs( vi) - mesh%zeta * ice%geom%Hi( vi)
+      z = geom%Hs( vi) - mesh%zeta * geom%Hi( vi)
 
       do k = 1, mesh%nz
         SIA%du_dz_3D( vi,k) = -2._dp * (ice_density * grav)**C%Glens_flow_law_exponent * abs_grad_Hs**(C%Glens_flow_law_exponent - 1._dp) * &
-          ice%A_flow( vi,k) * (ice%geom%Hs( vi) - z( k))**C%Glens_flow_law_exponent * dHs_dx( vi)
+          ice%A_flow( vi,k) * (geom%Hs( vi) - z( k))**C%Glens_flow_law_exponent * dHs_dx( vi)
         SIA%dv_dz_3D( vi,k) = -2._dp * (ice_density * grav)**C%Glens_flow_law_exponent * abs_grad_Hs**(C%Glens_flow_law_exponent - 1._dp) * &
-          ice%A_flow( vi,k) * (ice%geom%Hs( vi) - z( k))**C%Glens_flow_law_exponent * dHs_dy( vi)
+          ice%A_flow( vi,k) * (geom%Hs( vi) - z( k))**C%Glens_flow_law_exponent * dHs_dy( vi)
       end do
 
     end do

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_main.f90
@@ -9,6 +9,7 @@ module DIVA_main
   use model_configuration, only: C
   use mesh_types, only: type_mesh
   use ice_model_types, only: type_ice_model, type_ice_velocity_solver_DIVA
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
   use netcdf_io_main
   use mesh_disc_apply_operators, only: map_a_b_2D, map_a_b_3D, map_b_a_2D, map_b_a_3D
   use reallocate_mod, only: reallocate_bounds, reallocate_clean
@@ -75,20 +76,21 @@ contains
 
   end subroutine initialise_DIVA_solver
 
-  subroutine solve_DIVA( mesh, ice, bed_roughness, DIVA, n_visc_its, n_Axb_its, &
+  subroutine solve_DIVA( mesh, ice, geom, bed_roughness, DIVA, n_visc_its, n_Axb_its, &
     BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
     !< Calculate ice velocities by solving the Depth-Integrated Viscosity Approximation
 
     ! In/output variables:
-    type(type_mesh),                     intent(in   ) :: mesh
-    type(type_ice_model),                intent(inout) :: ice
-    type(type_bed_roughness_model),      intent(in   ) :: bed_roughness
-    type(type_ice_velocity_solver_DIVA), intent(inout) :: DIVA
-    integer,                             intent(  out) :: n_visc_its               ! Number of non-linear viscosity iterations
-    integer,                             intent(  out) :: n_Axb_its                ! Number of iterations in iterative solver for linearised momentum balance
-    integer,  dimension(:), optional,    intent(in   ) :: BC_prescr_mask_b         ! Mask of triangles where velocity is prescribed
-    real(dp), dimension(:), optional,    intent(in   ) :: BC_prescr_u_b            ! Prescribed velocities in the x-direction
-    real(dp), dimension(:), optional,    intent(in   ) :: BC_prescr_v_b            ! Prescribed velocities in the y-direction
+    type(type_mesh),                      intent(in   ) :: mesh
+    type(type_ice_model),                 intent(inout) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
+    type(type_bed_roughness_model),       intent(in   ) :: bed_roughness
+    type(type_ice_velocity_solver_DIVA),  intent(inout) :: DIVA
+    integer,                              intent(  out) :: n_visc_its               ! Number of non-linear viscosity iterations
+    integer,                              intent(  out) :: n_Axb_its                ! Number of iterations in iterative solver for linearised momentum balance
+    integer,  dimension(:), optional,     intent(in   ) :: BC_prescr_mask_b         ! Mask of triangles where velocity is prescribed
+    real(dp), dimension(:), optional,     intent(in   ) :: BC_prescr_u_b            ! Prescribed velocities in the x-direction
+    real(dp), dimension(:), optional,     intent(in   ) :: BC_prescr_v_b            ! Prescribed velocities in the y-direction
 
     ! Local variables:
     character(len=1024), parameter      :: routine_name = 'solve_DIVA'
@@ -100,10 +102,10 @@ contains
     case default
       call crash('unknown BC_ice_front "' // trim( C%BC_ice_front) // '"')
     case ('infinite_slab')
-      call solve_DIVA_infinite_slab( mesh, ice, bed_roughness, DIVA, n_visc_its, n_Axb_its, &
+      call solve_DIVA_infinite_slab( mesh, ice, geom, bed_roughness, DIVA, n_visc_its, n_Axb_its, &
         BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
     case ('ocean_pressure')
-      call solve_DIVA_ocean_pressure( mesh, ice, bed_roughness, DIVA, n_visc_its, n_Axb_its, &
+      call solve_DIVA_ocean_pressure( mesh, ice, geom, bed_roughness, DIVA, n_visc_its, n_Axb_its, &
         BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
     end select
 

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_solver_infinite_slab.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_solver_infinite_slab.f90
@@ -444,7 +444,7 @@ contains
     if (C%do_GL_subgrid_friction) then
       ! On the b-grid
       do ti = mesh%ti1, mesh%ti2
-        DIVA%beta_eff_b( ti) = DIVA%beta_eff_b( ti) * ice%geom%fraction_gr_b( ti)**C%subgrid_friction_exponent_on_B_grid
+        DIVA%beta_eff_b( ti) = DIVA%beta_eff_b( ti) * geom%fraction_gr_b( ti)**C%subgrid_friction_exponent_on_B_grid
       end do
     end if
 

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_solver_infinite_slab.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_solver_infinite_slab.f90
@@ -412,7 +412,8 @@ contains
     ! This is where the sliding law is called!
     call map_b_a_2D( mesh, DIVA%u_base_b, u_base_a)
     call map_b_a_2D( mesh, DIVA%v_base_b, v_base_a)
-    call calc_basal_friction_coefficient( mesh, ice, bed_roughness, u_base_a, v_base_a)
+    call calc_basal_friction_coefficient( mesh, ice%geom, bed_roughness, u_base_a, v_base_a, &
+      ice%effective_pressure, ice%till_yield_stress, ice%basal_friction_coefficient)
 
     ! Calculate beta_eff on the a-grid
     if (C%choice_sliding_law == 'no_sliding') then

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_solver_infinite_slab.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_solver_infinite_slab.f90
@@ -13,6 +13,7 @@ module DIVA_solver_infinite_slab
   use graph_types, only: type_graph_pair
   use graph_pair_creation, only: create_ice_only_graph_pair, deallocate_graph_pair
   use ice_model_types, only: type_ice_model, type_ice_velocity_solver_DIVA
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
   use netcdf_io_main
   use sliding_laws, only: calc_basal_friction_coefficient
   use mesh_disc_apply_operators, only: map_a_b_2D, map_a_b_3D, ddx_a_b_2D, ddy_a_b_2D, &
@@ -46,20 +47,21 @@ contains
 
   ! == Main routines
 
-  subroutine solve_DIVA_infinite_slab( mesh, ice, bed_roughness, DIVA, n_visc_its, n_Axb_its, &
+  subroutine solve_DIVA_infinite_slab( mesh, ice, geom, bed_roughness, DIVA, n_visc_its, n_Axb_its, &
     BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
     !< Calculate ice velocities by solving the Depth-Integrated Viscosity Approximation
 
     ! In/output variables:
-    type(type_mesh),                     intent(in   ) :: mesh
-    type(type_ice_model),                intent(inout) :: ice
-    type(type_bed_roughness_model),      intent(in   ) :: bed_roughness
-    type(type_ice_velocity_solver_DIVA), intent(inout) :: DIVA
-    integer,                             intent(  out) :: n_visc_its               ! Number of non-linear viscosity iterations
-    integer,                             intent(  out) :: n_Axb_its                ! Number of iterations in iterative solver for linearised momentum balance
-    integer,  dimension(:), optional,    intent(in   ) :: BC_prescr_mask_b         ! Mask of triangles where velocity is prescribed
-    real(dp), dimension(:), optional,    intent(in   ) :: BC_prescr_u_b            ! Prescribed velocities in the x-direction
-    real(dp), dimension(:), optional,    intent(in   ) :: BC_prescr_v_b            ! Prescribed velocities in the y-direction
+    type(type_mesh),                      intent(in   ) :: mesh
+    type(type_ice_model),                 intent(inout) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
+    type(type_bed_roughness_model),       intent(in   ) :: bed_roughness
+    type(type_ice_velocity_solver_DIVA),  intent(inout) :: DIVA
+    integer,                              intent(  out) :: n_visc_its               ! Number of non-linear viscosity iterations
+    integer,                              intent(  out) :: n_Axb_its                ! Number of iterations in iterative solver for linearised momentum balance
+    integer,  dimension(:), optional,     intent(in   ) :: BC_prescr_mask_b         ! Mask of triangles where velocity is prescribed
+    real(dp), dimension(:), optional,     intent(in   ) :: BC_prescr_u_b            ! Prescribed velocities in the x-direction
+    real(dp), dimension(:), optional,     intent(in   ) :: BC_prescr_v_b            ! Prescribed velocities in the y-direction
 
     ! Local variables:
     character(len=1024), parameter      :: routine_name = 'solve_DIVA_infinite_slab'
@@ -113,7 +115,7 @@ contains
     end if
 
     ! Calculate the driving stress
-    call calc_driving_stress( mesh, ice, DIVA%tau_dx_b, DIVA%tau_dy_b)
+    call calc_driving_stress( mesh, geom, DIVA%tau_dx_b, DIVA%tau_dy_b)
 
     ! Adaptive relaxation parameter for the viscosity iteration
     L2_uv                               = 1E9_dp
@@ -139,13 +141,13 @@ contains
       call calc_vertical_shear_strain_rates( mesh, DIVA)
 
       ! Calculate the effective viscosity for the current velocity solution
-      call calc_effective_viscosity( mesh, ice, DIVA, Glens_flow_law_epsilon_sq_0_applied)
+      call calc_effective_viscosity( mesh, ice, geom, DIVA, Glens_flow_law_epsilon_sq_0_applied)
 
       ! Calculate the F-integrals (Lipscomb et al. (2019), Eq. 30)
-      call calc_F_integrals( mesh, ice, DIVA)
+      call calc_F_integrals( mesh, geom, DIVA)
 
       ! Calculate the "effective" friction coefficient (turning the SSA into the DIVA)
-      call calc_effective_basal_friction_coefficient( mesh, ice, bed_roughness, DIVA)
+      call calc_effective_basal_friction_coefficient( mesh, ice, geom, bed_roughness, DIVA)
 
       ! Solve the linearised DIVA to calculate a new velocity solution
       call solve_SSA_DIVA_linearised( mesh, DIVA%u_vav_b, DIVA%v_vav_b, &
@@ -269,14 +271,15 @@ contains
 
   end subroutine calc_vertical_shear_strain_rates
 
-  subroutine calc_effective_viscosity( mesh, ice, &
+  subroutine calc_effective_viscosity( mesh, ice, geom, &
     DIVA, Glens_flow_law_epsilon_sq_0_applied)
 
     ! In/output variables:
-    type(type_mesh),                     intent(in   ) :: mesh
-    type(type_ice_model),                intent(inout) :: ice
-    type(type_ice_velocity_solver_DIVA), intent(inout) :: DIVA
-    real(dp),                            intent(in   ) :: Glens_flow_law_epsilon_sq_0_applied
+    type(type_mesh),                      intent(in   ) :: mesh
+    type(type_ice_model),                 intent(inout) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
+    type(type_ice_velocity_solver_DIVA),  intent(inout) :: DIVA
+    real(dp),                             intent(in   ) :: Glens_flow_law_epsilon_sq_0_applied
 
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'calc_effective_viscosity'
@@ -326,7 +329,7 @@ contains
 
     ! Calculate the product term N = eta * H on the a-grid
     do vi = mesh%vi1, mesh%vi2
-      DIVA%N_a( vi) = DIVA%eta_vav_a( vi) * max( 0.1, ice%geom%Hi( vi))
+      DIVA%N_a( vi) = DIVA%eta_vav_a( vi) * max( 0.1_dp, geom%Hi( vi))
     end do
 
     ! Calculate the product term N and its gradients on the b-grid
@@ -347,13 +350,13 @@ contains
 
   end subroutine calc_effective_viscosity
 
-  subroutine calc_F_integrals( mesh, ice, DIVA)
+  subroutine calc_F_integrals( mesh, geom, DIVA)
     !< Calculate the F-integrals on the a-grid (Lipscomb et al. (2019), Eq. 30)
 
     ! In/output variables:
-    type(type_mesh),                     intent(in   ) :: mesh
-    type(type_ice_model),                intent(in   ) :: ice
-    type(type_ice_velocity_solver_DIVA), intent(inout) :: DIVA
+    type(type_mesh),                      intent(in   ) :: mesh
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
+    type(type_ice_velocity_solver_DIVA),  intent(inout) :: DIVA
 
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'calc_F_integrals'
@@ -369,13 +372,13 @@ contains
       do k = 1, mesh%nz
         prof( k) = (mesh%zeta( k)    / DIVA%eta_3D_a( vi,k))
       end do
-      DIVA%F1_3D_a( vi,:) = -max( 0.1_dp, ice%geom%Hi( vi)) * integrate_from_zeta_is_one_to_zeta_is_zetap( mesh%zeta, prof)
+      DIVA%F1_3D_a( vi,:) = -max( 0.1_dp, geom%Hi( vi)) * integrate_from_zeta_is_one_to_zeta_is_zetap( mesh%zeta, prof)
 
       ! F2
       do k = 1, mesh%nz
         prof( k) = (mesh%zeta( k)**2 / DIVA%eta_3D_a( vi,k))
       end do
-      DIVA%F2_3D_a( vi,:) = -max( 0.1_dp, ice%geom%Hi( vi)) * integrate_from_zeta_is_one_to_zeta_is_zetap( mesh%zeta, prof)
+      DIVA%F2_3D_a( vi,:) = -max( 0.1_dp, geom%Hi( vi)) * integrate_from_zeta_is_one_to_zeta_is_zetap( mesh%zeta, prof)
 
     end do
 
@@ -391,14 +394,15 @@ contains
 
   end subroutine calc_F_integrals
 
-  subroutine calc_effective_basal_friction_coefficient( mesh, ice, bed_roughness, DIVA)
+  subroutine calc_effective_basal_friction_coefficient( mesh, ice, geom, bed_roughness, DIVA)
     !< Calculate the "effective" friction coefficient (turning the SSA into the DIVA)
 
     ! In/output variables:
-    type(type_mesh),                     intent(in   ) :: mesh
-    type(type_ice_model),                intent(inout) :: ice
-    type(type_bed_roughness_model),      intent(in   ) :: bed_roughness
-    type(type_ice_velocity_solver_DIVA), intent(inout) :: DIVA
+    type(type_mesh),                      intent(in   ) :: mesh
+    type(type_ice_model),                 intent(inout) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
+    type(type_bed_roughness_model),       intent(in   ) :: bed_roughness
+    type(type_ice_velocity_solver_DIVA),  intent(inout) :: DIVA
 
     ! Local variables:
     character(len=1024), parameter         :: routine_name = 'calc_effective_basal_friction_coefficient'

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_solver_ocean_pressure.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_solver_ocean_pressure.f90
@@ -14,6 +14,7 @@ module DIVA_solver_ocean_pressure
   use graph_pair_creation, only: create_ice_only_graph_pair, deallocate_graph_pair
   use ice_model_types, only: type_ice_model, type_ice_velocity_solver_DIVA, &
     type_ice_velocity_solver_DIVA_graphs
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
   use netcdf_io_main
   use sliding_laws, only: calc_basal_friction_coefficient
   use mesh_disc_apply_operators, only: map_a_b_2D, map_a_b_3D, ddx_a_b_2D, ddy_a_b_2D, &
@@ -43,20 +44,21 @@ contains
 
   ! == Main routines
 
-  subroutine solve_DIVA_ocean_pressure( mesh, ice, bed_roughness, DIVA, n_visc_its, n_Axb_its, &
+  subroutine solve_DIVA_ocean_pressure( mesh, ice, geom, bed_roughness, DIVA, n_visc_its, n_Axb_its, &
     BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
     !< Calculate ice velocities by solving the Depth-Integrated Viscosity Approximation
 
     ! In/output variables:
-    type(type_mesh),                     intent(in   ) :: mesh
-    type(type_ice_model),                intent(inout) :: ice
-    type(type_bed_roughness_model),      intent(in   ) :: bed_roughness
-    type(type_ice_velocity_solver_DIVA), intent(inout) :: DIVA
-    integer,                             intent(  out) :: n_visc_its               ! Number of non-linear viscosity iterations
-    integer,                             intent(  out) :: n_Axb_its                ! Number of iterations in iterative solver for linearised momentum balance
-    integer,  dimension(:), optional,    intent(in   ) :: BC_prescr_mask_b         ! Mask of triangles where velocity is prescribed
-    real(dp), dimension(:), optional,    intent(in   ) :: BC_prescr_u_b            ! Prescribed velocities in the x-direction
-    real(dp), dimension(:), optional,    intent(in   ) :: BC_prescr_v_b            ! Prescribed velocities in the y-direction
+    type(type_mesh),                      intent(in   ) :: mesh
+    type(type_ice_model),                 intent(inout) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
+    type(type_bed_roughness_model),       intent(in   ) :: bed_roughness
+    type(type_ice_velocity_solver_DIVA),  intent(inout) :: DIVA
+    integer,                              intent(  out) :: n_visc_its               ! Number of non-linear viscosity iterations
+    integer,                              intent(  out) :: n_Axb_its                ! Number of iterations in iterative solver for linearised momentum balance
+    integer,  dimension(:), optional,     intent(in   ) :: BC_prescr_mask_b         ! Mask of triangles where velocity is prescribed
+    real(dp), dimension(:), optional,     intent(in   ) :: BC_prescr_u_b            ! Prescribed velocities in the x-direction
+    real(dp), dimension(:), optional,     intent(in   ) :: BC_prescr_v_b            ! Prescribed velocities in the y-direction
 
     ! Local variables:
     character(len=1024), parameter      :: routine_name = 'solve_DIVA_ocean_pressure'
@@ -80,7 +82,7 @@ contains
     call init_routine( routine_name)
 
     ! if there is no grounded ice, no need (in fact, no way) to solve the DIVA
-    grounded_ice_exists = any( ice%geom%mask_grounded_ice)
+    grounded_ice_exists = any( geom%mask_grounded_ice)
     call MPI_ALLREDUCE( MPI_IN_PLACE, grounded_ice_exists, 1, MPI_logical, MPI_LOR, MPI_COMM_WORLD, ierr)
     if (.not. grounded_ice_exists) then
       DIVA%u_vav_b  = 0._dp
@@ -111,7 +113,7 @@ contains
       BC_prescr_v_b_applied    = 0._dp
     end if
 
-    call setup_DIVA_solver_on_graphs( mesh, ice, DIVA)
+    call setup_DIVA_solver_on_graphs( mesh, geom, DIVA)
 
     ! Calculate the driving stress and ocean back pressure
     call calc_driving_stress( DIVA%DIVA_graphs)
@@ -151,7 +153,7 @@ contains
       call calc_F_integrals( mesh, DIVA%DIVA_graphs)
 
       ! Calculate the "effective" friction coefficient (turning the SSA into the DIVA)
-      call calc_effective_basal_friction_coefficient( mesh, ice, bed_roughness, DIVA%DIVA_graphs)
+      call calc_effective_basal_friction_coefficient( mesh, ice, geom, bed_roughness, DIVA%DIVA_graphs)
 
       ! Solve the linearised DIVA to calculate a new velocity solution
       call solve_SSA_DIVA_linearised_ocean_pressure( DIVA%DIVA_graphs, &
@@ -251,12 +253,12 @@ contains
 
   end subroutine solve_DIVA_ocean_pressure
 
-  subroutine setup_DIVA_solver_on_graphs( mesh, ice, DIVA)
+  subroutine setup_DIVA_solver_on_graphs( mesh, geom, DIVA)
 
     ! In/output variables:
-    type(type_mesh),                     intent(in   ) :: mesh
-    type(type_ice_model),                intent(inout) :: ice
-    type(type_ice_velocity_solver_DIVA), intent(inout) :: DIVA
+    type(type_mesh),                      intent(in   ) :: mesh
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
+    type(type_ice_velocity_solver_DIVA),  intent(inout) :: DIVA
 
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'setup_DIVA_solver_on_graphs'
@@ -264,9 +266,9 @@ contains
     ! Add routine to path
     call init_routine( routine_name)
 
-    call create_ice_only_graph_pair( mesh, ice, DIVA%DIVA_graphs%graphs)
+    call create_ice_only_graph_pair( mesh, geom, DIVA%DIVA_graphs%graphs)
     call allocate_DIVA_solver_on_graphs( mesh, DIVA%DIVA_graphs)
-    call map_DIVA_from_mesh_to_graphs( mesh, ice, DIVA)
+    call map_DIVA_from_mesh_to_graphs( mesh, geom, DIVA)
 
     ! Finalise routine path
     call finalise_routine( routine_name, n_extra_MPI_windows_expected = 55)
@@ -433,12 +435,12 @@ contains
 
   end subroutine deallocate_DIVA_solver_on_graphs
 
-  subroutine map_DIVA_from_mesh_to_graphs( mesh, ice, DIVA)
+  subroutine map_DIVA_from_mesh_to_graphs( mesh, geom, DIVA)
 
     ! In/output variables:
-    type(type_mesh),                     intent(in   ) :: mesh
-    type(type_ice_model),                intent(in   ) :: ice
-    type(type_ice_velocity_solver_DIVA), intent(inout) :: DIVA
+    type(type_mesh),                      intent(in   ) :: mesh
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
+    type(type_ice_velocity_solver_DIVA),  intent(inout) :: DIVA
 
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'map_DIVA_from_mesh_to_graphs'
@@ -447,10 +449,10 @@ contains
     call init_routine( routine_name)
 
     ! Ice model forcing data
-    call map_mesh_vertices_to_graph ( mesh, ice%geom%Hi                           , DIVA%DIVA_graphs%graphs%graph_a, DIVA%DIVA_graphs%Hi_a                        )
-    call map_mesh_vertices_to_graph ( mesh, ice%geom%Hs                           , DIVA%DIVA_graphs%graphs%graph_a, DIVA%DIVA_graphs%Hs_a                        )
-    call map_mesh_vertices_to_graph ( mesh, ice%geom%Ho                           , DIVA%DIVA_graphs%graphs%graph_a, DIVA%DIVA_graphs%Ho_a                        )
-    call map_mesh_triangles_to_graph( mesh, ice%geom%fraction_gr_b                , DIVA%DIVA_graphs%graphs%graph_b, DIVA%DIVA_graphs%fraction_gr_b               )
+    call map_mesh_vertices_to_graph ( mesh, geom%Hi                           , DIVA%DIVA_graphs%graphs%graph_a, DIVA%DIVA_graphs%Hi_a                        )
+    call map_mesh_vertices_to_graph ( mesh, geom%Hs                           , DIVA%DIVA_graphs%graphs%graph_a, DIVA%DIVA_graphs%Hs_a                        )
+    call map_mesh_vertices_to_graph ( mesh, geom%Ho                           , DIVA%DIVA_graphs%graphs%graph_a, DIVA%DIVA_graphs%Ho_a                        )
+    call map_mesh_triangles_to_graph( mesh, geom%fraction_gr_b                , DIVA%DIVA_graphs%graphs%graph_b, DIVA%DIVA_graphs%fraction_gr_b               )
 
     ! Solution
     call map_mesh_triangles_to_graph( mesh, DIVA%u_vav_b                     , DIVA%DIVA_graphs%graphs%graph_b, DIVA%DIVA_graphs%u_vav_b                     )
@@ -1031,12 +1033,13 @@ contains
 
   end subroutine calc_F_integrals
 
-  subroutine calc_effective_basal_friction_coefficient( mesh, ice, bed_roughness, DIVA)
+  subroutine calc_effective_basal_friction_coefficient( mesh, ice, geom, bed_roughness, DIVA)
     !< Calculate the "effective" friction coefficient (turning the SSA into the DIVA)
 
     ! In/output variables:
     type(type_mesh),                            intent(in   ) :: mesh
     type(type_ice_model),                       intent(inout) :: ice
+    class(atype_ice_geometry_model_data),       intent(in   ) :: geom
     type(type_bed_roughness_model),             intent(in   ) :: bed_roughness
     type(type_ice_velocity_solver_DIVA_graphs), intent(inout) :: DIVA
 
@@ -1078,7 +1081,7 @@ contains
     ! This is where the sliding law is called!
     call map_graph_to_mesh_vertices( DIVA%graphs%graph_a, u_base_a, mesh, u_base_a_m)
     call map_graph_to_mesh_vertices( DIVA%graphs%graph_a, v_base_a, mesh, v_base_a_m)
-    call calc_basal_friction_coefficient( mesh, ice%geom, bed_roughness, u_base_a_m, v_base_a_m, &
+    call calc_basal_friction_coefficient( mesh, geom, bed_roughness, u_base_a_m, v_base_a_m, &
       ice%effective_pressure, ice%till_yield_stress, ice%basal_friction_coefficient)
     call map_mesh_vertices_to_graph( mesh, ice%basal_friction_coefficient, DIVA%graphs%graph_a, DIVA%basal_friction_coefficient_a)
 

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_solver_ocean_pressure.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/DIVA_solver_ocean_pressure.f90
@@ -1078,7 +1078,8 @@ contains
     ! This is where the sliding law is called!
     call map_graph_to_mesh_vertices( DIVA%graphs%graph_a, u_base_a, mesh, u_base_a_m)
     call map_graph_to_mesh_vertices( DIVA%graphs%graph_a, v_base_a, mesh, v_base_a_m)
-    call calc_basal_friction_coefficient( mesh, ice, bed_roughness, u_base_a_m, v_base_a_m)
+    call calc_basal_friction_coefficient( mesh, ice%geom, bed_roughness, u_base_a_m, v_base_a_m, &
+      ice%effective_pressure, ice%till_yield_stress, ice%basal_friction_coefficient)
     call map_mesh_vertices_to_graph( mesh, ice%basal_friction_coefficient, DIVA%graphs%graph_a, DIVA%basal_friction_coefficient_a)
 
     ! DENK DROM

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/SSA_DIVA_utilities.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/SSA_DIVA_utilities.f90
@@ -6,7 +6,7 @@ module SSA_DIVA_utilities
   use model_configuration, only: C
   use parameters, only: ice_density, grav
   use mesh_types, only: type_mesh
-  use ice_model_types, only: type_ice_model
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
   use mesh_disc_apply_operators, only: map_a_b_2D, ddx_a_b_2D, ddy_a_b_2D, ddx_b_a_2D, ddy_b_a_2D
   use checksum_mod, only: checksum
 
@@ -21,11 +21,11 @@ module SSA_DIVA_utilities
 
 contains
 
-  subroutine calc_driving_stress( mesh, ice, tau_dx_b, tau_dy_b)
+  subroutine calc_driving_stress( mesh, geom, tau_dx_b, tau_dy_b)
 
     ! In/output variables:
     type(type_mesh),                        intent(in   ) :: mesh
-    type(type_ice_model),                   intent(in   ) :: ice
+    class(atype_ice_geometry_model_data),   intent(in   ) :: geom
     real(dp), dimension(mesh%ti1:mesh%ti2), intent(  out) :: tau_dx_b, tau_dy_b
 
     ! Local variables:
@@ -44,9 +44,9 @@ contains
     allocate( dHs_dy_b( mesh%ti1:mesh%ti2))
 
     ! Calculate Hi, dHs/dx, and dHs/dy on the b-grid
-    call map_a_b_2D( mesh, ice%geom%Hi, Hi_b    )
-    call ddx_a_b_2D( mesh, ice%geom%Hs, dHs_dx_b)
-    call ddy_a_b_2D( mesh, ice%geom%Hs, dHs_dy_b)
+    call map_a_b_2D( mesh, geom%Hi, Hi_b    )
+    call ddx_a_b_2D( mesh, geom%Hs, dHs_dx_b)
+    call ddy_a_b_2D( mesh, geom%Hs, dHs_dy_b)
 
     ! Calculate the driving stress
     do ti = mesh%ti1, mesh%ti2

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/SSA_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/SSA_main.f90
@@ -12,6 +12,7 @@ module SSA_main
   use model_configuration, only: C
   use mesh_types, only: type_mesh
   use ice_model_types, only: type_ice_model, type_ice_velocity_solver_SSA
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
   use netcdf_io_main
   use sliding_laws, only: calc_basal_friction_coefficient
   use mesh_disc_apply_operators, only: ddx_a_b_2D, ddy_a_b_2D, map_a_b_2D, ddx_b_a_2D, ddy_b_a_2D, map_b_a_2D
@@ -82,13 +83,14 @@ contains
 
   end subroutine initialise_SSA_solver
 
-  subroutine solve_SSA( mesh, ice, bed_roughness, SSA, n_visc_its, n_Axb_its, &
+  subroutine solve_SSA( mesh, ice, geom, bed_roughness, SSA, n_visc_its, n_Axb_its, &
     BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
     !< Calculate ice velocities by solving the Shallow Shelf Approximation
 
     ! In/output variables:
     type(type_mesh),                    intent(in   ) :: mesh
     type(type_ice_model),               intent(inout) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
     type(type_bed_roughness_model),     intent(in   ) :: bed_roughness
     type(type_ice_velocity_solver_SSA), intent(inout) :: SSA
     integer,                            intent(  out) :: n_visc_its            ! Number of non-linear viscosity iterations
@@ -117,7 +119,7 @@ contains
     call init_routine( routine_name)
 
     ! if there is no grounded ice, or no sliding, no need to solve the SSA
-    grounded_ice_exists = any( ice%geom%mask_grounded_ice)
+    grounded_ice_exists = any( geom%mask_grounded_ice)
     call MPI_ALLREDUCE( MPI_IN_PLACE, grounded_ice_exists, 1, MPI_logical, MPI_LOR, MPI_COMM_WORLD, ierr)
     if (.not. grounded_ice_exists .or. C%choice_sliding_law == 'no_sliding') then
       SSA%u_b = 0._dp
@@ -145,7 +147,7 @@ contains
     end if
 
     ! Calculate the driving stress
-    call calc_driving_stress( mesh, ice%geom, SSA%tau_dx_b, SSA%tau_dy_b)
+    call calc_driving_stress( mesh, geom, SSA%tau_dx_b, SSA%tau_dy_b)
 
     ! Adaptive relaxation parameter for the viscosity iteration
     L2_uv                               = 1E9_dp
@@ -168,10 +170,10 @@ contains
         SSA%du_dx_a, SSA%du_dy_a, SSA%dv_dx_a, SSA%dv_dy_a)
 
       ! Calculate the effective viscosity for the current velocity solution
-      call calc_effective_viscosity( mesh, ice, SSA, Glens_flow_law_epsilon_sq_0_applied)
+      call calc_effective_viscosity( mesh, ice, geom, SSA, Glens_flow_law_epsilon_sq_0_applied)
 
       ! Calculate the basal friction coefficient betab for the current velocity solution
-      call calc_applied_basal_friction_coefficient( mesh, ice, bed_roughness, SSA)
+      call calc_applied_basal_friction_coefficient( mesh, ice, geom, bed_roughness, SSA)
 
       ! Solve the linearised SSA to calculate a new velocity solution
       call solve_SSA_DIVA_linearised( mesh, SSA%u_b, SSA%v_b, SSA%N_b, &
@@ -336,12 +338,13 @@ contains
 
   end subroutine calc_vertically_averaged_flow_parameter
 
-  subroutine calc_effective_viscosity( mesh, ice, SSA, Glens_flow_law_epsilon_sq_0_applied)
+  subroutine calc_effective_viscosity( mesh, ice, geom, SSA, Glens_flow_law_epsilon_sq_0_applied)
     !< Calculate the effective viscosity eta, the product term N = eta*H, and the gradients of N
 
     ! In/output variables:
     type(type_mesh),                    intent(in   ) :: mesh
     type(type_ice_model),               intent(inout) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
     type(type_ice_velocity_solver_SSA), intent(inout) :: SSA
     real(dp),                           intent(in   ) :: Glens_flow_law_epsilon_sq_0_applied
 
@@ -379,7 +382,7 @@ contains
     SSA%eta_a = min( max( SSA%eta_a, C%visc_eff_min), eta_max)
 
     ! Calculate the product term N = eta * H on the a-grid
-    SSA%N_a = SSA%eta_a * max( 0.1_dp, ice%geom%Hi)
+    SSA%N_a = SSA%eta_a * max( 0.1_dp, geom%Hi)
 
     ! Calculate the product term N and its gradients on the b-grid
     call map_a_b_2D( mesh, SSA%N_a, SSA%N_b    )
@@ -391,7 +394,7 @@ contains
 
   end subroutine calc_effective_viscosity
 
-  subroutine calc_applied_basal_friction_coefficient( mesh, ice, bed_roughness, SSA)
+  subroutine calc_applied_basal_friction_coefficient( mesh, ice, geom, bed_roughness, SSA)
     !< Calculate the applied basal friction coefficient beta_b, i.e. on the b-grid
     !< and scaled with the sub-grid grounded fraction
 
@@ -400,6 +403,7 @@ contains
     ! In/output variables:
     type(type_mesh),                    intent(in   ) :: mesh
     type(type_ice_model),               intent(inout) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
     type(type_bed_roughness_model),     intent(in   ) :: bed_roughness
     type(type_ice_velocity_solver_SSA), intent(inout) :: SSA
 
@@ -415,7 +419,7 @@ contains
     ! This is where the sliding law is called!
     call map_b_a_2D( mesh, SSA%u_b, u_a)
     call map_b_a_2D( mesh, SSA%v_b, v_a)
-    call calc_basal_friction_coefficient( mesh, ice%geom, bed_roughness, u_a, v_a, &
+    call calc_basal_friction_coefficient( mesh, geom, bed_roughness, u_a, v_a, &
       ice%effective_pressure, ice%till_yield_stress, ice%basal_friction_coefficient)
 
     ! Map the basal friction coefficient to the b-grid
@@ -424,7 +428,7 @@ contains
     ! Apply the sub-grid grounded fraction, and limit the friction coefficient to improve stability
     if (C%do_GL_subgrid_friction) then
       do ti = mesh%ti1, mesh%ti2
-        SSA%basal_friction_coefficient_b( ti) = SSA%basal_friction_coefficient_b( ti) * ice%geom%fraction_gr_b( ti)**C%subgrid_friction_exponent_on_B_grid
+        SSA%basal_friction_coefficient_b( ti) = SSA%basal_friction_coefficient_b( ti) * geom%fraction_gr_b( ti)**C%subgrid_friction_exponent_on_B_grid
       end do
     end if
 

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/SSA_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/SSA_main.f90
@@ -145,7 +145,7 @@ contains
     end if
 
     ! Calculate the driving stress
-    call calc_driving_stress( mesh, ice, SSA%tau_dx_b, SSA%tau_dy_b)
+    call calc_driving_stress( mesh, ice%geom, SSA%tau_dx_b, SSA%tau_dy_b)
 
     ! Adaptive relaxation parameter for the viscosity iteration
     L2_uv                               = 1E9_dp

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/SSA_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/SSA_DIVA/SSA_main.f90
@@ -415,7 +415,8 @@ contains
     ! This is where the sliding law is called!
     call map_b_a_2D( mesh, SSA%u_b, u_a)
     call map_b_a_2D( mesh, SSA%v_b, v_a)
-    call calc_basal_friction_coefficient( mesh, ice, bed_roughness, u_a, v_a)
+    call calc_basal_friction_coefficient( mesh, ice%geom, bed_roughness, u_a, v_a, &
+      ice%effective_pressure, ice%till_yield_stress, ice%basal_friction_coefficient)
 
     ! Map the basal friction coefficient to the b-grid
     call map_a_b_2D( mesh, ice%basal_friction_coefficient, SSA%basal_friction_coefficient_b)

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
@@ -121,7 +121,7 @@ contains
       case ('SIA')
         ! Calculate velocities according to the Shallow Ice Approximation
 
-        call solve_SIA( mesh, ice, ice%SIA)
+        call solve_SIA( mesh, ice, geom, ice%SIA)
         call set_ice_velocities_to_SIA_results( mesh, ice, ice%SIA)
 
         n_visc_its = 0
@@ -138,7 +138,7 @@ contains
       case ('SIA/SSA')
         ! Calculate velocities according to the hybrid SIA/SSA
 
-        call solve_SIA( mesh, ice, ice%SIA)
+        call solve_SIA( mesh, ice, geom, ice%SIA)
         call solve_SSA( mesh, ice, geom, bed_roughness, ice%SSA, &
           n_visc_its, n_Axb_its, &
           BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
@@ -128,7 +128,7 @@ contains
       case ('SSA')
         ! Calculate velocities according to the Shallow Shelf Approximation
 
-        call solve_SSA( mesh, ice, bed_roughness, ice%SSA, &
+        call solve_SSA( mesh, ice, ice%geom, bed_roughness, ice%SSA, &
           n_visc_its, n_Axb_its, &
           BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
         call set_ice_velocities_to_SSA_results( mesh, ice, ice%SSA)
@@ -137,7 +137,7 @@ contains
         ! Calculate velocities according to the hybrid SIA/SSA
 
         call solve_SIA( mesh, ice, ice%SIA)
-        call solve_SSA( mesh, ice, bed_roughness, ice%SSA, &
+        call solve_SSA( mesh, ice, ice%geom, bed_roughness, ice%SSA, &
           n_visc_its, n_Axb_its, &
           BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
         call set_ice_velocities_to_SIASSA_results( mesh, ice, ice%SIA, ice%SSA)

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
@@ -145,7 +145,7 @@ contains
       case ('DIVA')
         ! Calculate velocities according to the Depth-Integrated Viscosity Approximation
 
-        call solve_DIVA( mesh, ice, bed_roughness, ice%DIVA, &
+        call solve_DIVA( mesh, ice, ice%geom, bed_roughness, ice%DIVA, &
           n_visc_its, n_Axb_its, &
           BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
         call set_ice_velocities_to_DIVA_results( mesh, ice, ice%DIVA)

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
@@ -153,7 +153,7 @@ contains
       case ('BPA')
         ! Calculate velocities according to the Blatter-Pattyn Approximation
 
-        call solve_BPA( mesh, ice, bed_roughness, ice%BPA, &
+        call solve_BPA( mesh, ice, ice%geom, bed_roughness, ice%BPA, &
           n_visc_its, n_Axb_its, &
           BC_prescr_mask_bk, BC_prescr_u_bk, BC_prescr_v_bk)
         call set_ice_velocities_to_BPA_results( mesh, ice, ice%BPA)

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
@@ -12,6 +12,7 @@ module conservation_of_momentum_main
   use mesh_types, only: type_mesh
   use ice_model_types, only: type_ice_model, type_ice_velocity_solver_SIA, type_ice_velocity_solver_SSA, &
     type_ice_velocity_solver_DIVA, type_ice_velocity_solver_BPA, type_ice_velocity_solver_hybrid
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
   use SIA_main, only: initialise_SIA_solver, solve_SIA, remap_SIA_solver
   use SSA_main, only: initialise_SSA_solver, solve_SSA, remap_SSA_solver, &
     create_restart_file_SSA, write_to_restart_file_SSA
@@ -76,13 +77,14 @@ contains
 
   end subroutine initialise_velocity_solver
 
-  subroutine solve_stress_balance( mesh, ice, bed_roughness, BMB, region_name, n_visc_its, n_Axb_its, &
+  subroutine solve_stress_balance( mesh, ice, geom, bed_roughness, BMB, region_name, n_visc_its, n_Axb_its, &
     BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b, BC_prescr_mask_bk, BC_prescr_u_bk, BC_prescr_v_bk)
     !< Calculate all ice velocities based on the chosen stress balance approximation
 
     ! In/output variables:
     type(type_mesh),                        intent(inout) :: mesh
     type(type_ice_model),                   intent(inout) :: ice
+    class(atype_ice_geometry_model_data),   intent(in   ) :: geom
     type(type_bed_roughness_model),         intent(in   ) :: bed_roughness
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: BMB
     character(len=3),                       intent(in   ) :: region_name
@@ -128,7 +130,7 @@ contains
       case ('SSA')
         ! Calculate velocities according to the Shallow Shelf Approximation
 
-        call solve_SSA( mesh, ice, ice%geom, bed_roughness, ice%SSA, &
+        call solve_SSA( mesh, ice, geom, bed_roughness, ice%SSA, &
           n_visc_its, n_Axb_its, &
           BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
         call set_ice_velocities_to_SSA_results( mesh, ice, ice%SSA)
@@ -137,7 +139,7 @@ contains
         ! Calculate velocities according to the hybrid SIA/SSA
 
         call solve_SIA( mesh, ice, ice%SIA)
-        call solve_SSA( mesh, ice, ice%geom, bed_roughness, ice%SSA, &
+        call solve_SSA( mesh, ice, geom, bed_roughness, ice%SSA, &
           n_visc_its, n_Axb_its, &
           BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
         call set_ice_velocities_to_SIASSA_results( mesh, ice, ice%SIA, ice%SSA)
@@ -145,7 +147,7 @@ contains
       case ('DIVA')
         ! Calculate velocities according to the Depth-Integrated Viscosity Approximation
 
-        call solve_DIVA( mesh, ice, ice%geom, bed_roughness, ice%DIVA, &
+        call solve_DIVA( mesh, ice, geom, bed_roughness, ice%DIVA, &
           n_visc_its, n_Axb_its, &
           BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
         call set_ice_velocities_to_DIVA_results( mesh, ice, ice%DIVA)
@@ -153,7 +155,7 @@ contains
       case ('BPA')
         ! Calculate velocities according to the Blatter-Pattyn Approximation
 
-        call solve_BPA( mesh, ice, ice%geom, bed_roughness, ice%BPA, &
+        call solve_BPA( mesh, ice, geom, bed_roughness, ice%BPA, &
           n_visc_its, n_Axb_its, &
           BC_prescr_mask_bk, BC_prescr_u_bk, BC_prescr_v_bk)
         call set_ice_velocities_to_BPA_results( mesh, ice, ice%BPA)
@@ -161,7 +163,7 @@ contains
       case ('hybrid DIVA/BPA')
         ! Calculate velocities according to the hybrid DIVA/BPA
 
-        call solve_hybrid_DIVA_BPA( mesh, ice, ice%geom, bed_roughness, ice%hybrid, region_name, &
+        call solve_hybrid_DIVA_BPA( mesh, ice, geom, bed_roughness, ice%hybrid, region_name, &
           n_visc_its, n_Axb_its, &
           BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
         call set_ice_velocities_to_hybrid_DIVA_BPA_results( mesh, ice, ice%hybrid)

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/conservation_of_momentum_main.f90
@@ -161,7 +161,7 @@ contains
       case ('hybrid DIVA/BPA')
         ! Calculate velocities according to the hybrid DIVA/BPA
 
-        call solve_hybrid_DIVA_BPA( mesh, ice, bed_roughness, ice%hybrid, region_name, &
+        call solve_hybrid_DIVA_BPA( mesh, ice, ice%geom, bed_roughness, ice%hybrid, region_name, &
           n_visc_its, n_Axb_its, &
           BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
         call set_ice_velocities_to_hybrid_DIVA_BPA_results( mesh, ice, ice%hybrid)

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/hybrid_DIVA_BPA/hybrid_DIVA_BPA_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/hybrid_DIVA_BPA/hybrid_DIVA_BPA_main.f90
@@ -13,6 +13,7 @@ module hybrid_DIVA_BPA_main
   use mesh_types, only: type_mesh
   use graph_types, only: type_graph_pair
   use ice_model_types, only: type_ice_model, type_ice_velocity_solver_DIVA, type_ice_velocity_solver_BPA, type_ice_velocity_solver_hybrid
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
   use reallocate_mod, only: reallocate_bounds
   use remapping_main, only: map_from_mesh_to_mesh_with_reallocation_2D, map_from_mesh_to_mesh_with_reallocation_3D
   use DIVA_main, only: allocate_DIVA_solver, remap_DIVA_solver
@@ -106,7 +107,7 @@ contains
 
   end subroutine initialise_hybrid_DIVA_BPA_solver
 
-  subroutine solve_hybrid_DIVA_BPA( mesh, ice, bed_roughness, hybrid, region_name, &
+  subroutine solve_hybrid_DIVA_BPA( mesh, ice, geom, bed_roughness, hybrid, region_name, &
     n_visc_its, n_Axb_its, &
     BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b)
     !< Calculate ice velocities by solving the hybrid DIVA/BPA
@@ -114,6 +115,7 @@ contains
     ! In/output variables:
     type(type_mesh),                       intent(inout) :: mesh
     type(type_ice_model),                  intent(inout) :: ice
+    class(atype_ice_geometry_model_data),  intent(in   ) :: geom
     type(type_bed_roughness_model),        intent(in   ) :: bed_roughness
     type(type_ice_velocity_solver_hybrid), intent(inout) :: hybrid
     character(len=3),                      intent(in   ) :: region_name
@@ -143,7 +145,7 @@ contains
     call init_routine( routine_name)
 
     ! if there is no grounded ice, no need (in fact, no way) to solve the velocities
-    grounded_ice_exists = ANY( ice%geom%mask_grounded_ice)
+    grounded_ice_exists = ANY( geom%mask_grounded_ice)
     call MPI_ALLREDUCE( MPI_IN_PLACE, grounded_ice_exists, 1, MPI_logical, MPI_LOR, MPI_COMM_WORLD, ierr)
     if (.not. grounded_ice_exists) then
       hybrid%u_vav_b = 0._dp
@@ -173,7 +175,7 @@ contains
     end if
 
     ! Calculate zeta gradients
-    call calc_zeta_gradients( mesh, ice, ice%geom)
+    call calc_zeta_gradients( mesh, ice, geom)
 
     ! Calculate 3-D matrix operators for the current ice geometry
     call calc_3D_matrix_operators_mesh( mesh, &
@@ -182,8 +184,8 @@ contains
       ice%d2zeta_dx2_bk, ice%d2zeta_dxdy_bk, ice%d2zeta_dy2_bk)
 
     ! Calculate the driving stress
-    call calc_driving_stress_DIVA( mesh, ice%geom, hybrid%DIVA%tau_dx_b, hybrid%DIVA%tau_dy_b)
-    call calc_driving_stress_BPA ( mesh, ice, hybrid%BPA )
+    call calc_driving_stress_DIVA( mesh, geom, hybrid%DIVA%tau_dx_b, hybrid%DIVA%tau_dy_b)
+    call calc_driving_stress_BPA ( mesh, geom, hybrid%BPA )
 
     ! Calculate the solving masks for the hybrid solver
     call calc_hybrid_solver_masks_basic( mesh, hybrid, region_name)
@@ -215,13 +217,13 @@ contains
       call calc_vertical_shear_strain_rates_DIVA( mesh, hybrid%DIVA)
 
       ! Calculate the effective viscosity for the current velocity solution
-      call calc_effective_viscosity_DIVA( mesh, ice, ice%geom, hybrid%DIVA, Glens_flow_law_epsilon_sq_0_applied)
+      call calc_effective_viscosity_DIVA( mesh, ice, geom, hybrid%DIVA, Glens_flow_law_epsilon_sq_0_applied)
 
       ! Calculate the F-integrals
-      call calc_F_integrals_DIVA( mesh, ice%geom, hybrid%DIVA)
+      call calc_F_integrals_DIVA( mesh, geom, hybrid%DIVA)
 
       ! Calculate the "effective" friction coefficient (turning the SSA into the DIVA)
-      call calc_effective_basal_friction_coefficient_DIVA( mesh, ice, ice%geom, bed_roughness, hybrid%DIVA)
+      call calc_effective_basal_friction_coefficient_DIVA( mesh, ice, geom, bed_roughness, hybrid%DIVA)
 
       ! == Calculate secondary terms in the BPA
       ! =======================================
@@ -233,7 +235,7 @@ contains
       call calc_effective_viscosity_BPA( mesh, ice, hybrid%BPA, Glens_flow_law_epsilon_sq_0_applied)
 
       ! Calculate the basal friction coefficient betab for the current velocity solution
-      call calc_applied_basal_friction_coefficient_BPA( mesh, ice, ice%geom, bed_roughness, hybrid%BPA)
+      call calc_applied_basal_friction_coefficient_BPA( mesh, ice, geom, bed_roughness, hybrid%BPA)
 
       ! == Solve the linearised hybrid DIVA/BPA
       ! =======================================

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/hybrid_DIVA_BPA/hybrid_DIVA_BPA_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/hybrid_DIVA_BPA/hybrid_DIVA_BPA_main.f90
@@ -173,7 +173,7 @@ contains
     end if
 
     ! Calculate zeta gradients
-    call calc_zeta_gradients( mesh, ice)
+    call calc_zeta_gradients( mesh, ice, ice%geom)
 
     ! Calculate 3-D matrix operators for the current ice geometry
     call calc_3D_matrix_operators_mesh( mesh, &
@@ -233,7 +233,7 @@ contains
       call calc_effective_viscosity_BPA( mesh, ice, hybrid%BPA, Glens_flow_law_epsilon_sq_0_applied)
 
       ! Calculate the basal friction coefficient betab for the current velocity solution
-      call calc_applied_basal_friction_coefficient_BPA( mesh, ice, bed_roughness, hybrid%BPA)
+      call calc_applied_basal_friction_coefficient_BPA( mesh, ice, ice%geom, bed_roughness, hybrid%BPA)
 
       ! == Solve the linearised hybrid DIVA/BPA
       ! =======================================

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/hybrid_DIVA_BPA/hybrid_DIVA_BPA_main.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/hybrid_DIVA_BPA/hybrid_DIVA_BPA_main.f90
@@ -182,7 +182,7 @@ contains
       ice%d2zeta_dx2_bk, ice%d2zeta_dxdy_bk, ice%d2zeta_dy2_bk)
 
     ! Calculate the driving stress
-    call calc_driving_stress_DIVA( mesh, ice, hybrid%DIVA%tau_dx_b, hybrid%DIVA%tau_dy_b)
+    call calc_driving_stress_DIVA( mesh, ice%geom, hybrid%DIVA%tau_dx_b, hybrid%DIVA%tau_dy_b)
     call calc_driving_stress_BPA ( mesh, ice, hybrid%BPA )
 
     ! Calculate the solving masks for the hybrid solver
@@ -215,13 +215,13 @@ contains
       call calc_vertical_shear_strain_rates_DIVA( mesh, hybrid%DIVA)
 
       ! Calculate the effective viscosity for the current velocity solution
-      call calc_effective_viscosity_DIVA( mesh, ice, hybrid%DIVA, Glens_flow_law_epsilon_sq_0_applied)
+      call calc_effective_viscosity_DIVA( mesh, ice, ice%geom, hybrid%DIVA, Glens_flow_law_epsilon_sq_0_applied)
 
       ! Calculate the F-integrals
-      call calc_F_integrals_DIVA( mesh, ice, hybrid%DIVA)
+      call calc_F_integrals_DIVA( mesh, ice%geom, hybrid%DIVA)
 
       ! Calculate the "effective" friction coefficient (turning the SSA into the DIVA)
-      call calc_effective_basal_friction_coefficient_DIVA( mesh, ice, bed_roughness, hybrid%DIVA)
+      call calc_effective_basal_friction_coefficient_DIVA( mesh, ice, ice%geom, bed_roughness, hybrid%DIVA)
 
       ! == Calculate secondary terms in the BPA
       ! =======================================

--- a/src/UFEMISM/ice_dynamics/conservation_of_momentum/sliding_laws.f90
+++ b/src/UFEMISM/ice_dynamics/conservation_of_momentum/sliding_laws.f90
@@ -6,13 +6,14 @@ module sliding_laws
   use call_stack_and_comp_time_tracking, only: crash, init_routine, finalise_routine
   use model_configuration, only: C
   use mesh_types, only: type_mesh
-  use ice_model_types, only: type_ice_model
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
   use bed_roughness_model_types, only: type_bed_roughness_model
   use parameters
   use mesh_disc_apply_operators, only: map_b_a_2D
   use mesh_utilities, only: extrapolate_Gaussian
   use mpi_distributed_memory, only: gather_to_all
   use Schoof_SSA_solution, only: Schoof2006_icestream
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
 
   implicit none
 
@@ -22,18 +23,21 @@ module sliding_laws
 
 contains
 
-  subroutine calc_basal_friction_coefficient( mesh, ice, bed_roughness, u_a, v_a)
+  subroutine calc_basal_friction_coefficient( mesh, geom, bed_roughness, u_a, v_a, &
+    effective_pressure, till_yield_stress, basal_friction_coefficient)
     ! Calculate the effective basal friction coefficient using the specified sliding law
 
     ! In/output variables:
-    type(type_mesh),                intent(in   ) :: mesh
-    type(type_ice_model),           intent(inout) :: ice
-    type(type_bed_roughness_model), intent(in   ) :: bed_roughness
-    real(dp), dimension(:),         intent(in   ) :: u_a
-    real(dp), dimension(:),         intent(in   ) :: v_a
+    type(type_mesh),                        intent(in   ) :: mesh
+    class(atype_ice_geometry_model_data),   intent(in   ) :: geom
+    type(type_bed_roughness_model),         intent(in   ) :: bed_roughness
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: u_a, v_a
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: effective_pressure
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: till_yield_stress
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: basal_friction_coefficient
 
     ! Local variables:
-    character(len=1024), parameter :: routine_name = 'calc_basal_friction_coefficient'
+    character(len=*), parameter :: routine_name = 'calc_basal_friction_coefficient'
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -43,32 +47,38 @@ contains
       call crash('unknown choice_sliding_law "' // trim( C%choice_sliding_law) // '"')
     case ('no_sliding')
       ! No sliding allowed (implemented directly in linear equations of momentum balance; choice of beta is trivial)
-      ice%basal_friction_coefficient = 0._dp
+      basal_friction_coefficient = 0._dp
     case ('idealised')
       ! Sliding laws for some idealised experiments
-      call calc_sliding_law_idealised(   mesh, ice, u_a, v_a)
+      call calc_sliding_law_idealised( mesh, geom, u_a, v_a, &
+        till_yield_stress, basal_friction_coefficient)
     case ('Weertman')
       ! Weertman-type ("power law") sliding law
-      call calc_sliding_law_Weertman(    mesh, ice, bed_roughness, u_a, v_a)
+      call calc_sliding_law_Weertman( mesh, geom, bed_roughness, u_a, v_a, basal_friction_coefficient)
     case ('Coulomb')
       ! Coulomb-type sliding law
-      call calc_sliding_law_Coulomb(     mesh, ice, bed_roughness, u_a, v_a)
+      call calc_sliding_law_Coulomb( mesh, geom, bed_roughness, u_a, v_a, &
+        effective_pressure, till_yield_stress, basal_friction_coefficient)
     case ('Budd')
       ! Regularised Coulomb-type sliding law
-      call calc_sliding_law_Budd(        mesh, ice, bed_roughness, u_a, v_a)
+      call calc_sliding_law_Budd( mesh, geom, bed_roughness, u_a, v_a, &
+        effective_pressure, till_yield_stress, basal_friction_coefficient)
     case ('Tsai2015')
       ! Modified power-law relation according to Tsai et al. (2015)
-      call calc_sliding_law_Tsai2015(    mesh, ice, bed_roughness, u_a, v_a)
+      call calc_sliding_law_Tsai2015( mesh, geom, bed_roughness, u_a, v_a, &
+        effective_pressure, basal_friction_coefficient)
     case ('Schoof2005')
       ! Modified power-law relation according to Schoof (2005)
-      call calc_sliding_law_Schoof2005(  mesh, ice, bed_roughness, u_a, v_a)
+      call calc_sliding_law_Schoof2005( mesh, geom, bed_roughness, u_a, v_a, &
+        effective_pressure, basal_friction_coefficient)
     case ('Zoet-Iverson')
       ! Zoet-Iverson sliding law (Zoet & Iverson, 2020)
-      call calc_sliding_law_ZoetIverson( mesh, ice, bed_roughness, u_a, v_a)
+      call calc_sliding_law_ZoetIverson( mesh, geom, bed_roughness, u_a, v_a, &
+        effective_pressure, till_yield_stress, basal_friction_coefficient)
     end select
 
     ! Limit basal friction coefficient to improve stability
-    ice%basal_friction_coefficient = min( C%slid_beta_max, ice%basal_friction_coefficient)
+    basal_friction_coefficient = min( C%slid_beta_max, basal_friction_coefficient)
 
     ! Finalise routine path
     call finalise_routine( routine_name)
@@ -78,17 +88,18 @@ contains
 ! == Different sliding laws
 ! =========================
 
-  subroutine calc_sliding_law_Weertman( mesh, ice, bed_roughness, u_a, v_a)
+  subroutine calc_sliding_law_Weertman( mesh, geom, bed_roughness, u_a, v_a, basal_friction_coefficient)
     ! Weertman-type ("power law") sliding law
 
     ! In/output variables:
     type(type_mesh),                        intent(in   ) :: mesh
-    type(type_ice_model),                   intent(inout) :: ice
+    class(atype_ice_geometry_model_data),   intent(in   ) :: geom
     type(type_bed_roughness_model),         intent(in   ) :: bed_roughness
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: u_a, v_a
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: basal_friction_coefficient
 
     ! Local variables:
-    character(len=1024), parameter         :: routine_name = 'calc_sliding_law_Weertman'
+    character(len=*), parameter            :: routine_name = 'calc_sliding_law_Weertman'
     real(dp), dimension(mesh%vi1:mesh%vi2) :: bed_roughness_applied
     integer                                :: vi
     real(dp)                               :: uabs
@@ -102,7 +113,7 @@ contains
     ! Assume that bed roughness is represented by the beta_sq field
 
     ! Scale bed roughness based on grounded area fractions
-    call apply_grounded_fractions_to_bed_roughness( mesh, ice, &
+    call apply_grounded_fractions_to_bed_roughness( mesh, geom, &
       bed_roughness%beta_sq, bed_roughness_applied)
 
     ! == Basal friction field
@@ -115,7 +126,7 @@ contains
       uabs = sqrt( C%slid_delta_v**2 + u_a( vi)**2 + v_a( vi)**2)
 
       ! Asay-Davis et al. (2016), Eq. 6; replacing beta_sq by the bed roughness field from above
-      ice%basal_friction_coefficient( vi) = bed_roughness_applied( vi) * uabs ** (1._dp / C%slid_Weertman_m - 1._dp)
+      basal_friction_coefficient( vi) = bed_roughness_applied( vi) * uabs ** (1._dp / C%slid_Weertman_m - 1._dp)
 
     end do
 
@@ -124,17 +135,21 @@ contains
 
   end subroutine calc_sliding_law_Weertman
 
-  subroutine calc_sliding_law_Coulomb( mesh, ice, bed_roughness, u_a, v_a)
+  subroutine calc_sliding_law_Coulomb( mesh, geom, bed_roughness, u_a, v_a, &
+    effective_pressure, till_yield_stress, basal_friction_coefficient)
     ! Coulomb-type sliding law
 
     ! In/output variables:
     type(type_mesh),                        intent(in   ) :: mesh
-    type(type_ice_model),                   intent(inout) :: ice
+    class(atype_ice_geometry_model_data),   intent(in   ) :: geom
     type(type_bed_roughness_model),         intent(in   ) :: bed_roughness
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: u_a, v_a
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: effective_pressure
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: till_yield_stress
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: basal_friction_coefficient
 
     ! Local variables:
-    character(len=1024), parameter         :: routine_name = 'calc_sliding_law_Coulomb'
+    character(len=*), parameter            :: routine_name = 'calc_sliding_law_Coulomb'
     real(dp), dimension(mesh%vi1:mesh%vi2) :: bed_roughness_applied
     integer                                :: vi
     real(dp)                               :: uabs
@@ -148,19 +163,19 @@ contains
     ! Compute bed roughness based on till friction angle
 
     ! Scale bed roughness based on grounded area fractions
-    call apply_grounded_fractions_to_bed_roughness( mesh, ice, &
+    call apply_grounded_fractions_to_bed_roughness( mesh, geom, &
       bed_roughness%till_friction_angle, bed_roughness_applied)
 
     ! == Till yield stress
     ! ====================
 
     ! Calculate the till yield stress from the effective pressure and bed roughness
-    ice%till_yield_stress = ice%effective_pressure * tan(pi / 180._dp) * bed_roughness_applied
+    till_yield_stress = effective_pressure * tan(pi / 180._dp) * bed_roughness_applied
 
     ! == Extend till yield stress over ice-free land neighbours
     ! =========================================================
 
-    call extend_till_yield_stress_to_neighbours( mesh, ice)
+    call extend_till_yield_stress_to_neighbours( mesh, geom, till_yield_stress)
 
     ! == Basal friction field
     ! =======================
@@ -171,7 +186,7 @@ contains
       ! Include a normalisation term following Bueler & Brown (2009) to prevent divide-by-zero errors.
       uabs = sqrt( C%slid_delta_v**2 + u_a( vi)**2 + v_a( vi)**2)
 
-      ice%basal_friction_coefficient( vi) = ice%till_yield_stress( vi) / uabs
+      basal_friction_coefficient( vi) = till_yield_stress( vi) / uabs
 
     end do
 
@@ -180,17 +195,21 @@ contains
 
   end subroutine calc_sliding_law_Coulomb
 
-  subroutine calc_sliding_law_Budd( mesh, ice, bed_roughness, u_a, v_a)
+  subroutine calc_sliding_law_Budd( mesh, geom, bed_roughness, u_a, v_a, &
+    effective_pressure, till_yield_stress, basal_friction_coefficient)
     ! Budd-type sliding law (formerly known as regularised Coulomb-type sliding law)
 
     ! In/output variables:
     type(type_mesh),                        intent(in   ) :: mesh
-    type(type_ice_model),                   intent(inout) :: ice
+    class(atype_ice_geometry_model_data),   intent(in   ) :: geom
     type(type_bed_roughness_model),         intent(in   ) :: bed_roughness
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: u_a, v_a
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: effective_pressure
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: till_yield_stress
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: basal_friction_coefficient
 
     ! Local variables:
-    character(len=1024), parameter         :: routine_name = 'calc_sliding_law_Budd'
+    character(len=*), parameter            :: routine_name = 'calc_sliding_law_Budd'
     real(dp), dimension(mesh%vi1:mesh%vi2) :: bed_roughness_applied
     integer                                :: vi
     real(dp)                               :: uabs
@@ -204,19 +223,19 @@ contains
     ! Compute bed roughness based on till friction angle
 
     ! Scale bed roughness based on grounded area fractions
-    call apply_grounded_fractions_to_bed_roughness( mesh, ice, &
+    call apply_grounded_fractions_to_bed_roughness( mesh, geom, &
       bed_roughness%till_friction_angle, bed_roughness_applied)
 
     ! == Till yield stress
     ! ====================
 
     ! Calculate the till yield stress from the effective pressure and bed roughness
-    ice%till_yield_stress = ice%effective_pressure * tan(pi / 180._dp) * bed_roughness_applied
+    till_yield_stress = effective_pressure * tan(pi / 180._dp) * bed_roughness_applied
 
     ! == Extend till yield stress over ice-free land neighbours
     ! =========================================================
 
-    call extend_till_yield_stress_to_neighbours( mesh, ice)
+    call extend_till_yield_stress_to_neighbours( mesh, geom, till_yield_stress)
 
     ! == Basal friction field
     ! =======================
@@ -227,7 +246,8 @@ contains
       ! Include a normalisation term following Bueler & Brown (2009) to prevent divide-by-zero errors.
       uabs = sqrt( C%slid_delta_v**2 + u_a( vi)**2 + v_a( vi)**2)
 
-      ice%basal_friction_coefficient( vi) = ice%till_yield_stress( vi) * uabs ** (C%slid_Budd_q_plastic - 1._dp) / (C%slid_Budd_u_threshold ** C%slid_Budd_q_plastic)
+      basal_friction_coefficient( vi) = till_yield_stress( vi) * &
+        uabs ** (C%slid_Budd_q_plastic - 1._dp) / (C%slid_Budd_u_threshold ** C%slid_Budd_q_plastic)
 
     end do
 
@@ -236,7 +256,8 @@ contains
 
   end subroutine calc_sliding_law_Budd
 
-  subroutine calc_sliding_law_Tsai2015(  mesh, ice, bed_roughness, u_a, v_a)
+  subroutine calc_sliding_law_Tsai2015( mesh, geom, bed_roughness, u_a, v_a, &
+    effective_pressure, basal_friction_coefficient)
     ! Modified power-law relation according to Tsai et al. (2015)
     ! (implementation based on equations provided by Asay-Davis et al., 2016)
     !
@@ -249,12 +270,14 @@ contains
 
     ! In/output variables:
     type(type_mesh),                        intent(in   ) :: mesh
-    type(type_ice_model),                   intent(inout) :: ice
+    class(atype_ice_geometry_model_data),   intent(in   ) :: geom
     type(type_bed_roughness_model),         intent(in   ) :: bed_roughness
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: u_a, v_a
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: effective_pressure
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: basal_friction_coefficient
 
     ! Local variables:
-    character(len=1024), parameter         :: routine_name = 'calc_sliding_law_Tsai2015'
+    character(len=*), parameter            :: routine_name = 'calc_sliding_law_Tsai2015'
     real(dp), dimension(mesh%vi1:mesh%vi2) :: bed_roughness_applied
     integer                                :: vi
     real(dp)                               :: uabs
@@ -268,7 +291,7 @@ contains
     ! Assume that bed roughness is represented by the beta_sq field
 
     ! Scale bed roughness based on grounded area fractions
-    call apply_grounded_fractions_to_bed_roughness( mesh, ice, &
+    call apply_grounded_fractions_to_bed_roughness( mesh, geom, &
       bed_roughness%beta_sq, bed_roughness_applied)
 
     ! == Basal friction field
@@ -281,7 +304,7 @@ contains
       uabs = sqrt( C%slid_delta_v**2 + u_a( vi)**2 + v_a( vi)**2)
 
       ! Asay-Davis et al. (2016), Eq. 7; replacing beta_sq by the bed roughness field from above
-      ice%basal_friction_coefficient( vi) = min( bed_roughness%alpha_sq( vi) * ice%effective_pressure( vi), &
+      basal_friction_coefficient( vi) = min( bed_roughness%alpha_sq( vi) * effective_pressure( vi), &
         bed_roughness_applied( vi) * uabs ** (1._dp / C%slid_Weertman_m)) * uabs**(-1._dp)
 
     end do
@@ -291,8 +314,9 @@ contains
 
   end subroutine calc_sliding_law_Tsai2015
 
-  subroutine calc_sliding_law_Schoof2005(  mesh, ice, bed_roughness, u_a, v_a)
-    ! Modified power-law relation according to Tsai et al. (2015)
+  subroutine calc_sliding_law_Schoof2005( mesh, geom, bed_roughness, u_a, v_a, &
+    effective_pressure, basal_friction_coefficient)
+    ! Modified power-law relation according to Schoof (2005)
     ! (implementation based on equations provided by Asay-Davis et al., 2016)
     !
     ! Asay-Davis et al.: Experimental design for three interrelated marine ice sheet and ocean model
@@ -303,12 +327,14 @@ contains
 
     ! In/output variables:
     type(type_mesh),                        intent(in   ) :: mesh
-    type(type_ice_model),                   intent(inout) :: ice
+    class(atype_ice_geometry_model_data),   intent(in   ) :: geom
     type(type_bed_roughness_model),         intent(in   ) :: bed_roughness
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: u_a, v_a
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: effective_pressure
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: basal_friction_coefficient
 
     ! Local variables:
-    character(len=1024), parameter         :: routine_name = 'calc_sliding_law_Schoof2005'
+    character(len=*), parameter            :: routine_name = 'calc_sliding_law_Schoof2005'
     real(dp), dimension(mesh%vi1:mesh%vi2) :: bed_roughness_applied
     integer                                :: vi
     real(dp)                               :: uabs
@@ -322,7 +348,7 @@ contains
     ! Assume that bed roughness is represented by the beta_sq field
 
     ! Scale bed roughness based on grounded area fractions
-    call apply_grounded_fractions_to_bed_roughness( mesh, ice, &
+    call apply_grounded_fractions_to_bed_roughness( mesh, geom, &
       bed_roughness%beta_sq, bed_roughness_applied)
 
     ! == Basal friction field
@@ -335,8 +361,10 @@ contains
       uabs = sqrt( C%slid_delta_v**2 + u_a( vi)**2 + v_a( vi)**2)
 
       ! Asay-Davis et al. (2016), Eq. 11; replacing beta_sq by the bed roughness field from above
-      ice%basal_friction_coefficient( vi) = ((bed_roughness_applied( vi) * uabs**(1._dp / C%slid_Weertman_m) * bed_roughness%alpha_sq( vi) * ice%effective_pressure( vi)) / &
-        ((bed_roughness_applied( vi)**C%slid_Weertman_m * uabs + (bed_roughness%alpha_sq( vi) * ice%effective_pressure( vi))**C%slid_Weertman_m)**(1._dp / C%slid_Weertman_m))) * uabs**(-1._dp)
+      basal_friction_coefficient( vi) = &
+        ((bed_roughness_applied( vi) * uabs**(1._dp / C%slid_Weertman_m) * bed_roughness%alpha_sq( vi) * effective_pressure( vi)) / &
+         ((bed_roughness_applied( vi)**C%slid_Weertman_m * uabs + (bed_roughness%alpha_sq( vi) * &
+           effective_pressure( vi))**C%slid_Weertman_m)**(1._dp / C%slid_Weertman_m))) * uabs**(-1._dp)
 
     end do
 
@@ -345,17 +373,21 @@ contains
 
   end subroutine calc_sliding_law_Schoof2005
 
-  subroutine calc_sliding_law_ZoetIverson( mesh, ice, bed_roughness, u_a, v_a)
+  subroutine calc_sliding_law_ZoetIverson( mesh, geom, bed_roughness, u_a, v_a, &
+    effective_pressure, till_yield_stress, basal_friction_coefficient)
     ! Zoet-Iverson sliding law (Zoet & Iverson, 2020)
 
     ! In/output variables:
     type(type_mesh),                        intent(in   ) :: mesh
-    type(type_ice_model),                   intent(inout) :: ice
+    class(atype_ice_geometry_model_data),   intent(in   ) :: geom
     type(type_bed_roughness_model),         intent(in   ) :: bed_roughness
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: u_a, v_a
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: effective_pressure
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: till_yield_stress
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: basal_friction_coefficient
 
     ! Local variables:
-    character(len=1024), parameter         :: routine_name = 'calc_sliding_law_ZoetIverson'
+    character(len=*), parameter            :: routine_name = 'calc_sliding_law_ZoetIverson'
     real(dp), dimension(mesh%vi1:mesh%vi2) :: bed_roughness_applied
     integer                                :: vi
     real(dp)                               :: uabs
@@ -369,19 +401,19 @@ contains
     ! Compute bed roughness based on till friction angle
 
     ! Scale bed roughness based on grounded area fractions
-    call apply_grounded_fractions_to_bed_roughness( mesh, ice, &
+    call apply_grounded_fractions_to_bed_roughness( mesh, geom, &
       bed_roughness%till_friction_angle, bed_roughness_applied)
 
     ! == Till yield stress
     ! ====================
 
     ! Calculate the till yield stress from the effective pressure and bed roughness
-    ice%till_yield_stress = ice%effective_pressure * tan(pi / 180._dp) * bed_roughness_applied
+    till_yield_stress = effective_pressure * tan(pi / 180._dp) * bed_roughness_applied
 
     ! == Extend till yield stress over ice-free land neighbours
     ! =========================================================
 
-    call extend_till_yield_stress_to_neighbours( mesh, ice)
+    call extend_till_yield_stress_to_neighbours( mesh, geom, till_yield_stress)
 
     ! == Basal friction field
     ! =======================
@@ -393,7 +425,7 @@ contains
       uabs = sqrt( C%slid_delta_v**2 + u_a( vi)**2 + v_a( vi)**2)
 
       ! Zoet & Iverson (2020), Eq. (3) (divided by u to give beta = tau_b / u)
-      ice%basal_friction_coefficient( vi) = ice%till_yield_stress( vi) * &
+      basal_friction_coefficient( vi) = till_yield_stress( vi) * &
         (uabs**(1._dp / C%slid_ZI_p - 1._dp)) * ((uabs + C%slid_ZI_ut)**(-1._dp / C%slid_ZI_p))
 
     end do
@@ -403,16 +435,19 @@ contains
 
   end subroutine calc_sliding_law_ZoetIverson
 
-  subroutine calc_sliding_law_idealised(  mesh, ice, u_a, v_a)
+  subroutine calc_sliding_law_idealised( mesh, geom, u_a, v_a, &
+    till_yield_stress, basal_friction_coefficient)
     ! Sliding laws for some idealised experiments
 
     ! In/output variables:
     type(type_mesh),                        intent(in   ) :: mesh
-    type(type_ice_model),                   intent(inout) :: ice
+    class(atype_ice_geometry_model_data),   intent(in   ) :: geom
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: u_a, v_a
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: till_yield_stress
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: basal_friction_coefficient
 
     ! Local variables:
-    character(len=1024), parameter :: routine_name = 'calc_sliding_law_idealised'
+    character(len=*), parameter :: routine_name = 'calc_sliding_law_idealised'
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -422,19 +457,20 @@ contains
     case default
       call crash('unknown choice_idealised_sliding_law "' // trim( C%choice_idealised_sliding_law) // '"')
     case ('SSA_icestream')
-      call calc_sliding_law_idealised_SSA_icestream( mesh, ice, u_a, v_a)
+      call calc_sliding_law_idealised_SSA_icestream( mesh, u_a, v_a, &
+        till_yield_stress, basal_friction_coefficient)
     case ('ISMIP-HOM_C')
       ! ISMIP-HOM experiment C
-      call calc_sliding_law_idealised_ISMIP_HOM_C( mesh, ice)
+      call calc_sliding_law_idealised_ISMIP_HOM_C( mesh, basal_friction_coefficient)
     case ('ISMIP-HOM_D')
       ! ISMIP-HOM experiment D
-      call calc_sliding_law_idealised_ISMIP_HOM_D( mesh, ice)
+      call calc_sliding_law_idealised_ISMIP_HOM_D( mesh, basal_friction_coefficient)
     case ('ISMIP-HOM_E')
       ! ISMIP-HOM experiment E
       call crash('the Glacier Arolla experiment is not implemented in UFEMISM')
     case ('ISMIP-HOM_F')
       ! ISMIP-HOM experiment F
-      call calc_sliding_law_idealised_ISMIP_HOM_F( mesh, ice)
+      call calc_sliding_law_idealised_ISMIP_HOM_F( mesh, basal_friction_coefficient)
     end select
 
     ! Finalise routine path
@@ -442,20 +478,22 @@ contains
 
   end subroutine calc_sliding_law_idealised
 
-  subroutine calc_sliding_law_idealised_SSA_icestream( mesh, ice, u_a, v_a)
+  subroutine calc_sliding_law_idealised_SSA_icestream( mesh, u_a, v_a, &
+    till_yield_stress, basal_friction_coefficient)
     ! Sliding laws for some idealised experiments
     !
     ! SSA_icestream
 
     ! In/output variables:
     type(type_mesh),                        intent(in   ) :: mesh
-    type(type_ice_model),                   intent(inout) :: ice
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: u_a, v_a
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: till_yield_stress
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: basal_friction_coefficient
 
     ! Local variables:
-    character(len=1024), parameter:: routine_name = 'calc_sliding_law_idealised_SSA_icestream'
-    integer                       :: vi
-    real(dp)                      :: y, u, uabs
+    character(len=*), parameter :: routine_name = 'calc_sliding_law_idealised_SSA_icestream'
+    integer                     :: vi
+    real(dp)                    :: y, u, uabs
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -465,12 +503,12 @@ contains
       y = mesh%V( vi,2)
       call Schoof2006_icestream( C%uniform_Glens_flow_factor, C%Glens_flow_law_exponent, C%refgeo_idealised_SSA_icestream_Hi, &
         C%refgeo_idealised_SSA_icestream_dhdx, C%refgeo_idealised_SSA_icestream_L, C%refgeo_idealised_SSA_icestream_m, &
-        y, u, ice%till_yield_stress( vi))
+        y, u, till_yield_stress( vi))
 
       ! Include a normalisation term following Bueler & Brown (2009) to prevent divide-by-zero errors.
       uabs = sqrt( C%slid_delta_v**2 + u_a( vi)**2 + v_a( vi)**2)
 
-      ice%basal_friction_coefficient( vi) = ice%till_yield_stress( vi) / uabs
+      basal_friction_coefficient( vi) = till_yield_stress( vi) / uabs
 
     end do
 
@@ -479,19 +517,19 @@ contains
 
   end subroutine calc_sliding_law_idealised_SSA_icestream
 
-  subroutine calc_sliding_law_idealised_ISMIP_HOM_C( mesh, ice)
+  subroutine calc_sliding_law_idealised_ISMIP_HOM_C( mesh, basal_friction_coefficient)
     ! Sliding laws for some idealised experiments
     !
     ! ISMIP-HOM experiment C
 
     ! In/output variables:
-    type(type_mesh),      intent(in   ) :: mesh
-    type(type_ice_model), intent(inout) :: ice
+    type(type_mesh),                        intent(in   ) :: mesh
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: basal_friction_coefficient
 
     ! Local variables:
-    character(len=1024), parameter                     :: routine_name = 'calc_sliding_law_idealised_ISMIP_HOM_C'
-    integer                                            :: vi
-    real(dp)                                           :: x,y
+    character(len=*), parameter :: routine_name = 'calc_sliding_law_idealised_ISMIP_HOM_C'
+    integer                     :: vi
+    real(dp)                    :: x,y
 
     ! Add routine to path
     call init_routine( routine_name)
@@ -499,7 +537,7 @@ contains
     do vi = mesh%vi1, mesh%vi2
       x = mesh%V( vi,1)
       y = mesh%V( vi,2)
-      ice%basal_friction_coefficient( vi) = 1000._dp + &
+      basal_friction_coefficient( vi) = 1000._dp + &
         1000._dp * sin( 2._dp * pi * x / C%refgeo_idealised_ISMIP_HOM_L) * &
                    sin( 2._dp * pi * y / C%refgeo_idealised_ISMIP_HOM_L)
     end do
@@ -509,26 +547,26 @@ contains
 
   end subroutine calc_sliding_law_idealised_ISMIP_HOM_C
 
-  subroutine calc_sliding_law_idealised_ISMIP_HOM_D( mesh, ice)
+  subroutine calc_sliding_law_idealised_ISMIP_HOM_D( mesh, basal_friction_coefficient)
     ! Sliding laws for some idealised experiments
     !
     ! ISMIP-HOM experiment D
 
     ! In/output variables:
-    type(type_mesh),      intent(in   ) :: mesh
-    type(type_ice_model), intent(inout) :: ice
+    type(type_mesh),                        intent(in   ) :: mesh
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: basal_friction_coefficient
 
     ! Local variables:
-    character(len=1024), parameter :: routine_name = 'calc_sliding_law_idealised_ISMIP_HOM_D'
-    integer                        :: vi
-    real(dp)                       :: x
+    character(len=*), parameter :: routine_name = 'calc_sliding_law_idealised_ISMIP_HOM_D'
+    integer                     :: vi
+    real(dp)                    :: x
 
     ! Add routine to path
     call init_routine( routine_name)
 
     do vi = mesh%vi1, mesh%vi2
       x = mesh%V( vi,1)
-      ice%basal_friction_coefficient( vi) = 1000._dp + &
+      basal_friction_coefficient( vi) = 1000._dp + &
         1000._dp * sin( 2._dp * pi * x / C%refgeo_idealised_ISMIP_HOM_L)
     end do
 
@@ -537,14 +575,14 @@ contains
 
   end subroutine calc_sliding_law_idealised_ISMIP_HOM_D
 
-  subroutine calc_sliding_law_idealised_ISMIP_HOM_F( mesh, ice)
+  subroutine calc_sliding_law_idealised_ISMIP_HOM_F( mesh, basal_friction_coefficient)
     ! Sliding laws for some idealised experiments
     !
     ! ISMIP-HOM experiment F
 
     ! In/output variables:
-    type(type_mesh),      intent(in   ) :: mesh
-    type(type_ice_model), intent(inout) :: ice
+    type(type_mesh),                        intent(in   ) :: mesh
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: basal_friction_coefficient
 
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'calc_sliding_law_idealised_ISMIP_HOM_F'
@@ -554,7 +592,7 @@ contains
     call init_routine( routine_name)
 
     do vi = mesh%vi1, mesh%vi2
-      ice%basal_friction_coefficient( vi) = (C%uniform_Glens_flow_factor * 1000._dp)**(-1._dp)
+      basal_friction_coefficient( vi) = (C%uniform_Glens_flow_factor * 1000._dp)**(-1._dp)
     end do
 
     ! Finalise routine path
@@ -565,12 +603,12 @@ contains
 ! == Utilities
 ! ============
 
-  subroutine apply_grounded_fractions_to_bed_roughness( mesh, ice, bed_roughness, bed_roughness_applied)
+  subroutine apply_grounded_fractions_to_bed_roughness( mesh, geom, bed_roughness, bed_roughness_applied)
     ! Scale bed roughness based on grounded area fractions
 
     ! In/output variables:
     type(type_mesh),                        intent(in   ) :: mesh
-    type(type_ice_model),                   intent(in   ) :: ice
+    class(atype_ice_geometry_model_data),   intent(in   ) :: geom
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(in   ) :: bed_roughness
     real(dp), dimension(mesh%vi1:mesh%vi2), intent(  out) :: bed_roughness_applied
 
@@ -595,29 +633,29 @@ contains
       weight_gr = 1._dp
 
       ! Compute exponent for this vertex's weight based on ice thickness
-      exponent_hi = log10( max( 1._dp, ice%geom%Hi( vi)))
+      exponent_hi = log10( max( 1._dp, geom%Hi( vi)))
       ! Compute exponent for this vertex's weight based on surface gradients
-      exponent_hs = ice%geom%Hs_slope( vi) / 0.005_dp
+      exponent_hs = geom%Hs_slope( vi) / 0.005_dp
       ! Compute final exponent for this vertex's weight
       exponent_gr = max( 0._dp, exponent_hi - exponent_hs)
 
       ! Compute a weight based on the grounded area fractions
-      if (ice%geom%mask_gl_gr( vi)) then
-        weight_gr = ice%geom%fraction_gr( vi)**exponent_gr
+      if (geom%mask_gl_gr( vi)) then
+        weight_gr = geom%fraction_gr( vi)**exponent_gr
 
-      elseif (ice%geom%mask_cf_gr( vi)) then
-        weight_gr = ice%geom%fraction_gr( vi)**exponent_gr
+      elseif (geom%mask_cf_gr( vi)) then
+        weight_gr = geom%fraction_gr( vi)**exponent_gr
 
-      elseif (ice%geom%mask_gl_fl( vi)) then
-        weight_gr = ice%geom%fraction_gr( vi)**exponent_gr
+      elseif (geom%mask_gl_fl( vi)) then
+        weight_gr = geom%fraction_gr( vi)**exponent_gr
 
-      elseif (ice%geom%mask_grounded_ice( vi)) then
+      elseif (geom%mask_grounded_ice( vi)) then
         weight_gr = 1._dp
 
-      elseif (ice%geom%mask_floating_ice( vi)) then
+      elseif (geom%mask_floating_ice( vi)) then
         weight_gr = 0._dp
 
-      elseif (ice%geom%mask_icefree_ocean( vi)) then
+      elseif (geom%mask_icefree_ocean( vi)) then
         weight_gr = 0._dp
 
       end if
@@ -635,12 +673,13 @@ contains
 
   end subroutine apply_grounded_fractions_to_bed_roughness
 
-  subroutine extend_till_yield_stress_to_neighbours( mesh, ice)
+  subroutine extend_till_yield_stress_to_neighbours( mesh, geom, till_yield_stress)
     ! Extend till yield stress over ice-free land neighbours
 
     ! In/output variables:
-    type(type_mesh),      intent(in   ) :: mesh
-    type(type_ice_model), intent(inout) :: ice
+    type(type_mesh),                        intent(in   ) :: mesh
+    class(atype_ice_geometry_model_data),   intent(in   ) :: geom
+    real(dp), dimension(mesh%vi1:mesh%vi2), intent(inout) :: till_yield_stress
 
     ! Local variables:
     character(len=1024), parameter :: routine_name = 'extend_till_yield_stress_to_neighbours'
@@ -654,13 +693,13 @@ contains
     call init_routine( routine_name)
 
     ! Gather data from all processes
-    call gather_to_all( ice%geom%mask_grounded_ice, mask_grounded_ice_tot)
-    call gather_to_all( ice%till_yield_stress, till_yield_stress_tot)
+    call gather_to_all( geom%mask_grounded_ice, mask_grounded_ice_tot)
+    call gather_to_all( till_yield_stress, till_yield_stress_tot)
 
     do vi = mesh%vi1, mesh%vi2
 
       ! Skip if not ice-free land
-      if (.not. ice%geom%mask_icefree_land( vi)) cycle
+      if (.not. geom%mask_icefree_land( vi)) cycle
 
       ! Initialise
       found_grounded_neighbour = .false.
@@ -681,10 +720,10 @@ contains
 
       if (found_grounded_neighbour) then
         ! Use the minimum value among neighbours
-        ice%till_yield_stress( vi) = min_neighbour
+        till_yield_stress( vi) = min_neighbour
       else
         ! Use a default minimum value to avoid 0 friction
-        ice%till_yield_stress( vi) = C%Hi_min * ice_density * grav
+        till_yield_stress( vi) = C%Hi_min * ice_density * grav
       end if
 
     end do

--- a/src/UFEMISM/ice_dynamics/ice_dynamics_main.f90
+++ b/src/UFEMISM/ice_dynamics/ice_dynamics_main.f90
@@ -1269,7 +1269,7 @@ contains
     pseudo_time: do while (t_pseudo < dt_relax)
 
       ! Update velocity solution around the calving front
-      call solve_stress_balance( mesh, ice, bed_roughness, BMB_new, region_name, &
+      call solve_stress_balance( mesh, ice, ice%geom, bed_roughness, BMB_new, region_name, &
         n_visc_its, n_Axb_its, &
         BC_prescr_mask_b, BC_prescr_u_b, BC_prescr_v_b, BC_prescr_mask_bk, BC_prescr_u_bk, BC_prescr_v_bk)
 
@@ -1380,7 +1380,7 @@ contains
       region%ice%effective_pressure = MAX( 0._dp, ice_density * grav * region%ice%geom%Hi_eff) * region%ice%geom%fraction_gr
 
       ! Calculate ice velocities for the predicted geometry
-      call solve_stress_balance( region%mesh, region%ice, region%bed_roughness, &
+      call solve_stress_balance( region%mesh, region%ice, region%ice%geom, region%bed_roughness, &
         BMB_dummy, region%name, n_visc_its, n_Axb_its)
 
       ! Calculate thinning rates for current geometry and velocity

--- a/src/UFEMISM/ice_dynamics/ice_dynamics_main.f90
+++ b/src/UFEMISM/ice_dynamics/ice_dynamics_main.f90
@@ -172,7 +172,7 @@ contains
     ! NOTE: as calculating the zeta gradients is quite expensive, only do so when necessary,
     !       i.e. when solving the heat equation or the Blatter-Pattyn stress balance
     ! Calculate zeta gradients
-    call calc_zeta_gradients( region%mesh, region%ice)
+    call calc_zeta_gradients( region%mesh, region%ice, region%ice%geom)
 
     ! Calculate sub-grid grounded-area fractions
     call region%ice%geom%calc_grounded_fractions( region%ice%dHb)
@@ -304,7 +304,7 @@ contains
     call checksum( mesh%pai_V, ice%dHib_dt, 'ice%dHib_dt')
 
     ! Calculate zeta gradients
-    call calc_zeta_gradients( mesh, ice)
+    call calc_zeta_gradients( mesh, ice, ice%geom)
 
     ! Model states for ice dynamics model
     ice%t_Hi_prev = C%start_time_of_run
@@ -751,7 +751,7 @@ contains
     call ice%geom%calc_ice_base_slopes()
 
     ! Calculate zeta gradients
-    call calc_zeta_gradients( mesh_new, ice)
+    call calc_zeta_gradients( mesh_new, ice, ice%geom)
 
     ! Load target dHi_dt for inversions
     if (C%do_target_dHi_dt) then
@@ -1448,7 +1448,7 @@ contains
       ! NOTE: as calculating the zeta gradients is quite expensive, only do so when necessary,
       !       i.e. when solving the heat equation or the Blatter-Pattyn stress balance
       ! Calculate zeta gradients
-      call calc_zeta_gradients( region%mesh, region%ice)
+      call calc_zeta_gradients( region%mesh, region%ice, region%ice%geom)
 
       ! Calculate sub-grid grounded-area fractions
       call region%ice%geom%calc_grounded_fractions( region%ice%dHb)

--- a/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
+++ b/src/UFEMISM/ice_dynamics/time_stepping/predictor_corrector_scheme.f90
@@ -176,7 +176,7 @@ contains
       ! call run_BMB_model( region%mesh, region%ice, region%ocean, region%refgeo_PD, region%BMB, region%name, region%time)
 
       ! Calculate ice velocities for the predicted geometry
-      call solve_stress_balance( region%mesh, region%ice, region%bed_roughness, &
+      call solve_stress_balance( region%mesh, region%ice, region%ice%geom, region%bed_roughness, &
         region%BMB%BMB, region%name, n_visc_its, n_Axb_its)
 
       ! Update stability info

--- a/src/UFEMISM/ice_dynamics/utilities/zeta_gradients.f90
+++ b/src/UFEMISM/ice_dynamics/utilities/zeta_gradients.f90
@@ -5,6 +5,7 @@ module zeta_gradients
   use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine
   use mesh_types, only: type_mesh
   use ice_model_types, only: type_ice_model
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
   use mesh_disc_apply_operators, only: ddx_a_a_2D, ddy_a_a_2D, map_a_b_2D, ddx_a_b_2D, ddy_a_b_2D, &
     ddx_b_a_2D, ddy_b_a_2D
 
@@ -16,13 +17,14 @@ module zeta_gradients
 
 contains
 
-  subroutine calc_zeta_gradients( mesh, ice)
+  subroutine calc_zeta_gradients( mesh, ice, geom)
     !< Calculate all the gradients of zeta,
     !< needed to perform the scaled vertical coordinate transformation
 
     ! In/output variables:
     type(type_mesh),      intent(in   ) :: mesh
     type(type_ice_model), intent(inout) :: ice
+    class(atype_ice_geometry_model_data), intent(in   ) :: geom
 
     ! Local variables:
     character(len=1024), parameter    :: routine_name = 'calc_zeta_gradients'
@@ -88,11 +90,11 @@ contains
     ! Calculate gradients of Hi and Hs on both grids
 
     ! call map_a_a_2D( mesh, ice%geom%Hi,   Hi_a       )
-    call ddx_a_a_2D( mesh, ice%geom%Hi  , dHi_dx_a   )
-    call ddy_a_a_2D( mesh, ice%geom%Hi  , dHi_dy_a   )
-    call map_a_b_2D( mesh, ice%geom%Hi  , Hi_b       )
-    call ddx_a_b_2D( mesh, ice%geom%Hi  , dHi_dx_b   )
-    call ddy_a_b_2D( mesh, ice%geom%Hi  , dHi_dy_b   )
+    call ddx_a_a_2D( mesh, geom%Hi  , dHi_dx_a   )
+    call ddy_a_a_2D( mesh, geom%Hi  , dHi_dy_a   )
+    call map_a_b_2D( mesh, geom%Hi  , Hi_b       )
+    call ddx_a_b_2D( mesh, geom%Hi  , dHi_dx_b   )
+    call ddy_a_b_2D( mesh, geom%Hi  , dHi_dy_b   )
     call ddx_b_a_2D( mesh, dHi_dx_b, d2Hi_dx2_a )
     call ddy_b_a_2D( mesh, dHi_dx_b, d2Hi_dxdy_a)
     call ddy_b_a_2D( mesh, dHi_dy_b, d2Hi_dy2_a )
@@ -101,11 +103,11 @@ contains
     call ddy_a_b_2D( mesh, dHi_dy_a, d2Hi_dy2_b )
 
     ! call map_a_a_2D( mesh, ice%geom%Hs_a, Hs_a       )
-    call ddx_a_a_2D( mesh, ice%geom%Hs  , dHs_dx_a   )
-    call ddy_a_a_2D( mesh, ice%geom%Hs  , dHs_dy_a   )
-    call map_a_b_2D( mesh, ice%geom%Hs  , Hs_b       )
-    call ddx_a_b_2D( mesh, ice%geom%Hs  , dHs_dx_b   )
-    call ddy_a_b_2D( mesh, ice%geom%Hs  , dHs_dy_b   )
+    call ddx_a_a_2D( mesh, geom%Hs  , dHs_dx_a   )
+    call ddy_a_a_2D( mesh, geom%Hs  , dHs_dy_a   )
+    call map_a_b_2D( mesh, geom%Hs  , Hs_b       )
+    call ddx_a_b_2D( mesh, geom%Hs  , dHs_dx_b   )
+    call ddy_a_b_2D( mesh, geom%Hs  , dHs_dy_b   )
     call ddx_b_a_2D( mesh, dHs_dx_b, d2Hs_dx2_a )
     call ddy_b_a_2D( mesh, dHs_dx_b, d2Hs_dxdy_a)
     call ddy_b_a_2D( mesh, dHs_dy_b, d2Hs_dy2_a )
@@ -118,7 +120,7 @@ contains
     ! ak
     do vi = mesh%vi1, mesh%vi2
 
-      Hi = max( 10._dp, ice%geom%Hi( vi))
+      Hi = max( 10._dp, geom%Hi( vi))
 
       do k = 1, mesh%nz
 

--- a/src/UFEMISM/mesh_creation/graph_pair_creation.f90
+++ b/src/UFEMISM/mesh_creation/graph_pair_creation.f90
@@ -4,7 +4,7 @@ module graph_pair_creation
   use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine, crash
   use mesh_types, only: type_mesh
   use graph_types, only: type_graph_pair
-  use ice_model_types, only: type_ice_model
+  use ice_geometry_model_data, only: atype_ice_geometry_model_data
   use create_graphs_from_masked_mesh, only: create_graph_from_masked_mesh_a, &
     create_graph_from_masked_mesh_b
   use graph_operators, only: calc_graph_matrix_operators_2nd_order, &
@@ -20,12 +20,12 @@ module graph_pair_creation
 
 contains
 
-  subroutine create_ice_only_graph_pair( mesh, ice, graphs)
+  subroutine create_ice_only_graph_pair( mesh, geom, graphs)
 
     ! In/output variables:
-    type(type_mesh),       intent(in   ) :: mesh
-    type(type_ice_model),  intent(in   ) :: ice
-    type(type_graph_pair), intent(  out) :: graphs
+    type(type_mesh),                       intent(in   ) :: mesh
+    class(atype_ice_geometry_model_data),  intent(in   ) :: geom
+    type(type_graph_pair),                 intent(  out) :: graphs
 
     ! Local variables:
     character(len=1024), parameter        :: routine_name = 'create_ice_only_graph_pair'
@@ -37,7 +37,7 @@ contains
 
     ! Calculate the ice mask
     do vi = mesh%vi1, mesh%vi2
-      mask_ice_a( vi) = ice%geom%Hi( vi) > 0._dp
+      mask_ice_a( vi) = geom%Hi( vi) > 0._dp
     end do
 
     ! Create graphs from the masked vertices and triangles

--- a/src/UFEMISM/thermodynamics/thermodynamics_3D_heat_equation.f90
+++ b/src/UFEMISM/thermodynamics/thermodynamics_3D_heat_equation.f90
@@ -93,7 +93,7 @@ CONTAINS
     ALLOCATE( is_unstable         ( mesh%vi1:mesh%vi2        ), source = 0    )
 
     ! Calculate zeta gradients
-    CALL calc_zeta_gradients( mesh, ice)
+    CALL calc_zeta_gradients( mesh, ice, ice%geom)
 
     ! Calculate temperature-dependent heat capacity
     CALL calc_heat_capacity( mesh, ice)


### PR DESCRIPTION
All the velocity solvers now accept an ice geometry model as an input variable, paving the way for working with separate geometry objects in the p/c scheme.