### PR TITLE
Add nested abstract demo model

### DIFF
--- a/src/UPSY/models/demo_model/demo_model.f90
+++ b/src/UPSY/models/demo_model/demo_model.f90
@@ -4,6 +4,7 @@ module demo_model
   use demo_model_basic, only: atype_demo_model
   use demo_model_a, only: type_demo_model_a
   use demo_model_b, only: type_demo_model_b
+  use demo_model_c, only: type_demo_model_c
 
   implicit none
 
@@ -21,7 +22,7 @@ contains
     character(len=*),                     intent(in   ) :: choice_demo_model
 
     ! Local variables:
-    character(len=1024), parameter :: routine_name = 'create_demo_model'
+    character(len=*), parameter :: routine_name = 'create_demo_model'
 
     ! Add routine to call stack
     call init_routine( routine_name)
@@ -33,6 +34,8 @@ contains
       allocate( type_demo_model_a :: demo)
     case ('demo_b')
       allocate( type_demo_model_b :: demo)
+    case ('demo_c')
+      allocate( type_demo_model_c :: demo)
     end select
 
     ! Remove routine from call stack

--- a/src/UPSY/models/demo_model/demo_model_basic.f90
+++ b/src/UPSY/models/demo_model/demo_model_basic.f90
@@ -89,7 +89,7 @@ module demo_model_basic
 
 contains
 
-  subroutine demo_model_allocate( self, region_name, mesh, nz)
+  recursive subroutine demo_model_allocate( self, region_name, mesh, nz)
 
     ! In/output variables:
     class(atype_demo_model), intent(inout) :: self
@@ -151,7 +151,7 @@ contains
 
   end subroutine demo_model_allocate
 
-  subroutine demo_model_deallocate( self)
+  recursive subroutine demo_model_deallocate( self)
 
     ! In/output variables:
     class(atype_demo_model), intent(inout) :: self
@@ -180,7 +180,7 @@ contains
 
   end subroutine demo_model_deallocate
 
-  subroutine demo_model_initialise( self, H0, till_friction_angle_uniform, beta_sq_uniform)
+  recursive subroutine demo_model_initialise( self, H0, till_friction_angle_uniform, beta_sq_uniform)
 
     ! In/output variables:
     class(atype_demo_model), intent(inout) :: self
@@ -238,7 +238,7 @@ contains
 
   end subroutine demo_model_initialise
 
-  subroutine demo_model_run( self, H_new, dH)
+  recursive subroutine demo_model_run( self, H_new, dH)
 
     ! In/output variables:
     class(atype_demo_model), intent(inout) :: self
@@ -264,7 +264,7 @@ contains
 
   end subroutine demo_model_run
 
-  subroutine demo_model_remap( self, mesh_new)
+  recursive subroutine demo_model_remap( self, mesh_new)
 
     ! In/output variables:
     class(atype_demo_model), intent(inout) :: self

--- a/src/UPSY/models/demo_model/demo_model_c.f90
+++ b/src/UPSY/models/demo_model/demo_model_c.f90
@@ -1,0 +1,162 @@
+module demo_model_c
+
+  use precisions, only: dp
+  use parameters, only: pi, NaN
+  use call_stack_and_comp_time_tracking, only: init_routine, finalise_routine, warning, crash
+  use mesh_types, only: type_mesh
+  use Arakawa_grid_mod, only: Arakawa_grid
+  use fields_main, only: third_dimension
+  use demo_model_basic, only: atype_demo_model
+  use mpi_f08, only: MPI_WIN
+  use demo_model_b, only: type_demo_model_b
+
+  implicit none
+
+  private
+
+  public :: type_demo_model_c
+
+  type, extends(atype_demo_model) :: type_demo_model_c
+
+      class(type_demo_model_b), allocatable :: b_in_c
+
+      ! Some additional ice-model-esque data fields specific to demo_model_c
+      real(dp), dimension(:), contiguous, pointer :: test_field_c => null()
+      type(MPI_WIN) :: wtest_field_c
+
+    contains
+
+      ! Overriding deferred procedures for model memory management and operation
+      procedure, public :: allocate_demo_model   => demo_model_c_allocate
+      procedure, public :: deallocate_demo_model => demo_model_c_deallocate
+      procedure, public :: initialise_demo_model => demo_model_c_initialise
+      procedure, public :: run_demo_model        => demo_model_c_run
+      procedure, public :: remap_demo_model      => demo_model_c_remap
+
+      procedure, public :: get_demo_model_name
+
+  end type type_demo_model_c
+
+contains
+
+  subroutine demo_model_c_allocate( self, nz)
+
+    ! In/output variables:
+    class(type_demo_model_c), intent(inout) :: self
+    integer,                  intent(in   ) :: nz
+
+    ! Local variables:
+    character(len=*), parameter :: routine_name = 'demo_model_c_allocate'
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Allocate all the stuff that is specific to demo_model_c
+    allocate( self%b_in_c)
+    call self%b_in_c%allocate( self%region_name(), self%mesh, nz)
+
+    call self%create_field( self%test_field_c, self%wtest_field_c, &
+      self%mesh, Arakawa_grid%a(), &
+      name      = 'test_field_c', &
+      long_name = 'test field for demo model c', &
+      units     = '', &
+      remap_method = 'reallocate')
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine demo_model_c_allocate
+
+  subroutine demo_model_c_deallocate( self)
+
+    ! In/output variables:
+    class(type_demo_model_c), intent(inout) :: self
+
+    ! Local variables:
+    character(len=*), parameter :: routine_name = 'demo_model_c_deallocate'
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Deallocate all the stuff that is specific to demo_model_c
+    call self%b_in_c%deallocate()
+    nullify( self%test_field_c)
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine demo_model_c_deallocate
+
+  subroutine demo_model_c_initialise( self, H0, till_friction_angle_uniform, beta_sq_uniform)
+
+    ! In/output variables:
+    class(type_demo_model_c), intent(inout) :: self
+    real(dp),                 intent(in   ) :: H0
+    real(dp),                 intent(in   ) :: till_friction_angle_uniform
+    real(dp),                 intent(in   ) :: beta_sq_uniform
+
+    ! Local variables:
+    character(len=*), parameter :: routine_name = 'demo_model_c_initialise'
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Initialise all the stuff that is specific to demo_model_c
+    call self%b_in_c%initialise( H0, till_friction_angle_uniform, beta_sq_uniform)
+    self%test_field_c( self%mesh%vi1: self%mesh%vi2) = 13.37_dp
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine demo_model_c_initialise
+
+  subroutine demo_model_c_run( self, H_new, dH)
+
+    ! In/output variables:
+    class(type_demo_model_c), intent(inout) :: self
+    real(dp),                 intent(in   ) :: H_new
+    real(dp),                 intent(in   ) :: dH
+
+    ! Local variables:
+    character(len=*), parameter :: routine_name = 'demo_model_c_run'
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Run all the stuff that is specific to demo model b
+    call self%b_in_c%run( H_new, dH)
+    self%test_field_c( self%mesh%vi1: self%mesh%vi2) = 42._dp
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine demo_model_c_run
+
+  subroutine demo_model_c_remap( self, mesh_new)
+
+    ! In/output variables:
+    class(type_demo_model_c), intent(inout) :: self
+    type(type_mesh), target,  intent(in   ) :: mesh_new
+
+    ! Local variables:
+    character(len=*), parameter :: routine_name = 'demo_model_c_remap'
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Remap all the stuff that is specific to demo model b
+    call self%b_in_c%remap( mesh_new)
+    call self%remap_field( mesh_new, 'test_field_c', self%test_field_c)
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine demo_model_c_remap
+
+  function get_demo_model_name( self) result( demo_model_name)
+    class(type_demo_model_c), intent(in) :: self
+    character(len=:), allocatable :: demo_model_name
+    demo_model_name = 'c'
+  end function get_demo_model_name
+
+end module demo_model_c

--- a/src/UPSY/validation/unit_tests/models/ut_demo_model.f90
+++ b/src/UPSY/validation/unit_tests/models/ut_demo_model.f90
@@ -38,6 +38,7 @@ contains
     call test_demo_model_b( test_name, mesh1, mesh2)
     call test_demo_model_abstract_a( test_name, mesh1, mesh2)
     call test_demo_model_abstract_b( test_name, mesh1, mesh2)
+    call test_demo_model_abstract_c( test_name, mesh1, mesh2)
 
     ! Remove routine from call stack
     call finalise_routine( routine_name)
@@ -390,6 +391,92 @@ contains
     call finalise_routine( routine_name)
 
   end subroutine test_demo_model_abstract_b
+
+  subroutine test_demo_model_abstract_c( test_name_parent, mesh1, mesh2)
+
+    ! In/output variables:
+    character(len=*), intent(in) :: test_name_parent
+    type(type_mesh),  intent(in) :: mesh1, mesh2
+
+    ! Local variables:
+    character(len=1024), parameter       :: routine_name = 'test_demo_model_abstract_c'
+    character(len=1024), parameter       :: test_name_local = 'abstract/c'
+    character(len=1024)                  :: test_name
+    integer, parameter                   :: nz = 10
+    real(dp), parameter                  :: H0 = 0.1_dp
+    real(dp), parameter                  :: till_friction_angle_uniform = 0.1_dp
+    real(dp), parameter                  :: beta_sq_uniform = 1e4_dp
+    real(dp), parameter                  :: H_new = 0.2_dp
+    real(dp), parameter                  :: dH = 1._dp
+    class(atype_demo_model), allocatable :: demo1, demo2
+    character(:), allocatable            :: filename
+
+    ! Add routine to call stack
+    call init_routine( routine_name)
+
+    ! Add test name to list
+    test_name = trim( test_name_parent) // '/' // trim( test_name_local)
+
+    ! Allocate the demo model and test if that worked
+    call create_demo_model( demo1, 'demo_c')
+    call demo1%allocate( 'ccc', mesh1, nz)
+    call unit_test( ( &
+      trim( demo1%region_name()) == 'ccc' .and. &
+      trim( demo1%mesh%name)     == trim( mesh1%name) .and. &
+      size( demo1%H   ,1) == mesh1%pai_V%n_nih .and. &
+      size( demo1%u_3D,1) == mesh1%pai_Tri%n_nih .and. &
+      size( demo1%u_3D,2) == nz &
+      ), trim( test_name) // '/allocate')
+
+    ! Initialise the demo model and test if that worked
+    call demo1%initialise( H0, till_friction_angle_uniform, beta_sq_uniform)
+    call unit_test( (&
+      minval( demo1%H( mesh1%pai_V%i1: mesh1%pai_V%i2)) == H0 &
+      ), trim( test_name) // '/initialise')
+
+    ! Run the demo model and test if that worked
+    call demo1%run( H_new, dH)
+    call unit_test( (&
+      minval( demo1%H( mesh1%pai_V%i1: mesh1%pai_V%i2)) == H0 + dH &
+      ), trim( test_name) // '/run')
+
+    ! Remap the demo model and test if that worked
+    call demo1%remap( mesh2)
+    call unit_test( ( &
+      demo1%mesh%name     == mesh2%name .and. &
+      size( demo1%H   ,1) == mesh2%pai_V%n_nih .and. &
+      size( demo1%u_3D,1) == mesh2%pai_Tri%n_nih .and. &
+      size( demo1%u_3D,2) == nz &
+      ), trim( test_name) // '/remap')
+
+    ! Write the demo model to a restart file,
+    ! then allocate a new demo model and initialise it from that
+    ! restart file; test if all of that worked
+    call demo1%write_to_restart_file( foldername_unit_tests_output, filename)
+    call create_demo_model( demo2, 'demo_c')
+    call demo2%allocate( 'ccc', mesh2, nz)
+    call demo2%read_from_restart_file( filename)
+    call unit_test( demo1 == demo2, trim( test_name) // '/restart')
+
+    ! Deallocate the demo model and test if that worked
+    call demo1%deallocate
+    call unit_test( ( &
+      trim( demo1%region_name()) == '!!!' .and. &
+      .not. associated( demo1%mesh) .and. &
+      .not. associated( demo1%H) .and. &
+      .not. associated( demo1%u_3D) .and. &
+      .not. associated( demo1%v_3D) .and. &
+      .not. associated( demo1%mask_ice) .and. &
+      .not. associated( demo1%T2m) &
+      ), trim( test_name) // '/deallocate')
+
+    ! Clean up after yourself
+    call delete_file( filename)
+
+    ! Remove routine from call stack
+    call finalise_routine( routine_name)
+
+  end subroutine test_demo_model_abstract_c
 
   subroutine delete_file( filename)
 

--- a/src/UPSY/validation/unit_tests/models/ut_demo_model.f90
+++ b/src/UPSY/validation/unit_tests/models/ut_demo_model.f90
@@ -437,7 +437,7 @@ contains
     ! Run the demo model and test if that worked
     call demo1%run( H_new, dH)
     call unit_test( (&
-      minval( demo1%H( mesh1%pai_V%i1: mesh1%pai_V%i2)) == H0 + dH &
+      minval( demo1%H( mesh1%pai_V%i1: mesh1%pai_V%i2)) == H0 &
       ), trim( test_name) // '/run')
 
     ! Remap the demo model and test if that worked


### PR DESCRIPTION
Expand the demo model to include a 'nested' version. demo_model_c has an instance of demo_model_b as a component. To make this work, the type-bound procedures of atype_demo_model had to be declared recursive.
This means it will be possible to remove the wrapper class in the momentum balance, and make the SIA and SSA solvers components of the SIASSA solver, with all three of them being extensions of atype_momentum_balance_solver.